### PR TITLE
Error classes inherit from common base

### DIFF
--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -5,7 +5,7 @@ from yapconf.exceptions import YapconfItemNotFound
 
 from brewtils.decorators import command, parameter, system
 from brewtils.plugin import RemotePlugin
-from brewtils.errors import BrewmasterValidationError
+from brewtils.errors import ValidationError
 from brewtils.rest import normalize_url_prefix
 from brewtils.rest.system_client import SystemClient
 from .specification import SPECIFICATION
@@ -101,9 +101,9 @@ def load_config(cli_args=None, **kwargs):
         config = spec.load_config(*sources)
     except YapconfItemNotFound as ex:
         if ex.item.name == 'bg_host':
-            raise BrewmasterValidationError('Unable to create a plugin without a beer-garden host. '
-                                            'Please specify one on the command line (--bg-host), '
-                                            'in the environment (BG_HOST), or in kwargs (bg_host)')
+            raise ValidationError('Unable to create a plugin without a beer-garden host. '
+                                  'Please specify one on the command line (--bg-host), '
+                                  'in the environment (BG_HOST), or in kwargs (bg_host)')
         raise
 
     # Make sure the url_prefix is normal

--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -1,22 +1,21 @@
-"""Module containing all of the BREWMASTER error definitions"""
 import json
 
 from six import string_types
 
 
 # Models
-class BrewmasterModelError(Exception):
-    """Wrapper Error for All BrewmasterModelErrors"""
+class ModelError(Exception):
+    """Base exception for model errors"""
     pass
 
 
-class BrewmasterModelValidationError(BrewmasterModelError):
-    """Error to indicate an invalid Brewmaster Model"""
+class ModelValidationError(ModelError):
+    """Invalid model"""
     pass
 
 
-class RequestStatusTransitionError(BrewmasterModelValidationError):
-    """Error to indicate an updated status was not a valid transition"""
+class RequestStatusTransitionError(ModelValidationError):
+    """A status update was an invalid transition"""
     pass
 
 
@@ -72,65 +71,79 @@ class RequestProcessingError(AckAndContinueException):
 
 
 # Rest / Client errors
-class BrewmasterRestError(Exception):
-    """Wrapper Error to Wrap more specific BREWMASTER Rest Errors"""
+class RestError(Exception):
+    """Base exception for REST errors"""
     pass
 
 
-class BrewmasterRestClientError(BrewmasterRestError):
+class RestClientError(RestError):
     """Wrapper for all 4XX errors"""
     pass
 
 
-class BrewmasterRestServerError(BrewmasterRestError):
+class RestServerError(RestError):
     """Wrapper for all 5XX errors"""
     pass
 
 
-class BrewmasterConnectionError(BrewmasterRestServerError):
+class ConnectionError(RestServerError):
     """Error indicating a connection error while performing a request"""
     pass
 
 
-class BrewmasterTimeoutError(BrewmasterRestServerError):
+class TimeoutError(RestServerError):
     """Error Indicating a Timeout was reached while performing a request"""
     pass
 
 
-class BrewmasterFetchError(BrewmasterRestError):
+class FetchError(RestError):
     """Error Indicating a server Error occurred performing a GET"""
     pass
 
 
-class BrewmasterValidationError(BrewmasterRestClientError):
+class ValidationError(RestClientError):
     """Error Indicating a client (400) Error occurred performing a POST/PUT"""
     pass
 
 
-class BrewmasterSaveError(BrewmasterRestServerError):
+class SaveError(RestServerError):
     """Error Indicating a server Error occurred performing a POST/PUT"""
     pass
 
 
-class BrewmasterDeleteError(BrewmasterRestServerError):
+class DeleteError(RestServerError):
     """Error Indicating a server Error occurred performing a DELETE"""
     pass
 
 
-class BGConflictError(BrewmasterRestClientError):
+class BGConflictError(RestClientError):
     """Error indicating a 409 was raised on the server"""
     pass
 
 
-class BGRequestFailedError(BrewmasterRestError):
+class BGRequestFailedError(RestError):
     """Request returned with a 200, but the status was ERROR"""
     def __init__(self, request):
         self.request = request
 
 
-class BGNotFoundError(BrewmasterRestClientError):
+class BGNotFoundError(RestClientError):
     """Error Indicating a 404 was raised on the server"""
     pass
+
+
+# Alias the old 'Brewmaster' names
+BrewmasterModelError = ModelError
+BrewmasterModelValidationError = ModelValidationError
+BrewmasterRestError = RestError
+BrewmasterRestClientError = RestClientError
+BrewmasterRestServerError = RestServerError
+BrewmasterConnectionError = ConnectionError
+BrewmasterTimeoutError = TimeoutError
+BrewmasterFetchError = FetchError
+BrewmasterValidationError = ValidationError
+BrewmasterSaveError = SaveError
+BrewmasterDeleteError = DeleteError
 
 
 def parse_exception_as_json(exc):

--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -86,12 +86,12 @@ class RestServerError(RestError):
     pass
 
 
-class ConnectionError(RestServerError):
+class RestConnectionError(RestServerError):
     """Error indicating a connection error while performing a request"""
     pass
 
 
-class TimeoutError(RestServerError):
+class ConnectionTimeoutError(RestServerError):
     """Error Indicating a Timeout was reached while performing a request"""
     pass
 
@@ -116,34 +116,37 @@ class DeleteError(RestServerError):
     pass
 
 
-class BGConflictError(RestClientError):
+class ConflictError(RestClientError):
     """Error indicating a 409 was raised on the server"""
     pass
 
 
-class BGRequestFailedError(RestError):
+class RequestFailedError(RestError):
     """Request returned with a 200, but the status was ERROR"""
     def __init__(self, request):
         self.request = request
 
 
-class BGNotFoundError(RestClientError):
+class NotFoundError(RestClientError):
     """Error Indicating a 404 was raised on the server"""
     pass
 
 
-# Alias the old 'Brewmaster' names
+# Alias old names
 BrewmasterModelError = ModelError
 BrewmasterModelValidationError = ModelValidationError
 BrewmasterRestError = RestError
 BrewmasterRestClientError = RestClientError
 BrewmasterRestServerError = RestServerError
-BrewmasterConnectionError = ConnectionError
-BrewmasterTimeoutError = TimeoutError
+BrewmasterConnectionError = RestConnectionError
+BrewmasterTimeoutError = ConnectionTimeoutError
 BrewmasterFetchError = FetchError
 BrewmasterValidationError = ValidationError
 BrewmasterSaveError = SaveError
 BrewmasterDeleteError = DeleteError
+BGConflictError = ConflictError
+BGRequestFailedError = RequestFailedError
+BGNotFoundError = NotFoundError
 
 
 def parse_exception_as_json(exc):

--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -70,6 +70,11 @@ class RequestProcessingError(AckAndContinueException):
     pass
 
 
+class RequestPublishException(Exception):
+    """Error while publishing request"""
+    pass
+
+
 # Rest / Client errors
 class RestError(Exception):
     """Base exception for REST errors"""

--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -3,8 +3,13 @@ import json
 from six import string_types
 
 
+class BrewtilsException(Exception):
+    """Base exception"""
+    pass
+
+
 # Models
-class ModelError(Exception):
+class ModelError(BrewtilsException):
     """Base exception for model errors"""
     pass
 
@@ -20,7 +25,7 @@ class RequestStatusTransitionError(ModelValidationError):
 
 
 # Plugins
-class PluginError(Exception):
+class PluginError(BrewtilsException):
     """Generic error class"""
     pass
 
@@ -36,24 +41,29 @@ class PluginParamError(PluginError):
 
 
 # Requests
-class AckAndContinueException(Exception):
+class RequestProcessException(BrewtilsException):
+    """Base for exceptions that occur during request processing"""
     pass
 
 
-class NoAckAndDieException(Exception):
+class AckAndContinueException(RequestProcessException):
     pass
 
 
-class AckAndDieException(Exception):
+class NoAckAndDieException(RequestProcessException):
     pass
 
 
-class DiscardMessageException(Exception):
+class AckAndDieException(RequestProcessException):
+    pass
+
+
+class DiscardMessageException(RequestProcessException):
     """Raising an instance will result in a message not being requeued"""
     pass
 
 
-class RepublishRequestException(Exception):
+class RepublishRequestException(RequestProcessException):
     """Republish to the end of the message queue
 
     :param request: The Request to republish
@@ -70,13 +80,13 @@ class RequestProcessingError(AckAndContinueException):
     pass
 
 
-class RequestPublishException(Exception):
+class RequestPublishException(BrewtilsException):
     """Error while publishing request"""
     pass
 
 
 # Rest / Client errors
-class RestError(Exception):
+class RestError(BrewtilsException):
     """Base exception for REST errors"""
     pass
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -12,7 +12,7 @@ from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
 from brewtils.errors import ValidationError, RequestProcessingError, \
-    DiscardMessageException, RepublishRequestException, ConnectionError, \
+    DiscardMessageException, RepublishRequestException, RestConnectionError, \
     PluginValidationError, RestClientError, parse_exception_as_json
 from brewtils.models import Instance, Request, System
 from brewtils.request_consumer import RequestConsumer
@@ -475,7 +475,7 @@ class PluginBase(object):
     def _handle_request_update_failure(self, request, headers, exc):
 
         # If brew-view is down, we always want to try again (yes even if it is the 'final_attempt')
-        if isinstance(exc, (RequestsConnectionError, ConnectionError)):
+        if isinstance(exc, (RequestsConnectionError, RestConnectionError)):
             self.brew_view_down = True
             self.logger.error('Error updating request status: '
                               '{0} exception: {1}'.format(request.id, exc))
@@ -559,7 +559,7 @@ class PluginBase(object):
             if not self.brew_view_down:
                 try:
                     self.bm_client.instance_heartbeat(self.instance.id)
-                except (RequestsConnectionError, ConnectionError):
+                except (RequestsConnectionError, RestConnectionError):
                     self.brew_view_down = True
                     raise
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -8,12 +8,12 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import six
-from requests import ConnectionError
+from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
-from brewtils.errors import BrewmasterValidationError, RequestProcessingError, \
-    DiscardMessageException, RepublishRequestException, BrewmasterConnectionError, \
-    PluginValidationError, BrewmasterRestClientError, parse_exception_as_json
+from brewtils.errors import ValidationError, RequestProcessingError, \
+    DiscardMessageException, RepublishRequestException, ConnectionError, \
+    PluginValidationError, RestClientError, parse_exception_as_json
 from brewtils.models import Instance, Request, System
 from brewtils.request_consumer import RequestConsumer
 from brewtils.rest.easy_client import EasyClient
@@ -475,13 +475,13 @@ class PluginBase(object):
     def _handle_request_update_failure(self, request, headers, exc):
 
         # If brew-view is down, we always want to try again (yes even if it is the 'final_attempt')
-        if isinstance(exc, (ConnectionError, BrewmasterConnectionError)):
+        if isinstance(exc, (RequestsConnectionError, ConnectionError)):
             self.brew_view_down = True
             self.logger.error('Error updating request status: '
                               '{0} exception: {1}'.format(request.id, exc))
             raise RepublishRequestException(request, headers)
 
-        elif isinstance(exc, BrewmasterRestClientError):
+        elif isinstance(exc, RestClientError):
             message = ('Error updating request {0} and it is a '
                        'client error. Probable cause is that this '
                        'request is already updated. In which case, ignore '
@@ -559,7 +559,7 @@ class PluginBase(object):
             if not self.brew_view_down:
                 try:
                     self.bm_client.instance_heartbeat(self.instance.id)
-                except (ConnectionError, BrewmasterConnectionError):
+                except (RequestsConnectionError, ConnectionError):
                     self.brew_view_down = True
                     raise
 
@@ -591,16 +591,14 @@ class PluginBase(object):
                       metadata, display_name, max_instances):
         if system:
             if name or description or version or icon_name or display_name or max_instances:
-                raise BrewmasterValidationError("Sorry, you can't specify a system as well as "
-                                                "system creation helper keywords (name, "
-                                                "description, version, max_instances, "
-                                                "display_name, and icon_name)")
+                raise ValidationError("Sorry, you can't specify a system as well as system "
+                                      "creation helper keywords (name, description, version, "
+                                      "max_instances, display_name, and icon_name)")
 
             if not system.instances:
-                raise BrewmasterValidationError("Explicit system definition requires explicit "
-                                                "instance definition (use "
-                                                "instances=[Instance(name='default')] "
-                                                "for default behavior)")
+                raise ValidationError("Explicit system definition requires explicit instance "
+                                      "definition (use instances=[Instance(name='default')] "
+                                      "for default behavior)")
 
             if not system.max_instances:
                 system.max_instances = len(system.instances)

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 
 from brewtils.errors import FetchError, ValidationError, SaveError, \
-    DeleteError, ConnectionError, BGNotFoundError, BGConflictError, \
+    DeleteError, RestConnectionError, NotFoundError, ConflictError, \
     RestError
 from brewtils.models import Event, PatchOperation
 from brewtils.rest.client import RestClient
@@ -306,7 +306,7 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_logging_config(response.json())
         else:
-            self._handle_response_failure(response, default_exc=ConnectionError)
+            self._handle_response_failure(response, default_exc=RestConnectionError)
 
     def publish_event(self, *args, **kwargs):
         """Publish a new event by POSTing
@@ -367,15 +367,15 @@ class EasyClient(object):
     def _handle_response_failure(response, default_exc=RestError, raise_404=True):
         if response.status_code == 404:
             if raise_404:
-                raise BGNotFoundError(response.json())
+                raise NotFoundError(response.json())
             else:
                 return None
         elif response.status_code == 409:
-            raise BGConflictError(response.json())
+            raise ConflictError(response.json())
         elif 400 <= response.status_code < 500:
             raise ValidationError(response.json())
         elif response.status_code == 503:
-            raise ConnectionError(response.json())
+            raise RestConnectionError(response.json())
         else:
             raise default_exc(response.json())
 

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -1,16 +1,16 @@
 import logging
 import warnings
 
-from brewtils.errors import BrewmasterFetchError, BrewmasterValidationError, BrewmasterSaveError, \
-    BrewmasterDeleteError, BrewmasterConnectionError, BGNotFoundError, BGConflictError, \
-    BrewmasterRestError
+from brewtils.errors import FetchError, ValidationError, SaveError, \
+    DeleteError, ConnectionError, BGNotFoundError, BGConflictError, \
+    RestError
 from brewtils.models import Event, PatchOperation
 from brewtils.rest.client import RestClient
 from brewtils.schema_parser import SchemaParser
 
 
 class EasyClient(object):
-    """Client for communicating with beer-garden.
+    """Client for communicating with beer-garden
 
     This class provides nice wrappers around the functionality provided by a
     :py:class:`brewtils.rest.client.RestClient`
@@ -21,7 +21,7 @@ class EasyClient(object):
     :param api_version: The beer-garden REST API version. Will default to the latest version.
     :param ca_cert: beer-garden REST API server CA certificate.
     :param client_cert: The client certificate to use when making requests.
-    :param parser: The parser to use. If None will default to an instance of BrewmasterSchemaParser.
+    :param parser: The parser to use. If None will default to an instance of SchemaParser.
     :param logger: The logger to use. If None one will be created.
     :param url_prefix: beer-garden REST API URL Prefix.
     :param ca_verify: Flag indicating whether to verify server certificate when making a request.
@@ -45,10 +45,10 @@ class EasyClient(object):
         if response.ok:
             return response
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterFetchError)
+            self._handle_response_failure(response, default_exc=FetchError)
 
     def find_unique_system(self, **kwargs):
-        """Find a unique system using keyword arguments as search parameters.
+        """Find a unique system using keyword arguments as search parameters
 
         :param kwargs: Search parameters
         :return: One system instance
@@ -62,13 +62,12 @@ class EasyClient(object):
                 return None
 
             if len(systems) > 1:
-                raise BrewmasterFetchError("More than one system found that specifies "
-                                           "the given constraints")
+                raise FetchError("More than one system found that specifies the given constraints")
 
             return systems[0]
 
     def find_systems(self, **kwargs):
-        """Find systems using keyword arguments as search parameters.
+        """Find systems using keyword arguments as search parameters
 
         :param kwargs: Search parameters
         :return: A list of system instances satisfying the given search parameters
@@ -78,20 +77,20 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_system(response.json(), many=True)
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterFetchError)
+            self._handle_response_failure(response, default_exc=FetchError)
 
     def _find_system_by_id(self, system_id, **kwargs):
-        """Finds a system by id, convert JSON to a system object and return it."""
+        """Finds a system by id, convert JSON to a system object and return it"""
         response = self.client.get_system(system_id, **kwargs)
 
         if response.ok:
             return self.parser.parse_system(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterFetchError,
+            self._handle_response_failure(response, default_exc=FetchError,
                                           raise_404=False)
 
     def create_system(self, system):
-        """Create a new system by POSTing to a BREWMASTER server.
+        """Create a new system by POSTing
 
         :param system: The system to create
         :return: The system creation response
@@ -102,10 +101,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_system(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def update_system(self, system_id, new_commands=None, **kwargs):
-        """Update a system with a PATCH
+        """Update a system by PATCHing
 
         :param system_id: The ID of the system to update
         :param new_commands: The new commands
@@ -140,10 +139,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_system(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def remove_system(self, **kwargs):
-        """Remove a specific system using keyword arguments as search parameters.
+        """Remove a specific system by DELETEing, using keyword arguments as search parameters
 
         :param kwargs: Search parameters
         :return: The response
@@ -151,23 +150,23 @@ class EasyClient(object):
         system = self.find_unique_system(**kwargs)
 
         if system is None:
-            raise BrewmasterFetchError("Could not find system matching the given search parameters")
+            raise FetchError("Could not find system matching the given search parameters")
 
         return self._remove_system_by_id(system.id)
 
     def _remove_system_by_id(self, system_id):
 
         if system_id is None:
-            raise BrewmasterDeleteError("Cannot delete a system without an id")
+            raise DeleteError("Cannot delete a system without an id")
 
         response = self.client.delete_system(system_id)
         if response.ok:
             return True
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterDeleteError)
+            self._handle_response_failure(response, default_exc=DeleteError)
 
     def initialize_instance(self, instance_id):
-        """Start an instance by PATCHing to a BREWMASTER server.
+        """Start an instance by PATCHing
 
         :param instance_id: The ID of the instance to start
         :return: The start response
@@ -180,10 +179,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_instance(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def update_instance_status(self, instance_id, new_status):
-        """Update an instance by PATCHing to a BREWMASTER server.
+        """Update an instance by PATCHing
 
         :param instance_id: The ID of the instance to start
         :param new_status: The updated status
@@ -195,10 +194,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_instance(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def instance_heartbeat(self, instance_id):
-        """Send heartbeat to BREWMASTER for health and status purposes
+        """Send heartbeat for health and status
 
         :param instance_id: The ID of the instance
         :return: The response
@@ -209,10 +208,10 @@ class EasyClient(object):
         if response.ok:
             return True
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def find_unique_request(self, **kwargs):
-        """Find a unique request using keyword arguments as search parameters.
+        """Find a unique request using keyword arguments as search parameters
 
         .. note::
             If 'id' is present in kwargs then all other parameters will be ignored.
@@ -229,13 +228,13 @@ class EasyClient(object):
                 return None
 
             if len(requests) > 1:
-                raise BrewmasterFetchError("More than one request found that specifies "
-                                           "the given constraints")
+                raise FetchError("More than one request found that specifies "
+                                 "the given constraints")
 
             return requests[0]
 
     def find_requests(self, **kwargs):
-        """Find requests using keyword arguments as search parameters.
+        """Find requests using keyword arguments as search parameters
 
         :param kwargs: Search parameters
         :return: A list of request instances satisfying the given search parameters
@@ -245,20 +244,20 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_request(response.json(), many=True)
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterFetchError)
+            self._handle_response_failure(response, default_exc=FetchError)
 
     def _find_request_by_id(self, request_id):
-        """Finds a request by id, convert JSON to a request object and return it."""
+        """Finds a request by id, convert JSON to a request object and return it"""
         response = self.client.get_request(request_id)
 
         if response.ok:
             return self.parser.parse_request(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterFetchError,
+            self._handle_response_failure(response, default_exc=FetchError,
                                           raise_404=False)
 
     def create_request(self, request):
-        """Create a new request.
+        """Create a new request by POSTing
 
         :param request: The request to create
         :return: The response
@@ -269,10 +268,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_request(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def update_request(self, request_id, status=None, output=None, error_class=None):
-        """Set various fields on a request with a PATCH
+        """Set various fields on a request by PATCHing
 
         :param request_id: The ID of the request to update
         :param status: The new status
@@ -295,7 +294,7 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_request(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterSaveError)
+            self._handle_response_failure(response, default_exc=SaveError)
 
     def get_logging_config(self, system_name):
         """Get the logging configuration for a particular system.
@@ -307,10 +306,10 @@ class EasyClient(object):
         if response.ok:
             return self.parser.parse_logging_config(response.json())
         else:
-            self._handle_response_failure(response, default_exc=BrewmasterConnectionError)
+            self._handle_response_failure(response, default_exc=ConnectionError)
 
     def publish_event(self, *args, **kwargs):
-        """Publish a new event.
+        """Publish a new event by POSTing
 
         :param args: The Event to create
         :param _publishers: Optional list of specific publishers. If None all publishers will be
@@ -365,7 +364,7 @@ class EasyClient(object):
             self._handle_response_failure(response)
 
     @staticmethod
-    def _handle_response_failure(response, default_exc=BrewmasterRestError, raise_404=True):
+    def _handle_response_failure(response, default_exc=RestError, raise_404=True):
         if response.status_code == 404:
             if raise_404:
                 raise BGNotFoundError(response.json())
@@ -374,9 +373,9 @@ class EasyClient(object):
         elif response.status_code == 409:
             raise BGConflictError(response.json())
         elif 400 <= response.status_code < 500:
-            raise BrewmasterValidationError(response.json())
+            raise ValidationError(response.json())
         elif response.status_code == 503:
-            raise BrewmasterConnectionError(response.json())
+            raise ConnectionError(response.json())
         else:
             raise default_exc(response.json())
 

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -5,8 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from multiprocessing import cpu_count
 
-from brewtils.errors import BrewmasterTimeoutError, BrewmasterFetchError, \
-    BrewmasterValidationError, BGRequestFailedError
+from brewtils.errors import TimeoutError, FetchError, ValidationError, BGRequestFailedError
 from brewtils.models import Request
 from brewtils.plugin import request_context
 from brewtils.rest.easy_client import EasyClient
@@ -44,7 +43,7 @@ class SystemClient(object):
         The System definition is lazily loaded, so nothing happens until the first attempt to send
         a Request. At that point the SystemClient will query beer-garden to get a system definition
         that matches the system_name and version_constraint. If no matching system can be found a
-        BrewmasterFetchError will be raised. If always_update was set to True this will happen
+        FetchError will be raised. If always_update was set to True this will happen
         before making each request, not just the first.
 
     Making a Request:
@@ -56,7 +55,7 @@ class SystemClient(object):
         determined by periodically polling beer-garden to check the Request status. The time
         between polling requests starts at 0.5s and doubles each time the request has still not
         completed, up to max_delay. If a timeout was specified and the Request has not completed
-        within that time a ``BrewmasterTimeoutError`` will be raised.
+        within that time a ``TimeoutError`` will be raised.
 
         It is also possible to create the SystemClient in non-blocking mode by specifying
         blocking=False. In this case the request creation will immediately return a Future and
@@ -201,7 +200,7 @@ class SystemClient(object):
             want you should check out create_bg_request.
 
         :param kwargs: All necessary request parameters, including beer-garden internal parameters
-        :raise BrewmasterValidationError: If the Request creation failed validation on the server
+        :raise ValidationError: If the Request creation failed validation on the server
         :return: If the SystemClient was created with blocking=True a completed request object,
             otherwise a Future that will return the Request when it completes.
         """
@@ -210,7 +209,7 @@ class SystemClient(object):
         # check for a new version and retry
         try:
             request = self._easy_client.create_request(self._construct_bg_request(**kwargs))
-        except BrewmasterValidationError:
+        except ValidationError:
             if self._system and self._version_constraint == 'latest':
                 old_version = self._system.version
 
@@ -238,7 +237,7 @@ class SystemClient(object):
         If this method completes successfully the SystemClient will be ready to create and send
         Requests.
 
-        :raise BrewmasterFetchError: If unable to find a matching System
+        :raise FetchError: If unable to find a matching System
         :return: None
         """
 
@@ -251,9 +250,8 @@ class SystemClient(object):
                                                                 version=self._version_constraint)
 
         if self._system is None:
-            raise BrewmasterFetchError("beer-garden has no system named '%s' with a version "
-                                       "matching '%s'" %
-                                       (self._system_name, self._version_constraint))
+            raise FetchError("Beer-garden has no system named '%s' with a version matching '%s'" %
+                             (self._system_name, self._version_constraint))
 
         self._commands = {command.name: command for command in self._system.commands}
         self._loaded = True
@@ -266,8 +264,8 @@ class SystemClient(object):
         while request.status not in Request.COMPLETED_STATUSES:
 
             if self._timeout and total_wait_time > self._timeout:
-                raise BrewmasterTimeoutError("Timeout reached waiting for request '%s' to "
-                                             "complete" % str(request))
+                raise TimeoutError("Timeout reached waiting for request '%s' to complete" %
+                                   str(request))
 
             time.sleep(delay_time)
             total_wait_time += delay_time
@@ -314,13 +312,13 @@ class SystemClient(object):
             metadata['system_display_name'] = system_display
 
         if command is None:
-            raise BrewmasterValidationError('Unable to send a request with no command')
+            raise ValidationError('Unable to send a request with no command')
         if system_name is None:
-            raise BrewmasterValidationError('Unable to send a request with no system name')
+            raise ValidationError('Unable to send a request with no system name')
         if system_version is None:
-            raise BrewmasterValidationError('Unable to send a request with no system version')
+            raise ValidationError('Unable to send a request with no system version')
         if instance_name is None:
-            raise BrewmasterValidationError('Unable to send a request with no instance name')
+            raise ValidationError('Unable to send a request with no instance name')
 
         return Request(command=command, system=system_name, system_version=system_version,
                        instance_name=instance_name, comment=comment, output_type=output_type,

--- a/test/brewtils_test.py
+++ b/test/brewtils_test.py
@@ -7,7 +7,7 @@ from yapconf.exceptions import YapconfItemNotFound
 
 import brewtils
 import brewtils.rest
-from brewtils.errors import BrewmasterValidationError
+from brewtils.errors import ValidationError
 from brewtils.rest.easy_client import EasyClient
 
 
@@ -82,7 +82,7 @@ class BrewtilsTest(unittest.TestCase):
         self.assertEqual(self.params, brewtils.get_bg_connection_parameters(**params))
 
     def test_get_bg_connection_parameters_no_host(self):
-        self.assertRaises(BrewmasterValidationError, brewtils.get_bg_connection_parameters)
+        self.assertRaises(ValidationError, brewtils.get_bg_connection_parameters)
 
     def test_get_bg_connection_parameters_no_something(self):
 

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from mock import Mock, PropertyMock
 
-from brewtils.errors import BrewmasterModelValidationError, RequestStatusTransitionError
+from brewtils.errors import ModelValidationError, RequestStatusTransitionError
 from brewtils.models import Command, Instance, Parameter, PatchOperation, Request, System, \
     Choices, LoggingConfig, Event, Queue
 
@@ -247,7 +247,7 @@ class RequestTest(unittest.TestCase):
     def test_init_none_command_type(self):
         try:
             Request(system='foo', command='bar', command_type=None)
-        except BrewmasterModelValidationError:
+        except ModelValidationError:
             self.fail("Request should be allowed to initialize a None Command Type.")
 
     def test_str(self):

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -7,9 +7,9 @@ import sys
 from mock import MagicMock, Mock, patch
 from requests import ConnectionError
 
-from brewtils.errors import BrewmasterValidationError, RequestProcessingError, \
+from brewtils.errors import ValidationError, RequestProcessingError, \
     DiscardMessageException, RepublishRequestException, PluginValidationError, \
-    BrewmasterRestClientError
+    RestClientError
 from brewtils.models import Instance, Request, System, Command
 from brewtils.plugin import PluginBase
 
@@ -44,7 +44,7 @@ class PluginBaseTest(unittest.TestCase):
         os.environ = self.safe_copy
 
     def test_init_no_bg_host(self):
-        self.assertRaises(BrewmasterValidationError, PluginBase, self.client)
+        self.assertRaises(ValidationError, PluginBase, self.client)
 
     def test_init_no_instance_name_unique_name_check(self):
         self.assertEqual(self.plugin.unique_name, 'test_system[default]-1.0.0')
@@ -547,7 +547,7 @@ class PluginBaseTest(unittest.TestCase):
 
     def test_update_request_client_error(self):
         request_mock = Mock(is_ephemeral=False)
-        self.bm_client_mock.update_request.side_effect = BrewmasterRestClientError
+        self.bm_client_mock.update_request.side_effect = RestClientError
 
         self.assertRaises(DiscardMessageException, self.plugin._update_request, request_mock, {})
         self.assertTrue(self.bm_client_mock.update_request.called)
@@ -666,25 +666,25 @@ class PluginBaseTest(unittest.TestCase):
         self.assertEqual(4, self.plugin._setup_max_concurrent(False, 4))
 
     def test_setup_system_system_and_extra_params(self):
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', self.system,
                           'name', '', '', '', {}, None, None)
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', self.system,
                           '', 'description', '', '', {}, None, None)
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', self.system,
                           '', '', 'version', '', {}, None, None)
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', self.system,
                           '', '', '', 'icon name', {}, None, None)
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', self.system,
                           '', '', '', '', {}, "display_name", None)
 
     def test_setup_system_no_instances(self):
         system = System(name='test_system', version='1.0.0')
-        self.assertRaises(BrewmasterValidationError, self.plugin._setup_system, self.client,
+        self.assertRaises(ValidationError, self.plugin._setup_system, self.client,
                           'default', system,
                           '', '', '', '', {}, None, None)
 

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -4,7 +4,7 @@ import warnings
 from mock import ANY, Mock, patch
 
 from brewtils.errors import FetchError, ValidationError, SaveError, \
-    DeleteError, ConnectionError, BGNotFoundError, BGConflictError, RestError
+    DeleteError, RestConnectionError, NotFoundError, ConflictError, RestError
 from brewtils.models import System
 from brewtils.rest.easy_client import EasyClient, BrewmasterEasyClient
 
@@ -44,7 +44,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_version')
     def test_get_version_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.get_version)
+        self.assertRaises(RestConnectionError, self.client.get_version)
 
     @patch('brewtils.rest.client.RestClient.get_logging_config')
     def test_get_logging_config(self, mock_get):
@@ -58,7 +58,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_logging_config')
     def test_get_logging_config_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.get_logging_config, 'system_name')
+        self.assertRaises(RestConnectionError, self.client.get_logging_config, 'system_name')
 
     # Find systems
     @patch('brewtils.rest.client.RestClient.get_systems')
@@ -81,7 +81,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_systems')
     def test_find_systems_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.find_systems)
+        self.assertRaises(RestConnectionError, self.client.find_systems)
 
     @patch('brewtils.rest.client.RestClient.get_systems')
     def test_find_systems_call_parser(self, mock_get):
@@ -135,7 +135,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_system')
     def test_find_system_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client._find_system_by_id, 'id')
+        self.assertRaises(RestConnectionError, self.client._find_system_by_id, 'id')
 
     # Create system
     @patch('brewtils.rest.client.RestClient.post_systems')
@@ -161,7 +161,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.post_systems')
     def test_create_system_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.create_system, 'system')
+        self.assertRaises(RestConnectionError, self.client.create_system, 'system')
 
     # Update request
     @patch('brewtils.rest.client.RestClient.patch_system')
@@ -209,14 +209,14 @@ class EasyClientTest(unittest.TestCase):
     def test_update_system_invalid_id(self, mock_patch):
         mock_patch.return_value = self.fake_not_found_error_response
 
-        self.assertRaises(BGNotFoundError, self.client.update_system, 'id')
+        self.assertRaises(NotFoundError, self.client.update_system, 'id')
         mock_patch.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_system')
     def test_update_system_conflict(self, mock_patch):
         mock_patch.return_value = self.fake_conflict_error_response
 
-        self.assertRaises(BGConflictError, self.client.update_system, 'id')
+        self.assertRaises(ConflictError, self.client.update_system, 'id')
         mock_patch.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_system')
@@ -229,7 +229,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.patch_system')
     def test_update_system_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.update_system, 'system')
+        self.assertRaises(RestConnectionError, self.client.update_system, 'system')
 
     # Remove system
     @patch('brewtils.rest.easy_client.EasyClient._remove_system_by_id')
@@ -271,7 +271,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.delete_system')
     def test_remove_system_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client._remove_system_by_id, 'foo')
+        self.assertRaises(RestConnectionError, self.client._remove_system_by_id, 'foo')
 
     def test_remove_system_by_id_none(self):
         self.assertRaises(DeleteError, self.client._remove_system_by_id, None)
@@ -304,7 +304,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_initialize_instance_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.initialize_instance, 'id')
+        self.assertRaises(RestConnectionError, self.client.initialize_instance, 'id')
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_update_instance_status(self, request_mock):
@@ -334,7 +334,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_update_instance_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.update_instance_status, 'id',
+        self.assertRaises(RestConnectionError, self.client.update_instance_status, 'id',
                           'status')
 
     # Instance heartbeat
@@ -362,7 +362,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_instance_heartbeat_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.instance_heartbeat, 'id')
+        self.assertRaises(RestConnectionError, self.client.instance_heartbeat, 'id')
 
     # Find requests
     @patch('brewtils.rest.easy_client.EasyClient._find_request_by_id')
@@ -401,7 +401,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_requests')
     def test_find_requests_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.find_requests, search='params')
+        self.assertRaises(RestConnectionError, self.client.find_requests, search='params')
 
     @patch('brewtils.rest.client.RestClient.get_request')
     def test_find_request_by_id(self, mock_get):
@@ -429,7 +429,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_request')
     def test_find_request_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client._find_request_by_id, 'id')
+        self.assertRaises(RestConnectionError, self.client._find_request_by_id, 'id')
 
     # Create request
     @patch('brewtils.rest.client.RestClient.post_requests')
@@ -455,7 +455,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.post_requests')
     def test_create_request_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.create_request, 'request')
+        self.assertRaises(RestConnectionError, self.client.create_request, 'request')
 
     # Update request
     @patch('brewtils.rest.client.RestClient.patch_request')
@@ -488,7 +488,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.patch_request')
     def test_update_request_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.update_request, 'id')
+        self.assertRaises(RestConnectionError, self.client.update_request, 'id')
 
     # Publish Event
     @patch('brewtils.rest.client.RestClient.post_event')
@@ -505,7 +505,7 @@ class EasyClientTest(unittest.TestCase):
         self.assertRaises(RestError, self.client.publish_event, 'system')
 
         mock_post.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.publish_event, 'system')
+        self.assertRaises(RestConnectionError, self.client.publish_event, 'system')
 
     # Queues
     @patch('brewtils.rest.client.RestClient.get_queues')
@@ -523,7 +523,7 @@ class EasyClientTest(unittest.TestCase):
         self.assertRaises(RestError, self.client.get_queues)
 
         mock_get.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.get_queues)
+        self.assertRaises(RestConnectionError, self.client.get_queues)
 
     @patch('brewtils.rest.client.RestClient.delete_queue')
     def test_clear_queue(self, mock_delete):
@@ -539,7 +539,7 @@ class EasyClientTest(unittest.TestCase):
         self.assertRaises(RestError, self.client.clear_queue, 'queue')
 
         mock_delete.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.clear_queue, 'queue')
+        self.assertRaises(RestConnectionError, self.client.clear_queue, 'queue')
 
     @patch('brewtils.rest.client.RestClient.delete_queues')
     def test_clear_all_queues(self, mock_delete):
@@ -555,7 +555,7 @@ class EasyClientTest(unittest.TestCase):
         self.assertRaises(RestError, self.client.clear_all_queues)
 
         mock_delete.return_value = self.fake_connection_error_response
-        self.assertRaises(ConnectionError, self.client.clear_all_queues)
+        self.assertRaises(RestConnectionError, self.client.clear_all_queues)
 
 
 class BrewmasterEasyClientTest(unittest.TestCase):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -3,9 +3,8 @@ import warnings
 
 from mock import ANY, Mock, patch
 
-from brewtils.errors import BrewmasterFetchError, BrewmasterValidationError, BrewmasterSaveError, \
-    BrewmasterDeleteError, BrewmasterConnectionError, BGNotFoundError, BGConflictError, \
-    BrewmasterRestError
+from brewtils.errors import FetchError, ValidationError, SaveError, \
+    DeleteError, ConnectionError, BGNotFoundError, BGConflictError, RestError
 from brewtils.models import System
 from brewtils.rest.easy_client import EasyClient, BrewmasterEasyClient
 
@@ -39,13 +38,13 @@ class EasyClientTest(unittest.TestCase):
     def test_get_version_error(self, mock_get):
         mock_get.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterFetchError, self.client.get_version)
+        self.assertRaises(FetchError, self.client.get_version)
         mock_get.assert_called()
 
     @patch('brewtils.rest.client.RestClient.get_version')
     def test_get_version_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.get_version)
+        self.assertRaises(ConnectionError, self.client.get_version)
 
     @patch('brewtils.rest.client.RestClient.get_logging_config')
     def test_get_logging_config(self, mock_get):
@@ -59,7 +58,7 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_logging_config')
     def test_get_logging_config_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.get_logging_config, 'system_name')
+        self.assertRaises(ConnectionError, self.client.get_logging_config, 'system_name')
 
     # Find systems
     @patch('brewtils.rest.client.RestClient.get_systems')
@@ -77,12 +76,12 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_systems')
     def test_find_systems_server_error(self, mock_get):
         mock_get.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterFetchError, self.client.find_systems)
+        self.assertRaises(FetchError, self.client.find_systems)
 
     @patch('brewtils.rest.client.RestClient.get_systems')
     def test_find_systems_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.find_systems)
+        self.assertRaises(ConnectionError, self.client.find_systems)
 
     @patch('brewtils.rest.client.RestClient.get_systems')
     def test_find_systems_call_parser(self, mock_get):
@@ -108,7 +107,7 @@ class EasyClientTest(unittest.TestCase):
 
     def test_find_unique_system_multiple(self):
         self.client.find_systems = Mock(return_value=['system1', 'system2'])
-        self.assertRaises(BrewmasterFetchError, self.client.find_unique_system)
+        self.assertRaises(FetchError, self.client.find_unique_system)
 
     @patch('brewtils.rest.client.RestClient.get_system')
     def test_find_system_by_id(self, mock_get):
@@ -130,13 +129,13 @@ class EasyClientTest(unittest.TestCase):
     def test_find_system_by_id_server_error(self, mock_get):
         mock_get.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterFetchError, self.client._find_system_by_id, 'id')
+        self.assertRaises(FetchError, self.client._find_system_by_id, 'id')
         mock_get.assert_called_with('id')
 
     @patch('brewtils.rest.client.RestClient.get_system')
     def test_find_system_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client._find_system_by_id, 'id')
+        self.assertRaises(ConnectionError, self.client._find_system_by_id, 'id')
 
     # Create system
     @patch('brewtils.rest.client.RestClient.post_systems')
@@ -152,17 +151,17 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.post_systems')
     def test_create_system_client_error(self, mock_post):
         mock_post.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.create_system, 'system')
+        self.assertRaises(ValidationError, self.client.create_system, 'system')
 
     @patch('brewtils.rest.client.RestClient.post_systems')
     def test_create_system_server_error(self, mock_post):
         mock_post.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterSaveError, self.client.create_system, 'system')
+        self.assertRaises(SaveError, self.client.create_system, 'system')
 
     @patch('brewtils.rest.client.RestClient.post_systems')
     def test_create_system_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.create_system, 'system')
+        self.assertRaises(ConnectionError, self.client.create_system, 'system')
 
     # Update request
     @patch('brewtils.rest.client.RestClient.patch_system')
@@ -203,7 +202,7 @@ class EasyClientTest(unittest.TestCase):
     def test_update_system_client_error(self, mock_patch):
         mock_patch.return_value = self.fake_client_error_response
 
-        self.assertRaises(BrewmasterValidationError, self.client.update_system, 'id')
+        self.assertRaises(ValidationError, self.client.update_system, 'id')
         mock_patch.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_system')
@@ -224,13 +223,13 @@ class EasyClientTest(unittest.TestCase):
     def test_update_system_server_error(self, mock_patch):
         mock_patch.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterSaveError, self.client.update_system, 'id')
+        self.assertRaises(SaveError, self.client.update_system, 'id')
         mock_patch.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_system')
     def test_update_system_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.update_system, 'system')
+        self.assertRaises(ConnectionError, self.client.update_system, 'system')
 
     # Remove system
     @patch('brewtils.rest.easy_client.EasyClient._remove_system_by_id')
@@ -248,7 +247,7 @@ class EasyClientTest(unittest.TestCase):
     def test_remove_system_none_found(self, find_mock, remove_mock):
         find_mock.return_value = None
 
-        self.assertRaises(BrewmasterFetchError, self.client.remove_system, search='search params')
+        self.assertRaises(FetchError, self.client.remove_system, search='search params')
         self.assertFalse(remove_mock.called)
         find_mock.assert_called_once_with(search='search params')
 
@@ -262,20 +261,20 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.delete_system')
     def test_remove_system_by_id_client_error(self, mock_remove):
         mock_remove.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client._remove_system_by_id, 'foo')
+        self.assertRaises(ValidationError, self.client._remove_system_by_id, 'foo')
 
     @patch('brewtils.rest.client.RestClient.delete_system')
     def test_remove_system_by_id_server_error(self, mock_remove):
         mock_remove.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterDeleteError, self.client._remove_system_by_id, 'foo')
+        self.assertRaises(DeleteError, self.client._remove_system_by_id, 'foo')
 
     @patch('brewtils.rest.client.RestClient.delete_system')
     def test_remove_system_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client._remove_system_by_id, 'foo')
+        self.assertRaises(ConnectionError, self.client._remove_system_by_id, 'foo')
 
     def test_remove_system_by_id_none(self):
-        self.assertRaises(BrewmasterDeleteError, self.client._remove_system_by_id, None)
+        self.assertRaises(DeleteError, self.client._remove_system_by_id, None)
 
     # Initialize instance
     @patch('brewtils.rest.client.RestClient.patch_instance')
@@ -290,7 +289,7 @@ class EasyClientTest(unittest.TestCase):
     def test_initialize_instance_client_error(self, request_mock):
         request_mock.return_value = self.fake_client_error_response
 
-        self.assertRaises(BrewmasterValidationError, self.client.initialize_instance, 'id')
+        self.assertRaises(ValidationError, self.client.initialize_instance, 'id')
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with('id', ANY)
 
@@ -298,14 +297,14 @@ class EasyClientTest(unittest.TestCase):
     def test_initialize_instance_server_error(self, request_mock):
         request_mock.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterSaveError, self.client.initialize_instance, 'id')
+        self.assertRaises(SaveError, self.client.initialize_instance, 'id')
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_initialize_instance_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.initialize_instance, 'id')
+        self.assertRaises(ConnectionError, self.client.initialize_instance, 'id')
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_update_instance_status(self, request_mock):
@@ -319,7 +318,7 @@ class EasyClientTest(unittest.TestCase):
     def test_update_instance_status_client_error(self, request_mock):
         request_mock.return_value = self.fake_client_error_response
 
-        self.assertRaises(BrewmasterValidationError, self.client.update_instance_status, 'id',
+        self.assertRaises(ValidationError, self.client.update_instance_status, 'id',
                           'status')
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with('id', ANY)
@@ -328,14 +327,14 @@ class EasyClientTest(unittest.TestCase):
     def test_update_instance_status_server_error(self, request_mock):
         request_mock.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterSaveError, self.client.update_instance_status, 'id', 'status')
+        self.assertRaises(SaveError, self.client.update_instance_status, 'id', 'status')
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_update_instance_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.update_instance_status, 'id',
+        self.assertRaises(ConnectionError, self.client.update_instance_status, 'id',
                           'status')
 
     # Instance heartbeat
@@ -350,20 +349,20 @@ class EasyClientTest(unittest.TestCase):
     def test_instance_heartbeat_client_error(self, request_mock):
         request_mock.return_value = self.fake_client_error_response
 
-        self.assertRaises(BrewmasterValidationError, self.client.instance_heartbeat, 'id')
+        self.assertRaises(ValidationError, self.client.instance_heartbeat, 'id')
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_instance_heartbeat_server_error(self, request_mock):
         request_mock.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterSaveError, self.client.instance_heartbeat, 'id')
+        self.assertRaises(SaveError, self.client.instance_heartbeat, 'id')
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_instance')
     def test_instance_heartbeat_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.instance_heartbeat, 'id')
+        self.assertRaises(ConnectionError, self.client.instance_heartbeat, 'id')
 
     # Find requests
     @patch('brewtils.rest.easy_client.EasyClient._find_request_by_id')
@@ -381,7 +380,7 @@ class EasyClientTest(unittest.TestCase):
 
     def test_find_unique_request_multiple(self):
         self.client.find_requests = Mock(return_value=['request1', 'request2'])
-        self.assertRaises(BrewmasterFetchError, self.client.find_unique_request)
+        self.assertRaises(FetchError, self.client.find_unique_request)
 
     @patch('brewtils.rest.client.RestClient.get_requests')
     def test_find_requests(self, mock_get):
@@ -396,13 +395,13 @@ class EasyClientTest(unittest.TestCase):
     def test_find_requests_error(self, mock_get):
         mock_get.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterFetchError, self.client.find_requests, search='params')
+        self.assertRaises(FetchError, self.client.find_requests, search='params')
         mock_get.assert_called_with(search='params')
 
     @patch('brewtils.rest.client.RestClient.get_requests')
     def test_find_requests_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.find_requests, search='params')
+        self.assertRaises(ConnectionError, self.client.find_requests, search='params')
 
     @patch('brewtils.rest.client.RestClient.get_request')
     def test_find_request_by_id(self, mock_get):
@@ -424,13 +423,13 @@ class EasyClientTest(unittest.TestCase):
     def test_find_request_by_id_server_error(self, mock_get):
         mock_get.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterFetchError, self.client._find_request_by_id, 'id')
+        self.assertRaises(FetchError, self.client._find_request_by_id, 'id')
         mock_get.assert_called_with('id')
 
     @patch('brewtils.rest.client.RestClient.get_request')
     def test_find_request_by_id_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client._find_request_by_id, 'id')
+        self.assertRaises(ConnectionError, self.client._find_request_by_id, 'id')
 
     # Create request
     @patch('brewtils.rest.client.RestClient.post_requests')
@@ -446,17 +445,17 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.post_requests')
     def test_create_request_client_error(self, mock_post):
         mock_post.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.create_request, 'request')
+        self.assertRaises(ValidationError, self.client.create_request, 'request')
 
     @patch('brewtils.rest.client.RestClient.post_requests')
     def test_create_request_server_error(self, mock_post):
         mock_post.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterSaveError, self.client.create_request, 'request')
+        self.assertRaises(SaveError, self.client.create_request, 'request')
 
     @patch('brewtils.rest.client.RestClient.post_requests')
     def test_create_request_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.create_request, 'request')
+        self.assertRaises(ConnectionError, self.client.create_request, 'request')
 
     # Update request
     @patch('brewtils.rest.client.RestClient.patch_request')
@@ -476,20 +475,20 @@ class EasyClientTest(unittest.TestCase):
     def test_update_request_client_error(self, request_mock):
         request_mock.return_value = self.fake_client_error_response
 
-        self.assertRaises(BrewmasterValidationError, self.client.update_request, 'id')
+        self.assertRaises(ValidationError, self.client.update_request, 'id')
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_request')
     def test_update_request_server_error(self, request_mock):
         request_mock.return_value = self.fake_server_error_response
 
-        self.assertRaises(BrewmasterSaveError, self.client.update_request, 'id')
+        self.assertRaises(SaveError, self.client.update_request, 'id')
         request_mock.assert_called_once_with('id', ANY)
 
     @patch('brewtils.rest.client.RestClient.patch_request')
     def test_update_request_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.update_request, 'id')
+        self.assertRaises(ConnectionError, self.client.update_request, 'id')
 
     # Publish Event
     @patch('brewtils.rest.client.RestClient.post_event')
@@ -500,13 +499,13 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.post_event')
     def test_publish_event_errors(self, mock_post):
         mock_post.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.publish_event, 'system')
+        self.assertRaises(ValidationError, self.client.publish_event, 'system')
 
         mock_post.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterRestError, self.client.publish_event, 'system')
+        self.assertRaises(RestError, self.client.publish_event, 'system')
 
         mock_post.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.publish_event, 'system')
+        self.assertRaises(ConnectionError, self.client.publish_event, 'system')
 
     # Queues
     @patch('brewtils.rest.client.RestClient.get_queues')
@@ -518,13 +517,13 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.get_queues')
     def test_get_queues_errors(self, mock_get):
         mock_get.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.get_queues)
+        self.assertRaises(ValidationError, self.client.get_queues)
 
         mock_get.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterRestError, self.client.get_queues)
+        self.assertRaises(RestError, self.client.get_queues)
 
         mock_get.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.get_queues)
+        self.assertRaises(ConnectionError, self.client.get_queues)
 
     @patch('brewtils.rest.client.RestClient.delete_queue')
     def test_clear_queue(self, mock_delete):
@@ -534,13 +533,13 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.delete_queue')
     def test_clear_queue_errors(self, mock_delete):
         mock_delete.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.clear_queue, 'queue')
+        self.assertRaises(ValidationError, self.client.clear_queue, 'queue')
 
         mock_delete.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterRestError, self.client.clear_queue, 'queue')
+        self.assertRaises(RestError, self.client.clear_queue, 'queue')
 
         mock_delete.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.clear_queue, 'queue')
+        self.assertRaises(ConnectionError, self.client.clear_queue, 'queue')
 
     @patch('brewtils.rest.client.RestClient.delete_queues')
     def test_clear_all_queues(self, mock_delete):
@@ -550,13 +549,13 @@ class EasyClientTest(unittest.TestCase):
     @patch('brewtils.rest.client.RestClient.delete_queues')
     def test_clear_all_queues_errors(self, mock_delete):
         mock_delete.return_value = self.fake_client_error_response
-        self.assertRaises(BrewmasterValidationError, self.client.clear_all_queues)
+        self.assertRaises(ValidationError, self.client.clear_all_queues)
 
         mock_delete.return_value = self.fake_server_error_response
-        self.assertRaises(BrewmasterRestError, self.client.clear_all_queues)
+        self.assertRaises(RestError, self.client.clear_all_queues)
 
         mock_delete.return_value = self.fake_connection_error_response
-        self.assertRaises(BrewmasterConnectionError, self.client.clear_all_queues)
+        self.assertRaises(ConnectionError, self.client.clear_all_queues)
 
 
 class BrewmasterEasyClientTest(unittest.TestCase):

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -4,8 +4,8 @@ from concurrent.futures import wait
 
 from mock import call, patch, Mock, PropertyMock
 
-from brewtils.errors import TimeoutError, FetchError, \
-    ValidationError, BGRequestFailedError
+from brewtils.errors import ConnectionTimeoutError, FetchError, \
+    ValidationError, RequestFailedError
 from brewtils.rest.system_client import BrewmasterSystemClient, SystemClient
 
 
@@ -146,7 +146,7 @@ class SystemClientTest(unittest.TestCase):
         self.easy_client_mock.find_unique_request.return_value = self.mock_error
         self.easy_client_mock.create_request.return_value = self.mock_in_progress
 
-        with self.assertRaises(BGRequestFailedError) as ex:
+        with self.assertRaises(RequestFailedError) as ex:
             self.client.command_1(_raise_on_error=True)
 
         self.assertEqual(ex.exception.request.status, 'ERROR')
@@ -194,7 +194,7 @@ class SystemClientTest(unittest.TestCase):
 
         self.client._timeout = 1
 
-        self.assertRaises(TimeoutError, self.client.command_1)
+        self.assertRaises(ConnectionTimeoutError, self.client.command_1)
         self.easy_client_mock.find_unique_request.assert_called_with(id=self.mock_in_progress.id)
 
     @patch('brewtils.rest.system_client.time.sleep', Mock())
@@ -235,7 +235,7 @@ class SystemClientTest(unittest.TestCase):
 
         self.easy_client_mock.find_unique_request.assert_called_with(id=self.mock_in_progress.id)
         for future in futures:
-            self.assertRaises(TimeoutError, future.result)
+            self.assertRaises(ConnectionTimeoutError, future.result)
 
     def test_always_update(self):
         self.client._always_update = True

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -4,8 +4,8 @@ from concurrent.futures import wait
 
 from mock import call, patch, Mock, PropertyMock
 
-from brewtils.errors import BrewmasterTimeoutError, BrewmasterFetchError, \
-    BrewmasterValidationError, BGRequestFailedError
+from brewtils.errors import TimeoutError, FetchError, \
+    ValidationError, BGRequestFailedError
 from brewtils.rest.system_client import BrewmasterSystemClient, SystemClient
 
 
@@ -66,11 +66,11 @@ class SystemClientTest(unittest.TestCase):
     def test_load_bg_system_no_system_with_version_constraint(self):
         self.client._version_constraint = '1.0.0'
         self.easy_client_mock.find_unique_system.return_value = None
-        self.assertRaises(BrewmasterFetchError, self.client.load_bg_system)
+        self.assertRaises(FetchError, self.client.load_bg_system)
 
     def test_load_bg_system_no_system_without_version_constraint(self):
         self.easy_client_mock.find_systems.return_value = []
-        self.assertRaises(BrewmasterFetchError, self.client.load_bg_system)
+        self.assertRaises(FetchError, self.client.load_bg_system)
 
     def test_load_bg_system_latest_version(self):
         fake_system_2 = Mock(version='2.0.0', commands=[self.fake_command_1, self.fake_command_2],
@@ -121,13 +121,13 @@ class SystemClientTest(unittest.TestCase):
 
     def test_create_request_missing_fields(self):
 
-        self.assertRaises(BrewmasterValidationError, self.client._construct_bg_request,
+        self.assertRaises(ValidationError, self.client._construct_bg_request,
                           _system_name='', _system_version='', _instance_name='')
-        self.assertRaises(BrewmasterValidationError, self.client._construct_bg_request,
+        self.assertRaises(ValidationError, self.client._construct_bg_request,
                           _command='', _system_version='', _instance_name='')
-        self.assertRaises(BrewmasterValidationError, self.client._construct_bg_request,
+        self.assertRaises(ValidationError, self.client._construct_bg_request,
                           _command='', _system_name='', _instance_name='')
-        self.assertRaises(BrewmasterValidationError, self.client._construct_bg_request,
+        self.assertRaises(ValidationError, self.client._construct_bg_request,
                           _command='', _system_name='', _system_version='')
 
     @patch('brewtils.rest.system_client.time.sleep', Mock())
@@ -194,7 +194,7 @@ class SystemClientTest(unittest.TestCase):
 
         self.client._timeout = 1
 
-        self.assertRaises(BrewmasterTimeoutError, self.client.command_1)
+        self.assertRaises(TimeoutError, self.client.command_1)
         self.easy_client_mock.find_unique_request.assert_called_with(id=self.mock_in_progress.id)
 
     @patch('brewtils.rest.system_client.time.sleep', Mock())
@@ -235,7 +235,7 @@ class SystemClientTest(unittest.TestCase):
 
         self.easy_client_mock.find_unique_request.assert_called_with(id=self.mock_in_progress.id)
         for future in futures:
-            self.assertRaises(BrewmasterTimeoutError, future.result)
+            self.assertRaises(TimeoutError, future.result)
 
     def test_always_update(self):
         self.client._always_update = True
@@ -249,9 +249,9 @@ class SystemClientTest(unittest.TestCase):
         self.assertTrue(load_mock.called)
 
     def test_retry_send_no_different_version(self):
-        self.easy_client_mock.create_request.side_effect = BrewmasterValidationError
+        self.easy_client_mock.create_request.side_effect = ValidationError
 
-        self.assertRaises(BrewmasterValidationError, self.client.command_1)
+        self.assertRaises(ValidationError, self.client.command_1)
         self.assertEqual(1, self.easy_client_mock.create_request.call_count)
 
     def test_retry_send_different_version(self):
@@ -262,7 +262,7 @@ class SystemClientTest(unittest.TestCase):
         type(fake_system_2).name = PropertyMock(return_value='system')
         self.easy_client_mock.find_systems.return_value = [fake_system_2]
 
-        self.easy_client_mock.create_request.side_effect = [BrewmasterValidationError,
+        self.easy_client_mock.create_request.side_effect = [ValidationError,
                                                             self.mock_success]
 
         self.client.command_1()


### PR DESCRIPTION
This started as a preliminary step in addressing beer-garden/beer-garden#37 and morphed into having all exceptions inherit from a common base.

This should be reviewed after #46