### PR TITLE
Dependency update

### DIFF
--- a/brewtils/choices.py
+++ b/brewtils/choices.py
@@ -1,4 +1,4 @@
-from lark import Lark, Transformer
+from lark import Lark, Transformer, UnexpectedInput
 from lark.common import ParseError
 
 
@@ -65,7 +65,10 @@ def parse(input_string, parse_as=None):
     :raise lark.common.ParseError: The parser was not able to find a valid parsing of `input_string`
     """
     def _parse(_input_string, _parser):
-        return FunctionTransformer().transform(_parser.parse(_input_string))
+        try:
+            return FunctionTransformer().transform(_parser.parse(_input_string))
+        except UnexpectedInput as e:
+            raise ParseError(e)
 
     if parse_as is not None:
         return _parse(input_string, parsers[parse_as])

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -42,7 +42,6 @@ class EasyClient(object):
         else:
             self._handle_response_failure(response, default_exc=BrewmasterFetchError)
 
-
     def find_unique_system(self, **kwargs):
         """Find a unique system using keyword arguments as search parameters.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,41 +6,41 @@
 #
 alabaster==0.7.10         # via sphinx
 argh==0.26.2              # via watchdog
-babel==2.5.1              # via sphinx
-certifi==2017.7.27.1      # via requests
+babel==2.5.3              # via sphinx
+certifi==2018.1.18        # via requests
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via rednose
-coverage==4.4.1
+coverage==4.5
 docutils==0.14            # via sphinx
 enum34==1.1.6
 flake8==3.5.0
-futures==3.1.1 ; python_version < "3.0"
+futures==3.2.0 ; python_version < "3.0"
 idna==2.6                 # via requests
 imagesize==0.7.1          # via sphinx
-jinja2==2.9.6             # via sphinx
-lark-parser==0.3.7
+jinja2==2.10              # via sphinx
+lark-parser==0.5.3
 markupsafe==1.0           # via jinja2
-marshmallow==2.13.6
+marshmallow==2.15.0
 mccabe==0.6.1             # via flake8
 mock==2.0.0
 nose==1.3.7
 nosexcover==1.0.11
 pathtools==0.1.2          # via watchdog
 pbr==3.1.1                # via mock
-pika==0.11.0
-pluggy==0.5.2             # via tox
-py==1.4.34                # via tox
+pika==0.11.2
+pluggy==0.6.0             # via tox
+py==1.5.2                 # via tox
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via sphinx
-pytz==2017.2
+pytz==2017.3
 pyyaml==3.12              # via watchdog
-rednose==1.2.2
+rednose==1.2.3
 requests==2.18.4
 six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.2.4
-sphinx==1.6.4
+sphinx==1.6.7
 sphinxcontrib-websupport==1.0.1  # via sphinx
 termstyle==0.1.11         # via rednose
 tox==2.9.1


### PR DESCRIPTION

Updated dependencies.

The only relevant change I could find is that the lark-parser now
throws an UnexpectedInput instead of a ParseError in some cases.
This was breaking several tests in the choices_test, so I have
wrapped the exception to keep backwards compatibility working.