### PR TITLE
Beergarden/186

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -176,7 +176,7 @@ class Plugin(object):
             ssl_enabled=ssl_enabled,
             ca_cert=ca_cert,
             client_cert=client_cert,
-            url_prefix=bg_url_prefix,
+            url_prefix=bg_url_prefix or kwargs.get('url_prefix', None),
             ca_verify=kwargs.get('ca_verify', None),
             username=kwargs.get('username', None),
             password=kwargs.get('password', None),

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -172,7 +172,6 @@ class TestPluginInit(object):
         assert plugin.ssl_enabled is True
         assert plugin.ca_verify is True
 
-    @pytest.mark.xfail
     def test_cli(self, client, bg_system):
         args = [
             '--bg-host', 'remotehost',

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -86,10 +86,11 @@ class TestPluginInit(object):
         assert expected_unique == plugin.unique_name
 
     def test_init_defaults(self, plugin):
-        assert logging.getLogger('brewtils.plugin') == plugin.logger
-        assert 'default' == plugin.instance_name
-        assert 'localhost' == plugin.bg_host
-        assert 2337 == plugin.bg_port
+        assert plugin.logger == logging.getLogger('brewtils.plugin')
+        assert plugin.instance_name == 'default'
+        assert plugin.bg_host == 'localhost'
+        assert plugin.bg_port == 2337
+        assert plugin.bg_url_prefix == '/'
         assert plugin.ssl_enabled is True
         assert plugin.ca_verify is True
 
@@ -116,33 +117,41 @@ class TestPluginInit(object):
 
         plugin = Plugin(
             client,
-            bg_host='localhost',
+            bg_host='host1',
+            bg_port=2338,
+            bg_url_prefix='/beer/',
             system=bg_system,
             ssl_enabled=False,
             ca_verify=False,
             logger=logger,
         )
 
+        assert plugin.bg_host == 'host1'
+        assert plugin.bg_port == 2338
+        assert plugin.bg_url_prefix == '/beer/'
         assert plugin.ssl_enabled is False
         assert plugin.ca_verify is False
-        assert logger == plugin.logger
+        assert plugin.logger == logger
 
     def test_init_env(self, bg_system):
         os.environ['BG_HOST'] = 'remotehost'
         os.environ['BG_PORT'] = '7332'
+        os.environ['BG_URL_PREFIX'] = '/beer/'
         os.environ['BG_SSL_ENABLED'] = 'False'
         os.environ['BG_CA_VERIFY'] = 'False'
 
         plugin = Plugin(client, system=bg_system)
 
-        assert 'remotehost' == plugin.bg_host
-        assert 7332 == plugin.bg_port
+        assert plugin.bg_host == 'remotehost'
+        assert plugin.bg_port == 7332
+        assert plugin.bg_url_prefix == '/beer/'
         assert plugin.ssl_enabled is False
         assert plugin.ca_verify is False
 
     def test_init_conflicts(self, bg_system):
         os.environ['BG_HOST'] = 'remotehost'
         os.environ['BG_PORT'] = '7332'
+        os.environ['BG_URL_PREFIX'] = '/tea/'
         os.environ['BG_SSL_ENABLED'] = 'False'
         os.environ['BG_CA_VERIFY'] = 'False'
 
@@ -150,13 +159,15 @@ class TestPluginInit(object):
             client,
             bg_host='localhost',
             bg_port=2337,
+            bg_url_prefix='/beer/',
             system=bg_system,
             ssl_enabled=True,
             ca_verify=True,
         )
 
-        assert 'localhost' == plugin.bg_host
-        assert 2337 == plugin.bg_port
+        assert plugin.bg_host == 'localhost'
+        assert plugin.bg_port == 2337
+        assert plugin.bg_url_prefix == '/beer/'
         assert plugin.ssl_enabled is True
         assert plugin.ca_verify is True
 

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -68,7 +68,7 @@ def plugin(client, bm_client, parser, bg_system, bg_instance):
 
 class TestPluginInit(object):
 
-    def test_init_no_bg_host(self, client):
+    def test_no_bg_host(self, client):
         with pytest.raises(ValidationError):
             Plugin(client)
 
@@ -85,7 +85,7 @@ class TestPluginInit(object):
 
         assert expected_unique == plugin.unique_name
 
-    def test_init_defaults(self, plugin):
+    def test_defaults(self, plugin):
         assert plugin.logger == logging.getLogger('brewtils.plugin')
         assert plugin.instance_name == 'default'
         assert plugin.bg_host == 'localhost'
@@ -94,7 +94,7 @@ class TestPluginInit(object):
         assert plugin.ssl_enabled is True
         assert plugin.ca_verify is True
 
-    def test_init_default_logger(self, monkeypatch, client):
+    def test_default_logger(self, monkeypatch, client):
         """Test that the default logging configuration is used.
 
         This needs to be tested separately because pytest (understandably) does some
@@ -112,7 +112,7 @@ class TestPluginInit(object):
         dict_config.assert_called_once_with(DEFAULT_LOGGING_CONFIG)
         assert logging.getLogger('brewtils.plugin') == plugin.logger
 
-    def test_init_kwargs(self, bg_system):
+    def test_kwargs(self, client, bg_system):
         logger = Mock()
 
         plugin = Plugin(
@@ -133,7 +133,7 @@ class TestPluginInit(object):
         assert plugin.ca_verify is False
         assert plugin.logger == logger
 
-    def test_init_env(self, bg_system):
+    def test_env(self, client, bg_system):
         os.environ['BG_HOST'] = 'remotehost'
         os.environ['BG_PORT'] = '7332'
         os.environ['BG_URL_PREFIX'] = '/beer/'
@@ -148,7 +148,7 @@ class TestPluginInit(object):
         assert plugin.ssl_enabled is False
         assert plugin.ca_verify is False
 
-    def test_init_conflicts(self, bg_system):
+    def test_conflicts(self, client, bg_system):
         os.environ['BG_HOST'] = 'remotehost'
         os.environ['BG_PORT'] = '7332'
         os.environ['BG_URL_PREFIX'] = '/tea/'

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -11,6 +11,7 @@ import pytest
 from mock import MagicMock, Mock
 from requests import ConnectionError
 
+from brewtils import get_connection_info
 from brewtils.errors import (
     ValidationError, RequestProcessingError, DiscardMessageException,
     RepublishRequestException, PluginValidationError, RestClientError,
@@ -170,6 +171,24 @@ class TestPluginInit(object):
         assert plugin.bg_url_prefix == '/beer/'
         assert plugin.ssl_enabled is True
         assert plugin.ca_verify is True
+
+    @pytest.mark.xfail
+    def test_cli(self, client, bg_system):
+        args = [
+            '--bg-host', 'remotehost',
+            '--bg-port', '2338',
+            '--url-prefix', 'beer',
+            '--no-ssl-enabled',
+            '--no-ca-verify',
+        ]
+
+        plugin = Plugin(client, system=bg_system, **get_connection_info(cli_args=args))
+
+        assert plugin.bg_host == 'remotehost'
+        assert plugin.bg_port == 2338
+        assert plugin.bg_url_prefix == '/beer/'
+        assert plugin.ssl_enabled is False
+        assert plugin.ca_verify is False
 
 
 class TestPluginRun(object):


### PR DESCRIPTION
This fixes beer-garden/beer-garden#186.

The underlying issue here is that we have mismatch between what the spec says this option should be called (url_prefix) and what the plugin args think it should be called (bg_url_prefix).

In this situation I feel the spec needs to be treated as truth, so this PR modifies the Plugin to accept either name. If both options are passed it will use the value from bg_url_prefix to avoid changing behavior for anyone that's currently using this.