### PR TITLE
Handle breaking changes in pika 1.0

### DIFF
--- a/brewtils/queues.py
+++ b/brewtils/queues.py
@@ -3,6 +3,9 @@
 import ssl as pyssl
 
 from pika import ConnectionParameters, PlainCredentials, SSLOptions
+from pika import __version__ as pika_version
+
+PIKA_ONE = pika_version.startswith("1.0")
 
 
 class PikaClient(object):
@@ -53,11 +56,23 @@ class PikaClient(object):
         self._exchange = exchange
 
         ssl = ssl or {}
-        mode = pyssl.CERT_REQUIRED if ssl.get("ca_verify") else pyssl.CERT_NONE
         self._ssl_enabled = ssl.get("enabled", False)
-        self._ssl_options = SSLOptions(
-            cafile=ssl.get("ca_cert", None), verify_mode=mode
-        )
+
+        if not self._ssl_enabled:
+            self._ssl_options = None
+        elif PIKA_ONE:
+            ssl_context = pyssl.create_default_context(cafile=ssl.get("ca_cert", None))
+            if ssl.get("ca_verify"):
+                ssl_context.verify_mode = pyssl.CERT_REQUIRED
+            else:
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = pyssl.CERT_NONE
+            self._ssl_options = SSLOptions(ssl_context, self._host)
+        else:
+            mode = pyssl.CERT_REQUIRED if ssl.get("ca_verify") else pyssl.CERT_NONE
+            self._ssl_options = SSLOptions(
+                cafile=ssl.get("ca_cert", None), verify_mode=mode
+            )
 
         # Save the 'normal' params so they don't need to be reconstructed
         self._conn_params = self.connection_parameters()
@@ -97,20 +112,24 @@ class PikaClient(object):
             password=kwargs.get("password", self._password),
         )
 
-        return ConnectionParameters(
-            host=kwargs.get("host", self._host),
-            port=kwargs.get("port", self._port),
-            ssl=kwargs.get("ssl_enabled", self._ssl_enabled),
-            ssl_options=kwargs.get("ssl_options", self._ssl_options),
-            virtual_host=kwargs.get("virtual_host", self._virtual_host),
-            connection_attempts=kwargs.get(
+        conn_params = {
+            "host": kwargs.get("host", self._host),
+            "port": kwargs.get("port", self._port),
+            "ssl_options": kwargs.get("ssl_options", self._ssl_options),
+            "virtual_host": kwargs.get("virtual_host", self._virtual_host),
+            "connection_attempts": kwargs.get(
                 "connection_attempts", self._connection_attempts
             ),
-            heartbeat=kwargs.get(
+            "heartbeat": kwargs.get(
                 "heartbeat", kwargs.get("heartbeat_interval", self._heartbeat)
             ),
-            blocked_connection_timeout=kwargs.get(
+            "blocked_connection_timeout": kwargs.get(
                 "blocked_connection_timeout", self._blocked_connection_timeout
             ),
-            credentials=credentials,
-        )
+            "credentials": credentials,
+        }
+
+        if not PIKA_ONE:
+            conn_params["ssl"] = kwargs.get("ssl_enabled", self._ssl_enabled)
+
+        return ConnectionParameters(**conn_params)

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ lark-parser < 0.7
 marshmallow < 3
 marshmallow-polyfield < 4
 packaging < 20
-pika < 0.14, >= 0.11
+pika < 1.1, >= 0.11
 pyjwt < 2
 requests < 3
 simplejson < 4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "marshmallow<3",
         "marshmallow-polyfield<4",
         "packaging<20",
-        "pika<0.14,>=0.11",
+        "pika<1.1,>=0.11",
         "pyjwt<2",
         "requests<3",
         "simplejson<4",


### PR DESCRIPTION
Pika made a bunch of syntax changes in 1.0 (released in March).

Changed functions:
* basic_cancel - fixed 
   * Old: `basic_cancel(callback=None, consumer_tag='', nowait=False)`
   * New: `basic_cancel(consumer_tag='', callback=None)`
* basic_consume - fixed
   * Old: `basic_consume(consumer_callback, queue='', no_ack=False, exclusive=False, consumer_tag=None, arguments=None)`
   * New: `basic_consume(queue, on_message_callback, auto_ack=False, exclusive=False, consumer_tag=None, arguments=None, callback=None)`
* basic_get - not present
* basic_qos - no changes required
   * Old: `basic_qos(callback=None, prefetch_size=0, prefetch_count=0, all_channels=False)`
  * New: `basic_qos(prefetch_size=0, prefetch_count=0, global_qos=False, callback=None)`
* basic_recover - not present
* confirm_delivery - not present
* exchange_bind - not present
* exchange_declare - not present
* exchange_delete - not present
* exchange_unbind - not present
* flow - not present
* queue_bind - not present
* queue_declare - not present
* queue_delete - not present
* queue_purge - not present
* queue_unbind - not present

Closes #130.