### PR TITLE
WIP: Merge Specifications

### DIFF
--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -99,7 +99,7 @@ def get_argument_parser():
     return parser
 
 
-def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
+def get_connection_info(cli_args=None, argument_parser=None, merge_spec=None, **kwargs):
     """Wrapper around ``load_config`` that returns only connection parameters
 
     Args:
@@ -109,12 +109,19 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
             parsing cli_args. Supplying this allows adding additional arguments
             prior to loading the configuration. This can be useful if your
             startup script takes additional arguments.
+        merge_spec (dict, optional): Specification that will be merged with the
+            brewtils specification before loading the configuration
         **kwargs: Additional configuration overrides
 
     Returns:
         :dict: Parameters needed to make a connection to Beergarden
     """
-    config = load_config(cli_args=cli_args, argument_parser=argument_parser, **kwargs)
+    config = load_config(
+        cli_args=cli_args,
+        argument_parser=argument_parser,
+        merge_spec=merge_spec,
+        **kwargs
+    )
 
     return {
         key: config["bg"][key]
@@ -136,7 +143,7 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
     }
 
 
-def load_config(cli_args=None, argument_parser=None, **kwargs):
+def load_config(cli_args=None, argument_parser=None, merge_spec=None, **kwargs):
     """Load configuration using Yapconf
 
     Configuration will be loaded from these sources, with earlier sources having
@@ -155,12 +162,16 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
             prior to loading the configuration. This can be useful if your
             startup script takes additional arguments. See get_argument_parser
             for additional information.
+        merge_spec (dict, optional): Specification that will be merged with the
+            brewtils specification before loading the configuration
         **kwargs: Additional configuration overrides
 
     Returns:
         :obj:`box.Box`: The resolved configuration object
     """
-    spec = YapconfSpec(SPECIFICATION)
+    spec_definition = merge_spec or {}
+    spec_definition.update(SPECIFICATION)
+    spec = YapconfSpec(spec_definition)
 
     sources = []
 

--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -154,6 +154,10 @@ def load_config(cli_args=None, argument_parser=None, merge_spec=None, **kwargs):
         3. Environment variables using the ``BG_`` prefix
         4. Default values in the brewtils specification
 
+    The return value will be a ``Box`` object containing the resolved configuration.
+    Note that the Beergarden config items can be found under the ``bg`` attribute - this
+    is necessary to support additional specifications in a safe way.
+
     Args:
         cli_args (list, optional): List of command line arguments for
             configuration loading
@@ -167,7 +171,9 @@ def load_config(cli_args=None, argument_parser=None, merge_spec=None, **kwargs):
         **kwargs: Additional configuration overrides
 
     Returns:
-        :obj:`box.Box`: The resolved configuration object
+        :obj:`box.Box`: The resolved configuration object. Be aware that the brewtils
+            config items will be nested under the ``bg`` attribute. For example, to get
+            the Beergarden host you'd use ``config.bg.host``.
     """
     spec_definition = merge_spec or {}
     spec_definition.update(SPECIFICATION)

--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -183,7 +183,12 @@ def load_config(cli_args=None, argument_parser=None, merge_spec=None, **kwargs):
 
     if kwargs:
         # This ensures any older usage that was passing bg_host or such still works
-        real_kwargs = {key.lstrip("bg_"): value for key, value in kwargs.items()}
+        real_kwargs = {}
+        for key, value in kwargs.items():
+            real_key = key.lstrip("bg_") if key in SPECIFICATION["bg"]["items"] else key
+            real_kwargs[real_key] = value
+
+        # real_kwargs = {key.lstrip("bg_"): value for key, value in kwargs.items()}
 
         sources.append(("kwargs", {"bg": real_kwargs}))
 

--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -185,11 +185,9 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
     except YapconfItemNotFound as ex:
         if ex.item.fq_name == "bg.host":
             raise ValidationError(
-                "Unable to create a plugin without a "
-                "beer-garden host. Please specify one on the "
-                "command line (--bg-host), in the "
-                "environment (BG_HOST), or in kwargs "
-                "(bg_host)"
+                "Unable to create a plugin without a beer-garden host. "
+                "Please specify one on the command line (--bg-host), in the "
+                "environment (BG_HOST), or in kwargs (bg_host)"
             )
         raise
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -44,12 +44,12 @@ class Plugin(object):
     When creating a Plugin you can pass certain keyword arguments to let the
     Plugin know how to communicate with the beer-garden instance. These are:
 
-        - ``bg_host``
-        - ``bg_port``
+        - ``host``
+        - ``port``
         - ``ssl_enabled``
         - ``ca_cert``
         - ``client_cert``
-        - ``bg_url_prefix``
+        - ``url_prefix``
 
     A Plugin also needs some identifying data. You can either pass parameters to
     the Plugin or pass a fully defined System object (but not both). Note that
@@ -94,19 +94,20 @@ class Plugin(object):
 
     Plugins service requests using a
     :py:class:`concurrent.futures.ThreadPoolExecutor`. The maximum number of
-    threads available is controlled by the max_concurrent argument (the
-    'multithreaded' argument has been deprecated).
+    threads available is controlled by the max_concurrent argument.
 
     .. warning::
-        The default value for ``max_concurrent`` is 1. This means that a Plugin
-        that invokes a Command on itself in the course of processing a Request
-        will deadlock! If you intend to do this, please set ``max_concurrent``
-        to a value that makes sense and be aware that Requests are processed in
-        separate thread contexts!
+        The default value for ``max_concurrent`` is 5. This means that by
+        default a Plugin will process multiple requests simultaneously in
+        multiple thread contexts.
+        It's possible to set ``max_concurrent`` to 1 to get single-threaded
+        behavior. However, be aware that the Plugin invoking any commands on
+        itself (using a SystemClient) during the course of processing a
+        Request will cause a deadlock.
 
     :param client: Instance of a class annotated with @system.
-    :param str bg_host: Hostname of a beer-garden.
-    :param int bg_port: Port beer-garden is listening on.
+    :param str host: Hostname of a beer-garden.
+    :param int port: Port beer-garden is listening on.
     :param bool ssl_enabled: Whether to use SSL for beer-garden communication.
     :param ca_cert: Certificate that issued the server certificate used by the
         beer-garden server.
@@ -122,13 +123,12 @@ class Plugin(object):
     :type logger: :py:class:`logging.Logger`.
     :param parser: The parser to use when communicating with beer-garden.
     :type parser: :py:class:`brewtils.schema_parser.SchemaParser`.
-    :param bool multithreaded: DEPRECATED Process requests in a separate thread.
     :param int worker_shutdown_timeout: Time to wait during shutdown to finish
         processing.
     :param dict metadata: Metadata specific to this plugin.
     :param int max_concurrent: Maximum number of requests to process
         concurrently.
-    :param str bg_url_prefix: URL Prefix beer-garden is on.
+    :param str url_prefix: URL Prefix beer-garden is on.
     :param str display_name: The display name to use for the system.
     :param int max_attempts: Number of times to attempt updating the request
         before giving up (default -1 aka never).

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -1,81 +1,80 @@
 # -*- coding: utf-8 -*-
 
 SPECIFICATION = {
-    "bg_host": {
-        "type": "str",
-        "description": "The beergarden server FQDN",
-        "required": True,
-        "env_name": "HOST",
-        "alt_env_names": ["WEB_HOST"],
-    },
-    "bg_port": {
-        "type": "int",
-        "description": "The beergarden server port",
-        "default": 2337,
-        "env_name": "PORT",
-        "alt_env_names": ["WEB_PORT"],
-    },
-    "ca_cert": {
-        "type": "str",
-        "description": "CA certificate to use when verifying",
-        "required": False,
-        "alt_env_names": ["SSL_CA_CERT"],
-    },
-    "ca_verify": {
-        "type": "bool",
-        "description": "Verify server certificate when using SSL",
-        "default": True,
-    },
-    "client_cert": {
-        "type": "str",
-        "description": "Client certificate to use with beergarden",
-        "required": False,
-        "alt_env_names": ["SSL_CLIENT_CERT"],
-    },
-    "ssl_enabled": {
-        "type": "bool",
-        "description": "Use SSL when communicating with beergarden",
-        "default": True,
-    },
-    "url_prefix": {
-        "type": "str",
-        "description": "The beergarden server path",
-        "default": "/",
-    },
-    "api_version": {
-        "type": "int",
-        "description": "Beergarden API version",
-        "required": False,
-    },
-    "username": {
-        "type": "str",
-        "description": "Username for authentication",
-        "required": False,
-    },
-    "password": {
-        "type": "str",
-        "description": "Password for authentication",
-        "required": False,
-    },
-    "access_token": {
-        "type": "str",
-        "description": "Access token for authentication",
-        "required": False,
-    },
-    "refresh_token": {
-        "type": "str",
-        "description": "Refresh token for authentication",
-        "required": False,
-    },
-    "client_timeout": {
-        "type": "float",
-        "description": "Max time RestClient will wait for server response",
-        "long_description": "This setting controls how long the HTTP(s) client will wait "
-        "when opening a connection to Beergarden before aborting."
-        "This prevents some strange Beergarden server state from causing "
-        "plugins to hang indefinitely."
-        "Set to -1 to disable (this is a bad idea in production code, see "
-        "the Requests documentation).",
-        "default": -1,
-    },
+    "bg": {
+        "type": "dict",
+        "items": {
+            "host": {
+                "type": "str",
+                "description": "The beergarden server FQDN",
+                "required": True,
+            },
+            "port": {
+                "type": "int",
+                "description": "The beergarden server port",
+                "default": 2337,
+            },
+            "ca_cert": {
+                "type": "str",
+                "description": "CA certificate to use when verifying",
+                "required": False,
+            },
+            "ca_verify": {
+                "type": "bool",
+                "description": "Verify server certificate when using SSL",
+                "default": True,
+            },
+            "client_cert": {
+                "type": "str",
+                "description": "Client certificate to use with beergarden",
+                "required": False,
+            },
+            "ssl_enabled": {
+                "type": "bool",
+                "description": "Use SSL when communicating with beergarden",
+                "default": True,
+            },
+            "url_prefix": {
+                "type": "str",
+                "description": "The beergarden server path",
+                "default": "/",
+            },
+            "api_version": {
+                "type": "int",
+                "description": "Beergarden API version",
+                "required": False,
+            },
+            "username": {
+                "type": "str",
+                "description": "Username for authentication",
+                "required": False,
+            },
+            "password": {
+                "type": "str",
+                "description": "Password for authentication",
+                "required": False,
+            },
+            "access_token": {
+                "type": "str",
+                "description": "Access token for authentication",
+                "required": False,
+            },
+            "refresh_token": {
+                "type": "str",
+                "description": "Refresh token for authentication",
+                "required": False,
+            },
+            "client_timeout": {
+                "type": "float",
+                "description": "Max time RestClient will wait for server response",
+                "long_description": "This setting controls how long the HTTP(s) client will wait "
+                "when opening a connection to Beergarden before aborting."
+                "This prevents some strange Beergarden server state from causing "
+                "plugins to hang indefinitely."
+                "Set to -1 to disable (this is a bad idea in production code, see "
+                "the Requests documentation).",
+                "default": -1,
+            },
+        },
+    }
 }

--- a/test/brewtils_test.py
+++ b/test/brewtils_test.py
@@ -81,6 +81,21 @@ class TestLoadConfig(object):
         assert parsed_args.some_parameter == "param"
         assert "some_parameter" not in config
 
+    def test_merge_spec(self):
+        new_spec = {
+            "foo": {
+                "type": "dict",
+                "items": {"bar": {"type": "str", "required": False}},
+            }
+        }
+
+        os.environ["BG_HOST"] = "bg_host"
+        os.environ["FOO_BAR"] = "foobar"
+
+        config = brewtils.load_config(merge_spec=new_spec)
+        assert config.bg.host == "bg_host"
+        assert config.foo.bar == "foobar"
+
     def test_normalize_url_prefix(self, params):
         os.environ["BG_HOST"] = "bg_host"
         os.environ["BG_URL_PREFIX"] = "/beer"

--- a/test/brewtils_test.py
+++ b/test/brewtils_test.py
@@ -86,15 +86,17 @@ class TestLoadConfig(object):
             "foo": {
                 "type": "dict",
                 "items": {"bar": {"type": "str", "required": False}},
-            }
+            },
+            "bg_other": {"type": "str", "required": False},
         }
 
         os.environ["BG_HOST"] = "bg_host"
         os.environ["FOO_BAR"] = "foobar"
 
-        config = brewtils.load_config(merge_spec=new_spec)
+        config = brewtils.load_config(merge_spec=new_spec, bg_other="hi_there")
         assert config.bg.host == "bg_host"
         assert config.foo.bar == "foobar"
+        assert config.bg_other == "hi_there"
 
     def test_normalize_url_prefix(self, params):
         os.environ["BG_HOST"] = "bg_host"

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -95,11 +95,11 @@ class TestPluginInit(object):
     def test_defaults(self, plugin):
         assert plugin.logger == logging.getLogger("brewtils.plugin")
         assert plugin.instance_name == "default"
-        assert plugin.bg_host == "localhost"
-        assert plugin.bg_port == 2337
-        assert plugin.bg_url_prefix == "/"
-        assert plugin.ssl_enabled is True
-        assert plugin.ca_verify is True
+        assert plugin.connection_info["host"] == "localhost"
+        assert plugin.connection_info["port"] == 2337
+        assert plugin.connection_info["url_prefix"] == "/"
+        assert plugin.connection_info["ssl_enabled"] is True
+        assert plugin.connection_info["ca_verify"] is True
 
     def test_default_logger(self, monkeypatch, client):
         """Test that the default logging configuration is used.
@@ -134,12 +134,12 @@ class TestPluginInit(object):
             max_concurrent=1,
         )
 
-        assert plugin.bg_host == "host1"
-        assert plugin.bg_port == 2338
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
         assert plugin.logger == logger
+        assert plugin.connection_info["host"] == "host1"
+        assert plugin.connection_info["port"] == 2338
+        assert plugin.connection_info["url_prefix"] == "/beer/"
+        assert plugin.connection_info["ssl_enabled"] is False
+        assert plugin.connection_info["ca_verify"] is False
 
     def test_env(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -150,11 +150,11 @@ class TestPluginInit(object):
 
         plugin = Plugin(client, system=bg_system, max_concurrent=1)
 
-        assert plugin.bg_host == "remotehost"
-        assert plugin.bg_port == 7332
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
+        assert plugin.connection_info["host"] == "remotehost"
+        assert plugin.connection_info["port"] == 7332
+        assert plugin.connection_info["url_prefix"] == "/beer/"
+        assert plugin.connection_info["ssl_enabled"] is False
+        assert plugin.connection_info["ca_verify"] is False
 
     def test_conflicts(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -174,11 +174,11 @@ class TestPluginInit(object):
             max_concurrent=1,
         )
 
-        assert plugin.bg_host == "localhost"
-        assert plugin.bg_port == 2337
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is True
-        assert plugin.ca_verify is True
+        assert plugin.connection_info["host"] == "localhost"
+        assert plugin.connection_info["port"] == 2337
+        assert plugin.connection_info["url_prefix"] == "/beer/"
+        assert plugin.connection_info["ssl_enabled"] is True
+        assert plugin.connection_info["ca_verify"] is True
 
     def test_cli(self, client, bg_system):
         args = [
@@ -186,10 +186,10 @@ class TestPluginInit(object):
             "remotehost",
             "--bg-port",
             "2338",
-            "--url-prefix",
+            "--bg-url-prefix",
             "beer",
-            "--no-ssl-enabled",
-            "--no-ca-verify",
+            "--bg-no-ssl-enabled",
+            "--bg-no-ca-verify",
         ]
 
         plugin = Plugin(
@@ -199,11 +199,11 @@ class TestPluginInit(object):
             **get_connection_info(cli_args=args)
         )
 
-        assert plugin.bg_host == "remotehost"
-        assert plugin.bg_port == 2338
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
+        assert plugin.connection_info["host"] == "remotehost"
+        assert plugin.connection_info["port"] == 2338
+        assert plugin.connection_info["url_prefix"] == "/beer/"
+        assert plugin.connection_info["ssl_enabled"] is False
+        assert plugin.connection_info["ca_verify"] is False
 
 
 class TestPluginRun(object):


### PR DESCRIPTION
This fixes beer-garden/beer-garden#296

Edit from the future:
I'm much less invested in this PR now. It's mostly OBE due to the change where yapconf and brewtils no longer fail to load from the CLI if any "unknown" args are present.

This means that instead of having to construct a grand unified spec *before* resolving the config I can just load each spec's config individually. And actually, since config loading is now handled internally by the `Plugin` I only have to worry about config for my specific plugin:

```python
def main():
    plugin_config = YapconfSpec(PLUGIN_SPEC).load_config("CLI", "ENVIRONMENT")

    client = PluginClient(**plugin_config)

    Plugin(client).run()
```

Going to leave this open but WIP for now, but this can be closed once v3 is out.