### PR TITLE
Adding new get_instance method to EasyClient

### DIFF
--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -354,8 +354,25 @@ class EasyClient(object):
     @wrap_response(
         parse_method="parse_instance", parse_many=False, default_exc=FetchError
     )
+    def get_instance(self, instance_id):
+        """Get an Instance
+
+        Args:
+            instance_id: The Id
+
+        Returns:
+            The Instance
+
+        """
+        return self.client.get_instance(instance_id)
+
     def get_instance_status(self, instance_id):
-        """Get an instance's status
+        """Get an Instance
+
+        WARNING: This method currently returns the Instance, not the Instance's status.
+        This behavior will be corrected in 3.0.
+
+        To prepare for this change please use get_instance() instead of this method.
 
         Args:
             instance_id: The Id
@@ -364,7 +381,14 @@ class EasyClient(object):
             The status
 
         """
-        return self.client.get_instance(instance_id)
+        warnings.warn(
+            "This method currently returns the Instance, not the Instance's status. "
+            "This behavior will be corrected in 3.0. To prepare please use "
+            "get_instance() instead of this method.",
+            FutureWarning,
+        )
+
+        return self.get_instance(instance_id)
 
     @wrap_response(
         parse_method="parse_instance", parse_many=False, default_exc=SaveError

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -383,33 +383,89 @@ class EasyClientTest(unittest.TestCase):
         self.assertRaises(RestConnectionError, self.client.initialize_instance, "id")
 
     @patch("brewtils.rest.client.RestClient.get_instance")
-    def test_get_instance_status(self, request_mock):
+    def test_get_instance(self, request_mock):
         request_mock.return_value = self.fake_success_response
 
-        self.client.get_instance_status("id")
+        self.client.get_instance("id")
         self.assertTrue(self.parser.parse_instance.called)
         request_mock.assert_called_once_with("id")
 
     @patch("brewtils.rest.client.RestClient.get_instance")
-    def test_get_instance_status_client_error(self, request_mock):
+    def test_get_instance_client_error(self, request_mock):
         request_mock.return_value = self.fake_client_error_response
 
-        self.assertRaises(ValidationError, self.client.get_instance_status, "id")
+        self.assertRaises(ValidationError, self.client.get_instance, "id")
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with("id")
 
     @patch("brewtils.rest.client.RestClient.get_instance")
-    def test_get_instance_status_server_error(self, request_mock):
+    def test_get_instance_server_error(self, request_mock):
         request_mock.return_value = self.fake_server_error_response
 
-        self.assertRaises(FetchError, self.client.get_instance_status, "id")
+        self.assertRaises(FetchError, self.client.get_instance, "id")
         self.assertFalse(self.parser.parse_instance.called)
         request_mock.assert_called_once_with("id")
 
     @patch("brewtils.rest.client.RestClient.get_instance")
     def test_get_instance_connection_error(self, request_mock):
         request_mock.return_value = self.fake_connection_error_response
-        self.assertRaises(RestConnectionError, self.client.get_instance_status, "id")
+        self.assertRaises(RestConnectionError, self.client.get_instance, "id")
+
+    @patch("brewtils.rest.client.RestClient.get_instance")
+    def test_get_instance_status(self, request_mock):
+        request_mock.return_value = self.fake_success_response
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.client.get_instance_status("id")
+            self.assertTrue(self.parser.parse_instance.called)
+            request_mock.assert_called_once_with("id")
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, FutureWarning)
+
+    @patch("brewtils.rest.client.RestClient.get_instance")
+    def test_get_instance_status_client_error(self, request_mock):
+        request_mock.return_value = self.fake_client_error_response
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.assertRaises(ValidationError, self.client.get_instance_status, "id")
+            self.assertFalse(self.parser.parse_instance.called)
+            request_mock.assert_called_once_with("id")
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, FutureWarning)
+
+    @patch("brewtils.rest.client.RestClient.get_instance")
+    def test_get_instance_status_server_error(self, request_mock):
+        request_mock.return_value = self.fake_server_error_response
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.assertRaises(FetchError, self.client.get_instance_status, "id")
+            self.assertFalse(self.parser.parse_instance.called)
+            request_mock.assert_called_once_with("id")
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, FutureWarning)
+
+    @patch("brewtils.rest.client.RestClient.get_instance")
+    def test_get_instance_status_connection_error(self, request_mock):
+        request_mock.return_value = self.fake_connection_error_response
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.assertRaises(
+                RestConnectionError, self.client.get_instance_status, "id"
+            )
+
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[0].category, FutureWarning)
 
     @patch("brewtils.rest.client.RestClient.patch_instance")
     def test_update_instance_status(self, request_mock):


### PR DESCRIPTION
This is the first part of beer-garden/beer-garden#231.

It adds a new `get_instance` method to the `EasyClient`. It changes the current `get_instance_status` to log a `FutureWarning` (that the behavior will change in 3.0) and then just delegate to `get_instance`.

In 3.0 we'll just need to return the `status` attribute instead of the entire instance.