### PR TITLE
Reworking brewtils to be based on yapconf

### DIFF
--- a/brewtils/log/__init__.py
+++ b/brewtils/log/__init__.py
@@ -26,12 +26,9 @@ import brewtils
 # Loggers to always use. These are things that generally,
 # people do not want to see and/or are too verbose.
 DEFAULT_LOGGERS = {
-    "pika": {
-        "level": "ERROR"
-    },
-    "requests.packages.urllib3.connectionpool": {
-        "level": "WARN"
-    }
+    "pika": {"level": "ERROR"},
+    "requests.packages.urllib3.connectionpool": {"level": "WARN"},
+    "yapconf": {"level": "WARN"},
 }
 
 # A simple default format/formatter. Generally speaking, the API should return formatters,

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -130,16 +130,16 @@ class PluginBase(object):
             self._custom_logger = False
 
         connection_parameters = brewtils.get_bg_connection_parameters(
-            host=bg_host,
-            port=bg_port,
+            bg_host=bg_host,
+            bg_port=bg_port,
             ssl_enabled=ssl_enabled,
             ca_cert=ca_cert,
             client_cert=client_cert,
             url_prefix=bg_url_prefix,
             ca_verify=kwargs.get('ca_verify', None)
         )
-        self.bg_host = connection_parameters['host']
-        self.bg_port = connection_parameters['port']
+        self.bg_host = connection_parameters['bg_host']
+        self.bg_port = connection_parameters['bg_port']
         self.ssl_enabled = connection_parameters['ssl_enabled']
         self.ca_cert = connection_parameters['ca_cert']
         self.client_cert = connection_parameters['client_cert']

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -14,8 +14,8 @@ class RestClient(object):
     (e.g. :py:class:`brewtils.rest.easy_client.EasyClient`) build on this by providing useful
     abstractions.
 
-    :param host: beer-garden REST API hostname.
-    :param port: beer-garden REST API port.
+    :param bg_host: beer-garden REST API hostname.
+    :param bg_port: beer-garden REST API port.
     :param ssl_enabled: Flag indicating whether to use HTTPS when communicating with beer-garden.
     :param api_version: The beer-garden REST API version. Will default to the latest version.
     :param logger: The logger to use. If None one will be created.
@@ -30,8 +30,18 @@ class RestClient(object):
 
     JSON_HEADERS = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 
-    def __init__(self, host, port, ssl_enabled=False, api_version=None, logger=None, ca_cert=None,
-                 client_cert=None, url_prefix=None, ca_verify=True):
+    def __init__(self, bg_host=None, bg_port=None, ssl_enabled=False, api_version=None,
+                 logger=None, ca_cert=None, client_cert=None, url_prefix=None, ca_verify=True,
+                 **kwargs):
+
+        bg_host = bg_host or kwargs.get('host')
+        if not bg_host:
+            raise ValueError('Missing keyword argument "bg_host"')
+
+        bg_port = bg_port or kwargs.get('port')
+        if not bg_port:
+            raise ValueError('Missing keyword argument "bg_port"')
+
         self.logger = logger or logging.getLogger(__name__)
 
         # Configure the session to use when making requests
@@ -48,7 +58,7 @@ class RestClient(object):
 
         # Configure the beer-garden URLs
         scheme = 'https' if ssl_enabled else 'http'
-        base_url = '%s://%s:%s%s' % (scheme, host, port, normalize_url_prefix(url_prefix))
+        base_url = '%s://%s:%s%s' % (scheme, bg_host, bg_port, normalize_url_prefix(url_prefix))
         self.version_url = base_url + 'version'
         self.config_url = base_url + 'config'
 

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -15,8 +15,8 @@ class EasyClient(object):
     This class provides nice wrappers around the functionality provided by a
     :py:class:`brewtils.rest.client.RestClient`
 
-    :param host: beer-garden REST API hostname.
-    :param port: beer-garden REST API port.
+    :param bg_host: beer-garden REST API hostname.
+    :param bg_port: beer-garden REST API port.
     :param ssl_enabled: Flag indicating whether to use HTTPS when communicating with beer-garden.
     :param api_version: The beer-garden REST API version. Will default to the latest version.
     :param ca_cert: beer-garden REST API server CA certificate.
@@ -27,11 +27,16 @@ class EasyClient(object):
     :param ca_verify: Flag indicating whether to verify server certificate when making a request.
     """
 
-    def __init__(self, host, port, ssl_enabled=False, api_version=None, ca_cert=None,
-                 client_cert=None, parser=None, logger=None, url_prefix=None, ca_verify=True):
+    def __init__(self, bg_host=None, bg_port=None, ssl_enabled=False, api_version=None,
+                 ca_cert=None, client_cert=None, parser=None, logger=None, url_prefix=None,
+                 ca_verify=True, **kwargs):
+
+        bg_host = bg_host or kwargs.get('host')
+        bg_port = bg_port or kwargs.get('port')
+
         self.logger = logger or logging.getLogger(__name__)
         self.parser = parser or SchemaParser()
-        self.client = RestClient(host=host, port=port, ssl_enabled=ssl_enabled,
+        self.client = RestClient(bg_host=bg_host, bg_port=bg_port, ssl_enabled=ssl_enabled,
                                  api_version=api_version, ca_cert=ca_cert, client_cert=client_cert,
                                  url_prefix=url_prefix, ca_verify=ca_verify)
 

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -1,0 +1,48 @@
+SPECIFICATION = {
+    "bg_host": {
+        "type": "str",
+        "description": "The beergarden server FQDN",
+        "required": True,
+        "env_name": "HOST",
+        "alt_env_names": ["WEB_HOST"],
+    },
+    "bg_port": {
+        "type": "int",
+        "description": "The beergarden server port",
+        "default": 2337,
+        "env_name": "PORT",
+        "alt_env_names": ["WEB_PORT"],
+    },
+    "ca_cert": {
+        "type": "str",
+        "description": "CA certificate to use when verifying",
+        "required": False,
+        "alt_env_names": ["SSL_CA_CERT"],
+    },
+    "ca_verify": {
+        "type": "bool",
+        "description": "Verify server certificate when using SSL",
+        "default": True,
+    },
+    "client_cert": {
+        "type": "str",
+        "description": "Client certificate to use with beergarden",
+        "required": False,
+        "alt_env_names": ["SSL_CLIENT_CERT"],
+    },
+    "ssl_enabled": {
+        "type": "bool",
+        "description": "Use SSL when communicating with beergarden",
+        "default": True,
+    },
+    "url_prefix": {
+        "type": "str",
+        "description": "The beergarden server path",
+        "default": "/",
+    },
+    "api_version": {
+        "type": "int",
+        "description": "Beergarden API version",
+        "required": False,
+    },
+}

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ pika
 requests
 six
 wrapt
+yapconf >= "0.2.1"
 enum34 ; python_version < "3.4"
 futures ; python_version < "3.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via sphinx
 pytest==3.4.2
+python-box==3.1.1         # via yapconf
 pytz==2017.3
 pyyaml==3.12              # via watchdog
 requests-toolbelt==0.8.0  # via twine
@@ -53,3 +54,4 @@ virtualenv==15.1.0        # via tox
 watchdog==0.8.3
 wheel==0.30.0
 wrapt==1.10.11
+yapconf==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,13 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={'': ['README.md']},
     install_requires=[
+        'lark-parser',
         'marshmallow',
         'pika',
         'requests',
         'six',
         'wrapt',
-        'lark-parser',
+        'yapconf>=0.2.1',
     ],
     extras_require={
         ':python_version=="2.7"': ['futures',],

--- a/test/brewtils_test.py
+++ b/test/brewtils_test.py
@@ -2,6 +2,9 @@ import copy
 import os
 import unittest
 
+from mock import Mock, patch
+from yapconf.exceptions import YapconfItemNotFound
+
 import brewtils
 import brewtils.rest
 from brewtils.errors import BrewmasterValidationError
@@ -12,10 +15,10 @@ class BrewtilsTest(unittest.TestCase):
 
     def setUp(self):
         self.params = {
-            'host': 'bg_host',
-            'port': '1234',
+            'bg_host': 'bg_host',
+            'bg_port': 1234,
             'ssl_enabled': False,
-            'api_version': 1,
+            'api_version': None,
             'ca_cert': 'ca_cert',
             'client_cert': 'client_cert',
             'url_prefix': '/beer/',
@@ -27,6 +30,18 @@ class BrewtilsTest(unittest.TestCase):
     def tearDown(self):
         os.environ = self.safe_copy
 
+    def test_load_config_cli(self):
+        cli_args = ['--bg-host', 'the_host']
+
+        config = brewtils.load_config(cli_args)
+        self.assertEqual('the_host', config.bg_host)
+
+    def test_load_config_environment(self):
+        os.environ['BG_HOST'] = 'the_host'
+
+        config = brewtils.load_config([])
+        self.assertEqual('the_host', config.bg_host)
+
     def test_get_easy_client(self):
         client = brewtils.get_easy_client(host='bg_host')
         self.assertIsInstance(client, EasyClient)
@@ -35,25 +50,50 @@ class BrewtilsTest(unittest.TestCase):
         self.assertEqual(self.params, brewtils.get_bg_connection_parameters(**self.params))
 
     def test_get_bg_connection_parameters_env(self):
-        os.environ['BG_WEB_HOST'] = 'bg_host'
-        os.environ['BG_WEB_PORT'] = '1234'
+        os.environ['BG_HOST'] = 'bg_host'
+        os.environ['BG_PORT'] = '1234'
         os.environ['BG_SSL_ENABLED'] = 'False'
         os.environ['BG_CA_CERT'] = 'ca_cert'
         os.environ['BG_CLIENT_CERT'] = 'client_cert'
         os.environ['BG_URL_PREFIX'] = '/beer/'
-        os.environ['BG_CA_VERIFY'] = 'bg_host'
+        os.environ['BG_CA_VERIFY'] = 'True'
 
         self.assertEqual(self.params, brewtils.get_bg_connection_parameters())
 
+    def test_get_bg_connection_parameters_deprecated_kwargs(self):
+        params = copy.copy(self.params)
+        params['host'] = params.pop('bg_host')
+        params['port'] = params.pop('bg_port')
+
+        self.assertEqual(self.params, brewtils.get_bg_connection_parameters(**params))
+
     def test_get_bg_connection_parameters_deprecated_env(self):
         params = copy.copy(self.params)
+        params['bg_host'] = None
+        params['bg_port'] = None
         params['ca_cert'] = None
         params['client_cert'] = None
 
         os.environ['BG_SSL_CA_CERT'] = 'ca_cert'
         os.environ['BG_SSL_CLIENT_CERT'] = 'client_cert'
+        os.environ['BG_WEB_HOST'] = 'bg_host'
+        os.environ['BG_WEB_PORT'] = '1234'
 
         self.assertEqual(self.params, brewtils.get_bg_connection_parameters(**params))
 
     def test_get_bg_connection_parameters_no_host(self):
         self.assertRaises(BrewmasterValidationError, brewtils.get_bg_connection_parameters)
+
+    def test_get_bg_connection_parameters_no_something(self):
+
+        with patch('brewtils.spec') as mock_spec:
+            mock_spec.load_config.side_effect = YapconfItemNotFound('message',
+                                                                    Mock(item=Mock(name='bg_port')))
+            self.assertRaises(YapconfItemNotFound, brewtils.get_bg_connection_parameters)
+
+    def test_normalize_url_prefix(self):
+        os.environ['BG_WEB_HOST'] = 'bg_host'
+        os.environ['BG_URL_PREFIX'] = '/beer'
+
+        params = brewtils.get_bg_connection_parameters()
+        self.assertEqual(self.params['url_prefix'], params['url_prefix'])

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -60,15 +60,10 @@ class PluginBaseTest(unittest.TestCase):
                             metadata={'foo': 'bar'})
         self.assertEqual(plugin.instance_name, 'default')
         self.assertEqual(plugin.bg_host, 'localhost')
-        self.assertEqual(plugin.bg_port, '2337')
+        self.assertEqual(plugin.bg_port, 2337)
         self.assertEqual(plugin.ssl_enabled, True)
         self.assertFalse(plugin._custom_logger)
         self.assertEqual(plugin.ca_verify, True)
-
-    def test_init_ssl_bad_env_variable(self):
-        os.environ['BG_SSL_ENABLED'] = 'BAD VALUE HERE'
-        plugin = PluginBase(self.client, bg_host='localhost', system=self.system)
-        self.assertEqual(plugin.ssl_enabled, True)
 
     def test_init_not_ssl(self):
         plugin = PluginBase(self.client, bg_host='localhost', system=self.system, ssl_enabled=False)
@@ -83,11 +78,6 @@ class PluginBaseTest(unittest.TestCase):
         os.environ['BG_SSL_ENABLED'] = 'False'
         plugin = PluginBase(self.client, bg_host='localhost', system=self.system)
         self.assertEqual(plugin.ssl_enabled, False)
-
-    def test_init_ca_verify_bad_env_variable(self):
-        os.environ['BG_CA_VERIFY'] = 'BAD VALUE HERE'
-        plugin = PluginBase(self.client, bg_host='localhost', system=self.system)
-        self.assertEqual(plugin.ca_verify, True)
 
     def test_init_not_ca_verify(self):
         plugin = PluginBase(self.client, bg_host='localhost', system=self.system, ca_verify=False)
@@ -116,7 +106,7 @@ class PluginBaseTest(unittest.TestCase):
     def test_init_bg_port_env(self):
         os.environ['BG_WEB_PORT'] = '4000'
         plugin = PluginBase(self.client, bg_host='localhost', system=self.system)
-        self.assertEqual(plugin.bg_port, '4000')
+        self.assertEqual(plugin.bg_port, 4000)
 
     def test_init_bg_port_both(self):
         os.environ['BG_WEB_PORT'] = '4000'

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -15,8 +15,17 @@ class RestClientTest(unittest.TestCase):
         self.url_prefix = "beer"
         self.url_prefix = brewtils.rest.normalize_url_prefix(self.url_prefix)
 
-        self.client_version_1 = RestClient('host', 80, api_version=1, url_prefix=self.url_prefix)
+        self.client_version_1 = RestClient(bg_host='host', bg_port=80, api_version=1,
+                                           url_prefix=self.url_prefix)
         self.client_version_1.session = self.session_mock
+
+    def test_old_positional_args(self):
+        test_client = RestClient('host', 80, api_version=1, url_prefix=self.url_prefix)
+        self.assertEqual(test_client.version_url, self.client_version_1.version_url)
+
+    def test_no_host_or_port(self):
+        self.assertRaises(ValueError, RestClient, bg_port=80)
+        self.assertRaises(ValueError, RestClient, bg_host='host')
 
     def test_non_versioned_uris(self):
         client = RestClient('host', 80, url_prefix=self.url_prefix)


### PR DESCRIPTION
This change allows us to get away from the custom `get_arg_from` methods and load configuration in a more structured way.

Function signatures have been changed in such a way as to be backwards-compatible. Positional arguments have been changed to keyword but they've remained in the same order so they'll continue to work as positionals. The kwargs are also searched for the old names in case they were previously supplied as keyword arguments.

The only breaking change is that certain environment variables that map to boolean values were previously allowed to be non-boolean strings, which would cause them to map to `True` (see removed tests in `test/plugin_test.py`). With this change string values that can't be mapped to a boolean will now raise an exception. I think this is actually in improvement, but it _is_ a breaking change.

The actual spec can be further refined once certain things get added to yapconf (mainly support for using deprecated names).