### PR TITLE
Removing .venv file - shouldn't force a virtualenv name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,6 @@ docs/_build/
 # PyBuilder
 target/
 
-# pyenv python configuration file
+# python configuration file
 .python-version
+.venv

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-brewtils


### PR DESCRIPTION
We already ignore .python-version, we should remove and ignore this as well for consistency.

I vote we remove this rather than adding a .python-version file so as to let people manage their virtualenvs however they want.