### PR TITLE
Get log level from environment if set.

### DIFF
--- a/brewtils/log/__init__.py
+++ b/brewtils/log/__init__.py
@@ -21,6 +21,7 @@ Example:
 
 import logging.config
 import copy
+import os
 import brewtils
 
 # Loggers to always use. These are things that generally,
@@ -67,7 +68,7 @@ DEFAULT_LOGGING_CONFIG = {
     "handlers": DEFAULT_HANDLERS,
     "loggers": DEFAULT_LOGGERS,
     "root": {
-        "level": "INFO",
+        "level": os.environ.get("BG_LOG_LEVEL", "INFO"),
         "handlers": ["default"]
     }
 }


### PR DESCRIPTION
This change goes along with beer-garden/bartender#4
This will automatically setup a logging level for
local plugins that are using a logger, but did not
previously configure the logger.