### PR TITLE
Tweaking system fixture name to mesh with other fixtures

### DIFF
--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -183,7 +183,7 @@ def bg_instance(instance_dict, ts_dt):
 def system_dict(instance_dict, command_dict, system_id):
     """A system represented as a dictionary."""
     return {
-        'name': 'name',
+        'name': 'system',
         'description': 'desc',
         'version': '1.0.0',
         'id': system_id,

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -73,8 +73,8 @@ class TestPluginInit(object):
             Plugin(client)
 
     @pytest.mark.parametrize('instance_name,expected_unique', [
-        (None, 'name[default]-1.0.0'),
-        ('unique', 'name[unique]-1.0.0'),
+        (None, 'system[default]-1.0.0'),
+        ('unique', 'system[unique]-1.0.0'),
     ])
     def test_init_with_instance_name_unique_name_check(
         self, client, bg_system, instance_name, expected_unique,
@@ -425,7 +425,7 @@ class TestPreProcess(object):
 
     @pytest.mark.parametrize("request_args", [
         # Normal case
-        {"system": "name", "system_version": "1.0.0", "command_type": "ACTION"},
+        {"system": "system", "system_version": "1.0.0", "command_type": "ACTION"},
 
         # Missing or ephemeral command types should succeed even with wrong names
         {"system": "wrong", "system_version": "1.0.0"},


### PR DESCRIPTION
This makes the fixtures more consistent since bg_request has a system_name "system."