### PR TITLE
Issue/28

### DIFF
--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -109,6 +109,12 @@ class BGConflictError(BrewmasterRestError):
     pass
 
 
+class BGRequestFailedError(BrewmasterRestError):
+    """Request returned with a 200, but the status was ERROR"""
+    def __init__(self, request):
+        self.request = request
+
+
 class BGNotFoundError(BrewmasterRestError):
     """Error Indicating a 404 was raised on the server"""
     pass


### PR DESCRIPTION
Solves #28 

There are now two ways to allow the `SystemClient` to raise an error (`BGRequestFailedError`) if the request fails. You can pass in `raise_on_error` to the initializer:

```python
client = SystemClient(*args, raise_on_error=True)
```

Or on command calls:

```python
client.command_name(_raise_on_error=True)
```

By default, it is `False`.