### PR TITLE
Auth update

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -691,6 +691,9 @@ class Queue(object):
 
 
 class Principal(object):
+
+    schema = "PrincipalSchema"
+
     def __init__(
         self,
         id=None,
@@ -719,6 +722,9 @@ class Principal(object):
 
 
 class Role(object):
+
+    schema = "RoleSchema"
+
     def __init__(
         self, id=None, name=None, description=None, roles=None, permissions=None
     ):
@@ -740,6 +746,9 @@ class Role(object):
 
 
 class RefreshToken(object):
+
+    schema = "RefreshTokenSchema"
+
     def __init__(self, id=None, issued=None, expires=None, payload=None):
         self.id = id
         self.issued = issued

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -692,13 +692,20 @@ class Queue(object):
 
 class Principal(object):
     def __init__(
-        self, id=None, username=None, roles=None, permissions=None, preferences=None
+        self,
+        id=None,
+        username=None,
+        roles=None,
+        permissions=None,
+        preferences=None,
+        metadata=None,
     ):
         self.id = id
         self.username = username
         self.roles = roles
         self.permissions = permissions
         self.preferences = preferences
+        self.metadata = metadata
 
     def __str__(self):
         return "%s" % self.username

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -482,7 +482,8 @@ class RestClient(object):
             Response object
         """
         refresh_token = refresh_token or self.refresh_token
-        response = self.session.get(self.token_url + refresh_token)
+        body = {"refresh_id": refresh_token}
+        response = self.session.get(self.token_url, data=body)
 
         if response.ok:
             response_data = response.json()

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -482,8 +482,9 @@ class RestClient(object):
             Response object
         """
         refresh_token = refresh_token or self.refresh_token
-        body = {"refresh_id": refresh_token}
-        response = self.session.get(self.token_url, data=body)
+        response = self.session.get(
+            self.token_url, headers={"X-BG-RefreshID": refresh_token}
+        )
 
         # On older versions of the API (2.4.2 and below) the new refresh token
         # is not available.

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -485,6 +485,11 @@ class RestClient(object):
         body = {"refresh_id": refresh_token}
         response = self.session.get(self.token_url, data=body)
 
+        # On older versions of the API (2.4.2 and below) the new refresh token
+        # is not available.
+        if response.status_code == 404:
+            response = self.session.get(self.token_url + refresh_token)
+
         if response.ok:
             response_data = response.json()
 

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -247,6 +247,7 @@ class PrincipalSchema(BaseSchema):
     roles = fields.Nested("RoleSchema", many=True, allow_none=True)
     permissions = fields.List(fields.Str(), allow_none=True)
     preferences = fields.Dict(allow_none=True)
+    metadata = fields.Dict(allow_none=True)
 
 
 class RoleSchema(BaseSchema):

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -438,6 +438,7 @@ def principal_dict(role_dict):
         "roles": [role_dict],
         "permissions": ["bg-all"],
         "preferences": {"theme": "dark"},
+        "metadata": {"foo": "bar"},
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "yapconf>=0.2.1",
     ],
     extras_require={
-        ':python_version=="2.7"': ["futures, funcsigs"],
+        ':python_version=="2.7"': ["futures", "funcsigs"],
         ':python_version<"3.4"': ["enum34"],
         "test": ["pytest<4"],
     },

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -268,7 +268,7 @@ class TestRestClient(object):
 
         client.refresh(refresh_token="refresh")
         session_mock.get.assert_called_with(
-            client.token_url, data={"refresh_id": "refresh"}
+            client.token_url, headers={"X-BG-RefreshID": "refresh"}
         )
         assert client.access_token == "new_token"
 
@@ -283,7 +283,7 @@ class TestRestClient(object):
             client.token_url + 'refresh'
         )
         session_mock.get.assert_any_call(
-            client.token_url, data={'refresh_id': 'refresh'}
+            client.token_url, headers={"X-BG-RefreshID": "refresh"}
         )
         assert client.access_token == 'new_token'
 

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -267,7 +267,9 @@ class TestRestClient(object):
         session_mock.get.return_value = response
 
         client.refresh(refresh_token="refresh")
-        session_mock.get.assert_called_with(client.token_url + "refresh")
+        session_mock.get.assert_called_with(
+            client.token_url, data={"refresh_id": "refresh"}
+        )
         assert client.access_token == "new_token"
 
     def test_session_client_cert(self):

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -272,6 +272,21 @@ class TestRestClient(object):
         )
         assert client.access_token == "new_token"
 
+    def test_refresh_404_fallback(self, client, session_mock):
+        response404 = Mock(status_code=404)
+        response200 = Mock(status_code=404)
+        response200.json.return_value = {'token': 'new_token'}
+        session_mock.get.side_effect = [response404, response200]
+        client.refresh(refresh_token='refresh')
+        assert session_mock.get.call_count == 2
+        session_mock.get.assert_any_call(
+            client.token_url + 'refresh'
+        )
+        session_mock.get.assert_any_call(
+            client.token_url, data={'refresh_id': 'refresh'}
+        )
+        assert client.access_token == 'new_token'
+
     def test_session_client_cert(self):
         client = RestClient(
             bg_host="host", bg_port=80, api_version=1, client_cert="/path/to/cert"


### PR DESCRIPTION
This set of PRs goes along with the following:

* [bg-utils PR](https://github.com/beer-garden/bg-utils/pull/44)
* [brew-view PR](https://github.com/beer-garden/brew-view/pull/122)

## Major Updates

The way we obtain tokens by default is changing. It still works with the old API but this way is slightly more secure in that we aren't exposing anything in a URL anymore.

## Minor Updates

* Some of our models didn't define schemas for some reason. This was breaking tests in brew-view, so I added them here.
* Added a `metadata` class to principal