### PR TITLE
WIP Adding StatusInfo model

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -12,6 +12,7 @@ __all__ = [
     'Command',
     'Parameter',
     'Request',
+    'StatusInfo',
     'PatchOperation',
     'Choices',
     'LoggingConfig',
@@ -475,6 +476,20 @@ class System(object):
                 return True
 
         return False
+
+
+class StatusInfo(object):
+
+    schema = 'StatusInfoSchema'
+
+    def __init__(self, heartbeat=None):
+        self.heartbeat = heartbeat
+
+    def __str__(self):
+        return '%s' % self.heartbeat
+
+    def __repr__(self):
+        return '<StatusInfo: heartbeat=%s>' % self.heartbeat
 
 
 class PatchOperation(object):

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -8,7 +8,7 @@ import six
 from brewtils.models import (
     System, Instance, Command, Parameter, Request, PatchOperation, Choices,
     LoggingConfig, Event, Queue, Principal, Role, RefreshToken, Job,
-    RequestTemplate, DateTrigger, CronTrigger, IntervalTrigger
+    RequestTemplate, DateTrigger, CronTrigger, IntervalTrigger, StatusInfo,
 )
 from brewtils.schemas import (
     SystemSchema, InstanceSchema, CommandSchema, ParameterSchema, RequestSchema,
@@ -39,6 +39,7 @@ class SchemaParser(object):
         'DateTriggerSchema': DateTrigger,
         'IntervalTriggerSchema': IntervalTrigger,
         'CronTriggerSchema': CronTrigger,
+        'StatusInfoSchema': StatusInfo,
     }
 
     logger = logging.getLogger(__name__)

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -14,6 +14,7 @@ __all__ = [
     'CommandSchema',
     'ParameterSchema',
     'RequestSchema',
+    'StatusInfoSchema',
     'PatchSchema',
     'LoggingConfigSchema',
     'EventSchema',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ import pytz
 from brewtils.models import (
     Parameter, Command, Instance, System, Request, Choices, PatchOperation,
     LoggingConfig, Event, Queue, Principal, Role, Job, CronTrigger,
-    RequestTemplate, IntervalTrigger, DateTrigger
+    RequestTemplate, IntervalTrigger, DateTrigger, StatusInfo,
 )
 
 # This is a little weird, but we have a circular dependency and this makes
@@ -137,7 +137,19 @@ def bg_command(command_dict, bg_parameter):
 
 
 @pytest.fixture
-def instance_dict(ts_epoch):
+def status_dict(ts_epoch):
+    return {
+        'heartbeat': ts_epoch,
+    }
+
+
+@pytest.fixture
+def bg_status(ts_dt):
+    return StatusInfo(heartbeat=ts_dt)
+
+
+@pytest.fixture
+def instance_dict(status_dict):
     """An instance represented as a dictionary."""
     return {
         'id': '584f11af55a38e64799fd1d4',
@@ -150,16 +162,16 @@ def instance_dict(ts_epoch):
             'queue': 'abc[default]-0.0.1',
             'url': 'amqp://guest:guest@localhost:5672'
         },
-        'status_info': {'heartbeat': ts_epoch},
+        'status_info': status_dict,
         'metadata': {},
     }
 
 
 @pytest.fixture
-def bg_instance(instance_dict, ts_dt):
+def bg_instance(instance_dict, bg_status):
     """An instance as a model."""
     dict_copy = copy.deepcopy(instance_dict)
-    dict_copy['status_info']['heartbeat'] = ts_dt
+    dict_copy['status_info'] = bg_status
     return Instance(**dict_copy)
 
 

--- a/test/utils/comparable.py
+++ b/test/utils/comparable.py
@@ -5,7 +5,7 @@ from functools import partial
 from brewtils.models import (
     System, Command, Instance, Parameter, Request, PatchOperation,
     LoggingConfig, Event, Queue, Choices, Principal, Role, Job, IntervalTrigger,
-    DateTrigger, CronTrigger, RequestTemplate
+    DateTrigger, CronTrigger, RequestTemplate, StatusInfo,
 )
 
 __all__ = [
@@ -60,7 +60,7 @@ def _assert_equal(obj1, obj2, expected_type=None, deep_fields=None):
 
 
 # These are the 'simple' models - they don't have any nested models as fields
-assert_instance_equal = partial(_assert_equal, expected_type=Instance)
+assert_status_equal = partial(_assert_equal, expected_type=StatusInfo)
 assert_choices_equal = partial(_assert_equal, expected_type=Choices)
 assert_patch_equal = partial(_assert_equal, expected_type=PatchOperation)
 assert_logging_config_equal = partial(_assert_equal, expected_type=LoggingConfig)
@@ -69,6 +69,12 @@ assert_queue_equal = partial(_assert_equal, expected_type=Queue)
 assert_request_template_equal = partial(_assert_equal, expected_type=RequestTemplate)
 assert_trigger_equal = partial(_assert_equal,
                                expected_type=(CronTrigger, DateTrigger, IntervalTrigger))
+
+
+def assert_instance_equal(obj1, obj2):
+    _assert_equal(obj1, obj2,
+                  expected_type=Instance,
+                  deep_fields={'status_info': assert_status_equal})
 
 
 def assert_command_equal(obj1, obj2):


### PR DESCRIPTION
This addresses a small inconsistency in how the models are nested.

Currently the Instance `status_info` field is a nested field in the schema. The problem is that since there is no actual status info model class it gets parsed as a dictionary.

This adds that missing status info model class.

This is technically an API change - if anyone was using the clients to get an Instance and then inspecting the heartbeat it's a change:

```python
my_instance.status_info['heartbeat']
 # Becomes
my_instance.status_info.heartbeat
```

I think the correct thing to do here is to release this as part of 3.0 and mark as a breaking change in the release notes.