### PR TITLE
Run plugin

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -82,6 +82,8 @@ def system(cls=None, name=None, version=None):
         lambda self: brewtils.plugin.request_context.current_request
     )
 
+    cls.run_plugin = brewtils.plugin.run_plugin
+
     return cls
 
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -45,14 +45,27 @@ __all__ = [
 _wrap_functions = False
 
 
-def system(cls):
+def system(cls=None, name=None, version=None):
     """Class decorator that marks a class as a beer-garden System
 
-    Creates a ``_commands`` property on the class that holds all registered commands.
+    Creates some properties on the class:
+      * ``_commands``: holds all registered commands
+      * ``_name``: an optional system name
+      * ``_version``: an optional system version
+      * ``_current_request``: Reference to the currently executing request
 
-    :param cls: The class to decorated
-    :return: The decorated class
+    Args:
+        cls: The class to decorated
+        name: Optional plugin name
+        version: Optional plugin version
+
+    Returns:
+        The decorated class
+
     """
+    if cls is None:
+        return functools.partial(system, name=name, version=version)
+
     import brewtils.plugin
 
     commands = []
@@ -63,6 +76,8 @@ def system(cls):
             commands.append(method_command)
 
     cls._commands = commands
+    cls._name = name
+    cls._version = version
     cls._current_request = property(
         lambda self: brewtils.plugin.request_context.current_request
     )

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -851,6 +851,11 @@ class Plugin(object):
             return str(output)
 
 
+def run_plugin(client, **kwargs):
+    """Helper for running a Plugin from a Client instance"""
+    Plugin(client, **kwargs).run()
+
+
 # Alias old name
 PluginBase = Plugin
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -776,6 +776,12 @@ class Plugin(object):
                     "max_instances, display_name, and icon_name)"
                 )
 
+            if client._name or client._version:
+                raise ValidationError(
+                    "Sorry, you can't specify a system as well as system "
+                    "info in the @system decorator (name, version)"
+                )
+
             if not system.instances:
                 raise ValidationError(
                     "Explicit system definition requires explicit instance "
@@ -787,8 +793,8 @@ class Plugin(object):
                 system.max_instances = len(system.instances)
 
         else:
-            name = name or os.environ.get("BG_NAME", None)
-            version = version or os.environ.get("BG_VERSION", None)
+            name = name or os.environ.get("BG_NAME", None) or client._name
+            version = version or os.environ.get("BG_VERSION", None) or client._version
 
             if client.__doc__ and not description:
                 description = self.client.__doc__.split("\n")[0]

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -57,9 +57,21 @@ def wrap_functions(request):
 
 
 class TestSystem(object):
-    def test_system(self, sys):
+    def test_system_basic(self, sys):
         assert 1 == len(sys._commands)
         assert "foo" == sys._commands[0].name
+
+    def test_system(self):
+        @system(name="sys", version="1.0.0")
+        class SystemClass(object):
+            @command
+            def foo(self):
+                pass
+
+        assert SystemClass._name == "sys"
+        assert SystemClass._version == "1.0.0"
+        assert 1 == len(SystemClass._commands)
+        assert "foo" == SystemClass._commands[0].name
 
 
 class TestParameter(object):

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -45,7 +45,11 @@ def bm_client(bg_system, bg_instance):
 @pytest.fixture
 def client():
     return MagicMock(
-        name="client", spec=["command", "_commands"], _commands=["command"]
+        name="client",
+        spec=["command", "_commands", "_name", "_version"],
+        _commands=["command"],
+        _name=None,
+        _version=None,
     )
 
 
@@ -774,6 +778,12 @@ class TestSetupSystem(object):
         with pytest.raises(ValidationError, match="system creation helper keywords"):
             plugin._setup_system(client, "default", bg_system, *extra_args)
 
+    @pytest.mark.parametrize("attr,value", [("_name", "name"), ("_version", "1.1.1")])
+    def test_extra_decorator_params(self, plugin, client, bg_system, attr, value):
+        setattr(client, attr, value)
+        with pytest.raises(ValidationError, match="@system decorator"):
+            plugin._setup_system(client, "default", bg_system, *([None] * 7))
+
     def test_no_instances(self, plugin, client):
         system = System(name="name", version="1.0.0")
         with pytest.raises(ValidationError, match="explicit instance definition"):
@@ -805,13 +815,7 @@ class TestSetupSystem(object):
             "display_name",
             None,
         )
-
-        assert new_system.name == "name"
-        assert new_system.description == "desc"
-        assert new_system.version == "1.0.0"
-        assert new_system.icon_name == "icon"
-        assert new_system.metadata == {"foo": "bar"}
-        assert new_system.display_name == "display_name"
+        self._validate_system(new_system)
 
     def test_construct_client_docstring(self, plugin, client):
         client.__doc__ = "Description\nSome more stuff"
@@ -838,7 +842,28 @@ class TestSetupSystem(object):
             "display_name",
             None,
         )
+        self._validate_system(new_system)
 
+    def test_construct_from_decorator(self, plugin, client):
+        client._name = "name"
+        client._version = "1.0.0"
+
+        new_system = plugin._setup_system(
+            client,
+            "default",
+            None,
+            None,
+            "desc",
+            None,
+            "icon",
+            {"foo": "bar"},
+            "display_name",
+            None,
+        )
+        self._validate_system(new_system)
+
+    @staticmethod
+    def _validate_system(new_system):
         assert new_system.name == "name"
         assert new_system.description == "desc"
         assert new_system.version == "1.0.0"


### PR DESCRIPTION
This doesn't really fix any issue, so I'm not sure if we should merge it. But it was easy to do and kind of neat.

This really only helps once the PR for specifying `name` and `version` in the `@system` decorator is in. Once that is done this PR allows us to do something like this:

```python
def main():
    EchoClient().run_plugin(bg_host="localhost", bg_port=2337, ssl_enabled=False)
```

The tradeoff is that `run_plugin` becomes an invalid command name.

I'm not tied to this, so if you think it's not worth the trouble let me know :smile: 
