### PR TITLE
Plugins always send updated commands when initializing

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -391,11 +391,6 @@ class Plugin(object):
             name=self.system.name, version=self.system.version)
 
         if existing_system:
-            if existing_system.has_different_commands(self.system.commands):
-                new_commands = self.system.commands
-            else:
-                new_commands = None
-
             if not existing_system.has_instance(self.instance_name):
                 if len(existing_system.instances) < existing_system.max_instances:
                     existing_system.instances.append(Instance(name=self.instance_name))
@@ -413,7 +408,7 @@ class Plugin(object):
             # We always update in case the metadata has changed.
             self.system = self.bm_client.update_system(
                 existing_system.id,
-                new_commands=new_commands,
+                new_commands=self.system.commands,
                 metadata=self.system.metadata,
                 description=self.system.description,
                 display_name=self.system.display_name,

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -168,28 +168,13 @@ class TestPluginInitialize(object):
         assert bm_client.create_system.return_value == plugin.system
         assert bm_client.initialize_instance.return_value == plugin.instance
 
-    def test_system_exists_same_commands(
-        self, plugin, bm_client, bg_system, bg_instance,
-    ):
-        bm_client.update_system.return_value = bg_system
-        bm_client.find_unique_system.return_value = bg_system
-
-        plugin._initialize()
-        bm_client.initialize_instance.assert_called_once_with(bg_instance.id)
-        bm_client.update_system.assert_called_once_with(
-            bg_system.id,
-            new_commands=None,
-            metadata=bg_system.metadata,
-            description=bg_system.description,
-            icon_name=bg_system.icon_name,
-            display_name=bg_system.display_name,
-        )
-        assert bm_client.create_system.called is False
-        assert bm_client.create_system.return_value == plugin.system
-        assert bm_client.initialize_instance.return_value == plugin.instance
-
-    def test_system_exists_different_commands(
-        self, plugin, bm_client, bg_system, bg_instance,
+    @pytest.mark.parametrize('current_commands', [
+        [],
+        [Command('test')],
+        [Command('other_test')],
+    ])
+    def test_system_exists(
+        self, plugin, bm_client, bg_system, bg_instance, current_commands,
     ):
         bg_system.commands = [Command('test')]
         bm_client.update_system.return_value = bg_system
@@ -199,6 +184,7 @@ class TestPluginInitialize(object):
             name='test_system',
             version='0.0.1',
             instances=[bg_instance],
+            commands=current_commands,
             metadata={'foo': 'bar'},
         )
         bm_client.find_unique_system.return_value = existing_system


### PR DESCRIPTION
This is part of the fix for beer-garden/beer-garden#58. Plugins will just send the commands as they know them and let the server decide if the commands are allowed or not.