### PR TITLE
Removing merge_specification option from load_config

### DIFF
--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -124,7 +124,6 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
 def load_config(
         cli_args=None,
         argument_parser=None,
-        merge_specification=None,
         **kwargs
 ):
     """Load configuration using Yapconf
@@ -145,16 +144,12 @@ def load_config(
             prior to loading the configuration. This can be useful if your
             startup script takes additional arguments. See get_argument_parser
             for additional information.
-        merge_specification (dict, optional): Specification that will be merged
-            with the brewtils specification before loading the configuration
         **kwargs: Additional configuration overrides
 
     Returns:
         :obj:`box.Box`: The resolved configuration object
     """
-    spec_source = merge_specification or {}
-    spec_source.update(SPECIFICATION)
-    spec = YapconfSpec(spec_source, env_prefix='BG_')
+    spec = YapconfSpec(SPECIFICATION, env_prefix='BG_')
 
     sources = []
 

--- a/test/brewtils_test.py
+++ b/test/brewtils_test.py
@@ -2,7 +2,6 @@ import copy
 import os
 
 import pytest
-from yapconf.exceptions import YapconfItemNotFound
 
 import brewtils
 import brewtils.rest
@@ -70,24 +69,6 @@ class TestBrewtils(object):
 
         config = brewtils.load_config([])
         assert config.bg_host == 'the_host'
-
-    def test_load_config_extra_spec(self):
-        # Still always need a host
-        os.environ['BG_HOST'] = 'the_host'
-
-        spec = {
-            "some_parameter": {
-                "type": "str",
-                "description": "Another required parameter",
-            },
-        }
-
-        config = brewtils.load_config(merge_specification=spec,
-                                      some_parameter='param')
-        assert config.some_parameter == 'param'
-
-        with pytest.raises(YapconfItemNotFound):
-            brewtils.load_config(merge_specification=spec)
 
     def test_get_easy_client(self):
         client = brewtils.get_easy_client(host='bg_host')


### PR DESCRIPTION
So I think this ability would be useful, but we don't have an immediate need for it and there's still a little bit of weirdness regarding how we would load from environment variables.

I think in order to support this fully `yapconf` would need to be tweaked. Since this is very much not pressing I think it's best to take it out for now so we aren't locked into this API.