### PR TITLE
Marking choices grammar as a raw string

### DIFF
--- a/brewtils/choices.py
+++ b/brewtils/choices.py
@@ -16,7 +16,7 @@ except ImportError:
     LexError = ParseError
 
 
-choices_grammar = """
+choices_grammar = r"""
     func: CNAME [func_args]
     url: ADDRESS [url_args]
     reference: ref


### PR DESCRIPTION
The newest version of flake8 (3.6.0) complains about the presence of invalid escape sequence `\?` in the grammar string. It was lucky that this was an *invalid* sequence, otherwise our grammar would have just been quietly wrong.

This should be a raw string so that no escape sequences are interpreted.