### PR TITLE
File upload

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -520,7 +520,7 @@ def _format_type(param_type):
     elif param_type == dict:
         return "Dictionary"
     else:
-        return param_type
+        return str(param_type).title()
 
 
 def _format_choices(choices):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -518,8 +518,14 @@ def _resolve_display_modifiers(
 
 
 def _format_type(param_type):
-    if param_type == str:
-        return "String"
+    if param_type in [str, bytes]:
+        # Python 3 vs 2 differences. If we are in Python 2,
+        # there is no difference between str and bytes, so
+        # just assume they want "String"
+        if str is not bytes and param_type == bytes:
+            return "Bytes"
+        else:
+            return "String"
     elif param_type == int:
         return "Integer"
     elif param_type == float:
@@ -528,8 +534,6 @@ def _format_type(param_type):
         return "Boolean"
     elif param_type == dict:
         return "Dictionary"
-    elif param_type == bytes:
-        return "Bytes"
     elif str(param_type).lower() == "file":
         return "Bytes"
     else:

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -536,6 +536,8 @@ def _format_type(param_type):
         return "Dictionary"
     elif str(param_type).lower() == "file":
         return "Bytes"
+    elif str(param_type).lower() == "datetime":
+        return "DateTime"
     else:
         return str(param_type).title()
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -276,6 +276,15 @@ def parameter(
 
     param.choices = _format_choices(param.choices)
 
+    # Type info is where type specific information goes. For now, this is specific
+    # to file types. See #289 for more details.
+    if str(type).lower() == "file":
+        param.type_info = {
+            "storage": "gridfs",
+        }
+    else:
+        param.type_info = {}
+
     # Model is another special case - it requires its own handling
     if model is not None:
         param.type = "Dictionary"
@@ -422,6 +431,7 @@ def _generate_nested_params(model_class):
         maximum = parameter_definition.maximum
         minimum = parameter_definition.minimum
         regex = parameter_definition.regex
+        type_info = parameter_definition.type_info
 
         choices = _format_choices(parameter_definition.choices)
 
@@ -446,6 +456,7 @@ def _generate_nested_params(model_class):
                 maximum=maximum,
                 minimum=minimum,
                 regex=regex,
+                type_info=type_info,
             )
         )
     return parameters_to_return
@@ -519,6 +530,10 @@ def _format_type(param_type):
         return "Boolean"
     elif param_type == dict:
         return "Dictionary"
+    elif param_type == bytes:
+        return "Bytes"
+    elif str(param_type).lower() == "file":
+        return "Bytes"
     else:
         return str(param_type).title()
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -278,10 +278,8 @@ def parameter(
 
     # Type info is where type specific information goes. For now, this is specific
     # to file types. See #289 for more details.
-    if str(type).lower() == "file":
-        param.type_info = {
-            "storage": "gridfs",
-        }
+    if param.type == "Bytes":
+        param.type_info = {"storage": "gridfs"}
     else:
         param.type_info = {}
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -538,6 +538,8 @@ def _format_type(param_type):
         return "Bytes"
     elif str(param_type).lower() == "datetime":
         return "DateTime"
+    elif not param_type:
+        return "Any"
     else:
         return str(param_type).title()
 

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -300,10 +300,7 @@ class RequestFile(object):
 
     schema = "RequestFileSchema"
 
-    def __init__(
-        self, content_type=None, storage_type=None, filename=None, external_link=None
-    ):
-        self.content_type = content_type
+    def __init__(self, storage_type=None, filename=None, external_link=None):
         self.storage_type = storage_type
         self.filename = filename
         self.external_link = external_link
@@ -312,9 +309,8 @@ class RequestFile(object):
         return self.filename
 
     def __repr__(self):
-        return "<RequestFile: filename=%s, content_type=%s, storage_type=%s, " % (
+        return "<RequestFile: filename=%s, storage_type=%s, " % (
             self.filename,
-            self.content_type,
             self.storage_type,
         )
 

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -23,6 +23,7 @@ __all__ = [
     "RefreshToken",
     "Job",
     "RequestTemplate",
+    "RequestFile",
     "DateTrigger",
     "CronTrigger",
     "IntervalTrigger",
@@ -288,6 +289,29 @@ class Parameter(object):
                 return True
 
         return False
+
+
+class RequestFile(object):
+
+    schema = "RequestFileSchema"
+
+    def __init__(
+        self, content_type=None, storage_type=None, filename=None, external_link=None
+    ):
+        self.content_type = content_type
+        self.storage_type = storage_type
+        self.filename = filename
+        self.external_link = external_link
+
+    def __str__(self):
+        return self.filename
+
+    def __repr__(self):
+        return "<RequestFile: filename=%s, content_type=%s, storage_type=%s, " % (
+            self.filename,
+            self.content_type,
+            self.storage_type,
+        )
 
 
 class RequestTemplate(object):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -46,6 +46,7 @@ class Events(Enum):
     SYSTEM_REMOVED = 13
     QUEUE_CLEARED = 14
     ALL_QUEUES_CLEARED = 15
+    FILE_CREATED = 16
 
 
 class Command(object):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -95,6 +95,19 @@ class Command(object):
         """
         return [p.key for p in self.parameters]
 
+    def parameter_keys_by_type(self, desired_type):
+        """Returns all parameter keys for the desired type.
+
+        :param desired_type:
+        :return: An array of array of key names.
+        """
+        keys = []
+        for p in self.parameters:
+            k = p.keys_by_type(desired_type)
+            if k:
+                keys.append(k)
+        return keys
+
     def get_parameter_by_key(self, key):
         """Given a Key, it will return the parameter (or None) with that key
 
@@ -259,6 +272,39 @@ class Parameter(object):
             self.description,
         )
 
+    def keys_by_type(self, desired_type):
+        """Gets all keys by the specified type.
+
+        Since parameters can be nested, this method will also return all
+        keys of all nested parameters. The return value is a possibly
+        nested list, where the first value of each list is going to be a
+        string, while the next value is a list.
+
+        Args:
+            desired_type str: Desired type
+
+        Returns:
+            An empty list if the types do not exist, otherwise it will
+            be a list containing at least one entry which is a string,
+            each subsequent entry is nested list with the same structure.
+
+        """
+        keys = []
+        if self.type == desired_type:
+            keys.append(self.key)
+
+        if not self.parameters:
+            return keys
+
+        for p in self.parameters:
+            nested_keys = p.keys_by_type(desired_type)
+            if nested_keys:
+                if not keys:
+                    keys = [self.key]
+
+                keys.append(nested_keys)
+        return keys
+
     def is_different(self, other):
         if not type(other) is type(self):
             return True
@@ -300,10 +346,9 @@ class RequestFile(object):
 
     schema = "RequestFileSchema"
 
-    def __init__(self, storage_type=None, filename=None, external_link=None):
+    def __init__(self, storage_type=None, filename=None):
         self.storage_type = storage_type
         self.filename = filename
-        self.external_link = external_link
 
     def __str__(self):
         return self.filename

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -210,6 +210,7 @@ class Parameter(object):
         "Dictionary",
         "Date",
         "DateTime",
+        "Bytes",
     )
     FORM_INPUT_TYPES = ("textarea",)
 
@@ -229,6 +230,7 @@ class Parameter(object):
         minimum=None,
         regex=None,
         form_input_type=None,
+        type_info=None,
     ):
         self.key = key
         self.type = type
@@ -244,6 +246,7 @@ class Parameter(object):
         self.minimum = minimum
         self.regex = regex
         self.form_input_type = form_input_type
+        self.type_info = type_info or {}
 
     def __str__(self):
         return self.key
@@ -262,6 +265,7 @@ class Parameter(object):
         fields_to_compare = [
             "key",
             "type",
+            "type_info",
             "multi",
             "optional",
             "default",

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -27,7 +27,7 @@ from brewtils.errors import (
 from brewtils.log import DEFAULT_LOGGING_CONFIG
 from brewtils.models import Instance, Request, System
 from brewtils.request_consumer import RequestConsumer
-from brewtils.resolvers import ParameterResolver, build_resolver_map
+from brewtils.resolvers import DownloadResolver, build_resolver_map
 from brewtils.rest.easy_client import EasyClient
 from brewtils.schema_parser import SchemaParser
 
@@ -247,7 +247,7 @@ class Plugin(object):
             logger=self.logger, parser=self.parser, **connection_parameters
         )
 
-        self._resolvers = build_resolver_map(self)
+        self._resolvers = build_resolver_map(self.bm_client)
         self.working_directory = kwargs.get("working_directory")
         if self.working_directory is None:
             appname = os.path.join(self.system.name, self.instance_name)
@@ -334,8 +334,8 @@ class Plugin(object):
         self._update_request(request, headers)
 
         keys = json.loads(headers.get("resolve_parameters", "[]"), encoding="utf-8")
-        with ParameterResolver(
-            request, keys, self.working_directory, self._resolvers
+        with DownloadResolver(
+            request, keys, self._resolvers, self.working_directory
         ) as parameters:
             try:
                 # Set request context so this request will be the parent of any

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -255,9 +255,6 @@ class Plugin(object):
                 appname, version=self.system.version
             )
 
-        if not os.path.exists(self.working_directory):
-            os.makedirs(self.working_directory)
-
     def run(self):
         # Let Beergarden know about our system and instance
         self._initialize()

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -539,7 +539,8 @@ class Plugin(object):
 
         :param target: The object to search for the function implementation.
             Will be self or self.client.
-        :param request: The request to process
+        :param command: The command name to execute on the target.
+        :param parameters: parameters to pass as keyword arguments to the command.
         :raise RequestProcessingError: The specified target does not define a
             callable implementation of request.command
         :return: The output of the function invocation

--- a/brewtils/resolvers/__init__.py
+++ b/brewtils/resolvers/__init__.py
@@ -1,0 +1,19 @@
+from brewtils.resolvers.parameter import ParameterResolver
+from brewtils.resolvers.gridfs import GridfsResolver
+
+__all__ = ["build_resolver_map", "ParameterResolver", "GridfsResolver"]
+
+_resolver_map = {
+    "gridfs": {"class": GridfsResolver, "self_kwargs": {"client": "bm_client"}}
+}
+
+
+def build_resolver_map(obj):
+    """Builds all the resolvers"""
+    resolvers = {}
+    for key, options in _resolver_map.items():
+        klass = options["class"]
+        self_kwargs = options["self_kwargs"]
+        kwargs = {key: getattr(obj, value) for key, value in self_kwargs.items()}
+        resolvers[key] = klass(**kwargs)
+    return resolvers

--- a/brewtils/resolvers/__init__.py
+++ b/brewtils/resolvers/__init__.py
@@ -1,19 +1,15 @@
-from brewtils.resolvers.parameter import ParameterResolver
+from brewtils.resolvers.parameter import UploadResolver, DownloadResolver
 from brewtils.resolvers.gridfs import GridfsResolver
 
-__all__ = ["build_resolver_map", "ParameterResolver", "GridfsResolver"]
+__all__ = ["build_resolver_map", "UploadResolver", "DownloadResolver", "GridfsResolver"]
 
-_resolver_map = {
-    "gridfs": {"class": GridfsResolver, "self_kwargs": {"client": "bm_client"}}
-}
+_resolver_map = {"gridfs": {"class": GridfsResolver}}
 
 
-def build_resolver_map(obj):
+def build_resolver_map(easy_client):
     """Builds all the resolvers"""
     resolvers = {}
     for key, options in _resolver_map.items():
         klass = options["class"]
-        self_kwargs = options["self_kwargs"]
-        kwargs = {key: getattr(obj, value) for key, value in self_kwargs.items()}
-        resolvers[key] = klass(**kwargs)
+        resolvers[key] = klass(client=easy_client)
     return resolvers

--- a/brewtils/resolvers/gridfs.py
+++ b/brewtils/resolvers/gridfs.py
@@ -1,3 +1,12 @@
+import io
+import os
+import sys
+
+import six
+
+from brewtils.errors import ValidationError
+
+
 class GridfsResolver(object):
     """Bytes-Resolver for GridFS
 
@@ -7,6 +16,11 @@ class GridfsResolver(object):
 
     This class is mean to be used transparently to Plugin developers.
 
+    Resolvers respond to two methods:
+
+    * `upload(value)`
+    * `download(bytes_parameter, writer)`
+
     Attributes:
         client: A `brewtils.EasyClient`
     """
@@ -14,8 +28,8 @@ class GridfsResolver(object):
     def __init__(self, client):
         self.client = client
 
-    def resolve(self, bytes_parameter, writer):
-        """Resolve the given bytes parameters.
+    def download(self, bytes_parameter, writer):
+        """Download the given bytes parameter.
 
         Args:
             bytes_parameter: A specific request's parameter value.
@@ -23,3 +37,66 @@ class GridfsResolver(object):
 
         """
         self.client.stream_to_source(bytes_parameter["id"], writer)
+
+    def upload(self, value):
+        """Upload the given value to the server if necessary.
+
+        The value can be one of the following:
+
+        1. A dictionary with a storage_type and filename.
+        2. A string pointing to a valid filename.
+        3. An open file descriptor.
+
+        If you use a dictionary, and include an "id" the resolver will
+        assume you have already uploaded the file, and skip doing it for you.
+
+        Args:
+            value: Value to upload.
+
+        Returns:
+            A valid dictionary to use as a bytes parameter.
+
+        """
+        if sys.version_info[0] == 2:
+            file_types = (io.IOBase, file)  # noqa: F821
+        else:
+            file_types = (io.IOBase,)
+        if isinstance(value, dict):
+            return self._upload_dict(value)
+        elif isinstance(value, six.string_types):
+            return self._upload_filename(value)
+        elif isinstance(value, file_types):
+            return self._upload_file_descriptor(value)
+        else:
+            raise ValidationError(
+                "Do not know how to upload bytes type %s" % type(value)
+            )
+
+    def _upload_dict(self, value):
+        if "id" in value:
+            return value
+
+        if "filename" not in value:
+            raise ValidationError(
+                "When uploading a bytes object as a dictionary, you must include a 'filename' key."
+            )
+
+        return self._upload_filename(value["filename"], value.get("desired_filename"))
+
+    def _upload_filename(self, filename, desired_filename=None):
+        if not os.path.isfile(filename):
+            raise ValidationError(
+                "Cannot upload a bytes object if the file does not exist %s" % filename
+            )
+
+        desired_filename = desired_filename or os.path.basename(filename)
+
+        with open(filename) as file_to_upload:
+            return self._upload_file_descriptor(file_to_upload, desired_filename)
+
+    def _upload_file_descriptor(self, fd, filename=None):
+        if filename is None and hasattr(fd, "name"):
+            filename = os.path.basename(fd.name)
+
+        filename = filename or str(fd)
+        return self.client.upload_file(fd, filename)

--- a/brewtils/resolvers/gridfs.py
+++ b/brewtils/resolvers/gridfs.py
@@ -14,7 +14,7 @@ class GridfsResolver(object):
     In this case, we are just simply using the API to stream bytes
     into a file.
 
-    This class is mean to be used transparently to Plugin developers.
+    This class is meant to be used transparently to Plugin developers.
 
     Resolvers respond to two methods:
 
@@ -36,7 +36,7 @@ class GridfsResolver(object):
             writer: File-like object that has a `write` method.
 
         """
-        self.client.stream_to_source(bytes_parameter["id"], writer)
+        self.client.stream_to_sink(bytes_parameter["id"], writer)
 
     def upload(self, value):
         """Upload the given value to the server if necessary.
@@ -91,7 +91,7 @@ class GridfsResolver(object):
 
         desired_filename = desired_filename or os.path.basename(filename)
 
-        with open(filename) as file_to_upload:
+        with open(filename, "rb") as file_to_upload:
             return self._upload_file_descriptor(file_to_upload, desired_filename)
 
     def _upload_file_descriptor(self, fd, filename=None):

--- a/brewtils/resolvers/gridfs.py
+++ b/brewtils/resolvers/gridfs.py
@@ -1,0 +1,25 @@
+class GridfsResolver(object):
+    """Bytes-Resolver for GridFS
+
+    Resolvers are meant to be written for specific storage types.
+    In this case, we are just simply using the API to stream bytes
+    into a file.
+
+    This class is mean to be used transparently to Plugin developers.
+
+    Attributes:
+        client: A `brewtils.EasyClient`
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    def resolve(self, bytes_parameter, writer):
+        """Resolve the given bytes parameters.
+
+        Args:
+            bytes_parameter: A specific request's parameter value.
+            writer: File-like object that has a `write` method.
+
+        """
+        self.client.stream_to_source(bytes_parameter["id"], writer)

--- a/brewtils/resolvers/parameter.py
+++ b/brewtils/resolvers/parameter.py
@@ -1,17 +1,19 @@
-import shutil
+import logging
 import os
+import shutil
+
+from brewtils.errors import ValidationError
 
 
-class ParameterResolver(object):
-    def __init__(self, request, params_to_resolve, base_directory, resolvers):
+class BaseResolver(object):
+    def __init__(self, request, params_to_resolve, resolvers):
         if request.is_ephemeral and params_to_resolve:
             raise ValueError("Cannot resolve parameters for ephemeral requests.")
 
         self.parameters = request.parameters
         self.params_to_resolve = params_to_resolve
-        self.base_directory = base_directory
         self.resolvers = resolvers
-        self._working_dir = os.path.join(str(self.base_directory), request.id or "")
+        self.logger = logging.getLogger(__name__)
 
     def __enter__(self):
         try:
@@ -23,16 +25,21 @@ class ParameterResolver(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
 
-    def cleanup(self):
-        if os.path.isdir(self._working_dir):
-            shutil.rmtree(self._working_dir)
-
     def resolve_parameters(self):
         if not self.params_to_resolve:
             return self.parameters
 
-        self._ensure_working_dir()
+        self.pre_resolve()
         return self._recurse_and_resolve(self.params_to_resolve, self.parameters)
+
+    def simple_resolve(self, value):
+        raise NotImplementedError("No implementation for 'simple_resolve'")
+
+    def pre_resolve(self):
+        pass
+
+    def cleanup(self):
+        pass
 
     def _recurse_and_resolve(self, params_to_resolve, parameters):
         if not isinstance(parameters, dict):
@@ -45,9 +52,9 @@ class ParameterResolver(object):
             if index == -1:
                 resolved_value = value
             elif len(params_to_resolve[index]) == 1 and isinstance(value, list):
-                resolved_value = [self._resolve(v) for v in value]
+                resolved_value = [self.simple_resolve(v) for v in value]
             elif len(params_to_resolve[index]) == 1:
-                resolved_value = self._resolve(value)
+                resolved_value = self.simple_resolve(value)
             else:
                 resolved_value = self._recurse_and_resolve(
                     params_to_resolve[index], value
@@ -55,28 +62,51 @@ class ParameterResolver(object):
             resolved_parameters[key] = resolved_value
         return resolved_parameters
 
-    def _resolve(self, value):
-        resolve_type = value["storage_type"]
-        if resolve_type not in self.resolvers:
-            raise KeyError("No resolver found for %s" % resolve_type)
-
-        filename = value["filename"]
-        resolver = self.resolvers[resolve_type]
-        full_path = os.path.join(self._working_dir, filename)
-        if os.path.exists(full_path):
-            full_path = os.path.join(self._working_dir, value["id"])
-
-        with open(full_path, "wb") as file_to_write:
-            resolver.resolve(value, file_to_write)
-        return full_path
-
-    def _ensure_working_dir(self):
-        if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
-
     @staticmethod
     def _index_of(arr, val):
         try:
             return arr.index(val)
         except ValueError:
             return -1
+
+    def _get_resolver(self, value):
+        storage_type = "gridfs"
+        if isinstance(value, dict):
+            storage_type = value.get("storage_type", storage_type)
+
+        if storage_type not in self.resolvers:
+            raise ValidationError("No resolver found for %s" % storage_type)
+
+        return self.resolvers[storage_type]
+
+
+class DownloadResolver(BaseResolver):
+    def __init__(self, request, params_to_resolve, resolvers, base_directory):
+        super(DownloadResolver, self).__init__(request, params_to_resolve, resolvers)
+        self.base_directory = base_directory
+        self._working_dir = os.path.join(str(self.base_directory), request.id or "")
+
+    def cleanup(self):
+        if os.path.isdir(self._working_dir):
+            shutil.rmtree(self._working_dir)
+
+    def simple_resolve(self, value):
+        resolver = self._get_resolver(value)
+        filename = value["filename"]
+        full_path = os.path.join(self._working_dir, filename)
+        if os.path.exists(full_path):
+            full_path = os.path.join(self._working_dir, value["id"])
+
+        with open(full_path, "wb") as file_to_write:
+            resolver.download(value, file_to_write)
+        return full_path
+
+    def pre_resolve(self):
+        if not os.path.isdir(self._working_dir):
+            os.makedirs(self._working_dir)
+
+
+class UploadResolver(BaseResolver):
+    def simple_resolve(self, value):
+        resolver = self._get_resolver(value)
+        return resolver.upload(value)

--- a/brewtils/resolvers/parameter.py
+++ b/brewtils/resolvers/parameter.py
@@ -1,0 +1,82 @@
+import shutil
+import os
+
+
+class ParameterResolver(object):
+    def __init__(self, request, params_to_resolve, base_directory, resolvers):
+        if request.is_ephemeral and params_to_resolve:
+            raise ValueError("Cannot resolve parameters for ephemeral requests.")
+
+        self.parameters = request.parameters
+        self.params_to_resolve = params_to_resolve
+        self.base_directory = base_directory
+        self.resolvers = resolvers
+        self._working_dir = os.path.join(self.base_directory, request.id or "")
+
+    def __enter__(self):
+        try:
+            return self.resolve_parameters()
+        except Exception:
+            self.cleanup()
+            raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    def cleanup(self):
+        if os.path.isdir(self._working_dir):
+            shutil.rmtree(self._working_dir)
+
+    def resolve_parameters(self):
+        if not self.params_to_resolve:
+            return self.parameters
+
+        self._ensure_working_dir()
+        return self._recurse_and_resolve(self.params_to_resolve, self.parameters)
+
+    def _recurse_and_resolve(self, params_to_resolve, parameters):
+        if not isinstance(parameters, dict):
+            raise ValueError("Nested bytes found, but the value was not a dictionary.")
+
+        resolved_parameters = {}
+        top_level_keys = [k[0] for k in params_to_resolve]
+        for key, value in parameters.items():
+            index = self._index_of(top_level_keys, key)
+            if index == -1:
+                resolved_value = value
+            elif len(params_to_resolve[index]) == 1 and isinstance(value, list):
+                resolved_value = [self._resolve(v) for v in value]
+            elif len(params_to_resolve[index]) == 1:
+                resolved_value = self._resolve(value)
+            else:
+                resolved_value = self._recurse_and_resolve(
+                    params_to_resolve[index], value
+                )
+            resolved_parameters[key] = resolved_value
+        return resolved_parameters
+
+    def _resolve(self, value):
+        resolve_type = value["storage_type"]
+        if resolve_type not in self.resolvers:
+            raise KeyError("No resolver found for %s" % resolve_type)
+
+        filename = value["filename"]
+        resolver = self.resolvers[resolve_type]
+        full_path = os.path.join(self._working_dir, filename)
+        if os.path.exists(full_path):
+            full_path = os.path.join(self._working_dir, value["id"])
+
+        with open(full_path, "wb") as file_to_write:
+            resolver.resolve(value, file_to_write)
+        return full_path
+
+    def _ensure_working_dir(self):
+        if not os.path.isdir(self._working_dir):
+            os.makedirs(self._working_dir)
+
+    @staticmethod
+    def _index_of(arr, val):
+        try:
+            return arr.index(val)
+        except ValueError:
+            return -1

--- a/brewtils/resolvers/parameter.py
+++ b/brewtils/resolvers/parameter.py
@@ -11,7 +11,7 @@ class ParameterResolver(object):
         self.params_to_resolve = params_to_resolve
         self.base_directory = base_directory
         self.resolvers = resolvers
-        self._working_dir = os.path.join(self.base_directory, request.id or "")
+        self._working_dir = os.path.join(str(self.base_directory), request.id or "")
 
     def __enter__(self):
         try:

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -664,19 +664,19 @@ class EasyClient(object):
         """
         self._patch_job(job_id, [PatchOperation("update", "/status", "RUNNING")])
 
-    def stream_to_source(self, file_id, source, **kwargs):
-        """Stream the given file id to the source.
+    def stream_to_sink(self, file_id, sink, **kwargs):
+        """Stream the given file id to the sink.
 
         Examples:
 
             To stream a given file to a local file you can do::
 
                 with open("filename", "rb") as my_file:
-                    client.stream_to_source("id", my_file)
+                    client.stream_to_sink("id", my_file)
 
         Args:
             file_id: The File ID
-            source: An object with a `.write` method, often times this is
+            sink: An object with a `.write` method, often times this is
             an open file descriptor.
 
         Keyword Args:
@@ -688,14 +688,14 @@ class EasyClient(object):
             if not response.ok:
                 handle_response_failure(response)
             for chunk in response.iter_content(chunk_size=chunk_size):
-                source.write(chunk)
+                sink.write(chunk)
 
     def upload_file(self, file_to_upload, desired_filename=None):
         """Upload a given file to the Beer Garden server.
 
         Args:
             file_to_upload: Can either be an open file descriptor or a path.
-            desired_filename: The desired filename if none is provided, it
+            desired_filename: The desired filename. If none is provided, it
             will use the basename of the path_to_file argument.
 
         Returns:

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -663,6 +663,32 @@ class EasyClient(object):
         """
         self._patch_job(job_id, [PatchOperation("update", "/status", "RUNNING")])
 
+    def stream_to_source(self, file_id, source, **kwargs):
+        """Stream the given file id to the source.
+
+        Examples:
+
+            To stream a given file to a local file you can do::
+
+                with open("filename", "rb") as my_file:
+                    client.stream_to_source("id", my_file)
+
+        Args:
+            file_id: The File ID
+            source: An object with a `.write` method, often times this is
+            an open file descriptor.
+
+        Keyword Args:
+            chunk_size: Size of chunks as they are written/read.
+
+        """
+        chunk_size = kwargs.get("chunk_size", 4096)
+        with self.client.get_file(file_id, stream=True) as response:
+            if not response.ok:
+                handle_response_failure(response)
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                source.write(chunk)
+
     @wrap_response(
         parse_method="parse_principal", parse_many=False, default_exc=FetchError
     )

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -21,6 +21,7 @@ from brewtils.models import (
     RefreshToken,
     Job,
     RequestTemplate,
+    RequestFile,
     DateTrigger,
     CronTrigger,
     IntervalTrigger,
@@ -31,6 +32,7 @@ from brewtils.schemas import (
     CommandSchema,
     ParameterSchema,
     RequestSchema,
+    RequestFileSchema,
     PatchSchema,
     LoggingConfigSchema,
     EventSchema,
@@ -50,6 +52,7 @@ class SchemaParser(object):
         "InstanceSchema": Instance,
         "CommandSchema": Command,
         "ParameterSchema": Parameter,
+        "RequestFileSchema": RequestFile,
         "RequestTemplateSchema": RequestTemplate,
         "RequestSchema": Request,
         "PatchSchema": PatchOperation,
@@ -115,6 +118,19 @@ class SchemaParser(object):
         """
         return cls._do_parse(
             parameter, ParameterSchema(**kwargs), from_string=from_string
+        )
+
+    @classmethod
+    def parse_request_file(cls, request_file, from_string=False, **kwargs):
+        """Convert raw JSON string or dictionary to a request file model object
+
+        :param request_file: The raw input
+        :param from_string: True if input is a JSON string, False if a dictionary
+        :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+        :return: A Request object
+        """
+        return cls._do_parse(
+            request_file, RequestFileSchema(**kwargs), from_string=from_string
         )
 
     @classmethod
@@ -309,6 +325,17 @@ class SchemaParser(object):
         :return: Serialized representation of parameter
         """
         return cls._do_serialize(ParameterSchema(**kwargs), parameter, to_string)
+
+    @classmethod
+    def serialize_request_file(cls, request_file, to_string=True, **kwargs):
+        """Convert a request file model into serialized form
+
+        :param request_file: The request file object(s) to be serialized
+        :param to_string: True to generate a JSON-formatted string, False to generate a dictionary
+        :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+        :return: Serialized representation of request
+        """
+        return cls._do_serialize(RequestFileSchema(**kwargs), request_file, to_string)
 
     @classmethod
     def serialize_request(cls, request, to_string=True, **kwargs):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -15,6 +15,7 @@ __all__ = [
     "CommandSchema",
     "ParameterSchema",
     "RequestSchema",
+    "RequestFileSchema",
     "PatchSchema",
     "LoggingConfigSchema",
     "EventSchema",
@@ -114,6 +115,7 @@ class ParameterSchema(BaseSchema):
     minimum = fields.Int(allow_none=True)
     regex = fields.Str(allow_none=True)
     form_input_type = fields.Str(allow_none=True)
+    type_info = fields.Dict(allow_none=True)
 
 
 class CommandSchema(BaseSchema):
@@ -156,6 +158,14 @@ class SystemSchema(BaseSchema):
     commands = fields.Nested("CommandSchema", many=True)
     display_name = fields.Str(allow_none=True)
     metadata = fields.Dict(allow_none=True)
+
+
+class RequestFileSchema(BaseSchema):
+
+    content_type = fields.Str(allow_none=True)
+    storage_type = fields.Str(allow_none=True)
+    filename = fields.Str(allow_none=True)
+    external_link = fields.Str(allow_none=True)
 
 
 class RequestTemplateSchema(BaseSchema):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -164,7 +164,6 @@ class RequestFileSchema(BaseSchema):
 
     storage_type = fields.Str(allow_none=True)
     filename = fields.Str(allow_none=True)
-    external_link = fields.Str(allow_none=True)
 
 
 class RequestTemplateSchema(BaseSchema):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -162,7 +162,6 @@ class SystemSchema(BaseSchema):
 
 class RequestFileSchema(BaseSchema):
 
-    content_type = fields.Str(allow_none=True)
     storage_type = fields.Str(allow_none=True)
     filename = fields.Str(allow_none=True)
     external_link = fields.Str(allow_none=True)

--- a/brewtils/test/comparable.py
+++ b/brewtils/test/comparable.py
@@ -30,6 +30,7 @@ from brewtils.models import (
     DateTrigger,
     CronTrigger,
     RequestTemplate,
+    RequestFile,
 )
 
 __all__ = [
@@ -173,6 +174,7 @@ assert_request_template_equal = partial(_assert_wrapper, expected_type=RequestTe
 assert_trigger_equal = partial(
     _assert_wrapper, expected_type=(CronTrigger, DateTrigger, IntervalTrigger)
 )
+assert_request_file_equal = partial(_assert_wrapper, expected_type=RequestFile)
 
 
 def assert_command_equal(obj1, obj2, do_raise=False):

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -508,7 +508,6 @@ def job_dict(ts_epoch, request_template_dict, date_trigger_dict):
 def request_file_dict():
     """A request file represented as a dictionary."""
     return {
-        "content_type": "application/json",
         "storage_type": "gridfs",
         "filename": "request_filename",
         "external_link": None,

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -92,6 +92,7 @@ def nested_parameter_dict():
         "minimum": None,
         "regex": None,
         "form_input_type": None,
+        "type_info": {},
     }
 
 
@@ -113,6 +114,7 @@ def parameter_dict(nested_parameter_dict, choices_dict):
         "minimum": 1,
         "regex": ".*",
         "form_input_type": None,
+        "type_info": {},
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -24,6 +24,7 @@ from brewtils.models import (
     RequestTemplate,
     IntervalTrigger,
     DateTrigger,
+    RequestFile,
 )
 
 
@@ -502,6 +503,17 @@ def job_dict(ts_epoch, request_template_dict, date_trigger_dict):
 
 
 @pytest.fixture
+def request_file_dict():
+    """A request file represented as a dictionary."""
+    return {
+        "content_type": "application/json",
+        "storage_type": "gridfs",
+        "filename": "request_filename",
+        "external_link": None,
+    }
+
+
+@pytest.fixture
 def cron_job_dict(job_dict, cron_trigger_dict):
     """A cron job represented as a dictionary."""
     dict_copy = copy.deepcopy(job_dict)
@@ -614,3 +626,9 @@ def bg_date_trigger(date_trigger_dict, ts_dt):
     dict_copy = copy.deepcopy(date_trigger_dict)
     dict_copy["run_date"] = ts_dt
     return DateTrigger(**dict_copy)
+
+
+@pytest.fixture
+def bg_request_file(request_file_dict):
+    """A request file as a model"""
+    return RequestFile(**request_file_dict)

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -507,11 +507,7 @@ def job_dict(ts_epoch, request_template_dict, date_trigger_dict):
 @pytest.fixture
 def request_file_dict():
     """A request file represented as a dictionary."""
-    return {
-        "storage_type": "gridfs",
-        "filename": "request_filename",
-        "external_link": None,
-    }
+    return {"storage_type": "gridfs", "filename": "request_filename"}
 
 
 @pytest.fixture

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 
 # Dependencies
+appdirs<2
 lark-parser < 0.7
 marshmallow < 3
 marshmallow-polyfield < 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 alabaster==0.7.12         # via sphinx
-appdirs==1.4.3            # via black
+appdirs==1.4.3
 argh==0.26.2              # via watchdog
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via black, pytest

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=find_packages(exclude=["test", "test.*"]),
     package_data={"": ["README.md"]},
     install_requires=[
+        "appdirs<2",
         "lark-parser<0.7",
         "marshmallow<3",
         "marshmallow-polyfield<4",

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -110,6 +110,7 @@ class TestParameter(object):
     @pytest.mark.parametrize(
         "t,expected",
         [
+            (None, "Any"),
             (str, "String"),
             (int, "Integer"),
             (float, "Float"),

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -115,18 +115,26 @@ class TestParameter(object):
             (float, "Float"),
             (bool, "Boolean"),
             (dict, "Dictionary"),
+            (bytes, "Bytes"),
             ("String", "String"),
             ("Integer", "Integer"),
             ("Float", "Float"),
             ("Boolean", "Boolean"),
             ("Dictionary", "Dictionary"),
             ("Any", "Any"),
+            ("file", "Bytes"),
             ("string", "String"),
         ],
     )
     def test_types(self, cmd, t, expected):
         wrapped = parameter(cmd, key="foo", type=t)
         assert expected == wrapped._command.get_parameter_by_key("foo").type
+
+    def test_file_type_info(self, cmd):
+        wrapped = parameter(cmd, key="foo", type="file")
+        assert wrapped._command.get_parameter_by_key("foo").type_info == {
+            "storage": "gridfs"
+        }
 
     def test_values(self, cmd, param_definition):
         wrapped = parameter(cmd, **param_definition)

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -120,6 +120,7 @@ class TestParameter(object):
             ("Float", "Float"),
             ("Boolean", "Boolean"),
             ("Dictionary", "Dictionary"),
+            ("DateTime", "DateTime"),
             ("Any", "Any"),
             ("file", "Bytes"),
             ("Bytes", "Bytes"),

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -115,7 +115,6 @@ class TestParameter(object):
             (float, "Float"),
             (bool, "Boolean"),
             (dict, "Dictionary"),
-            (bytes, "Bytes"),
             ("String", "String"),
             ("Integer", "Integer"),
             ("Float", "Float"),
@@ -123,11 +122,23 @@ class TestParameter(object):
             ("Dictionary", "Dictionary"),
             ("Any", "Any"),
             ("file", "Bytes"),
+            ("Bytes", "Bytes"),
             ("string", "String"),
         ],
     )
     def test_types(self, cmd, t, expected):
         wrapped = parameter(cmd, key="foo", type=t)
+        assert expected == wrapped._command.get_parameter_by_key("foo").type
+
+    def test_bytes_types(self, cmd):
+        # Because of the bytes change in python 2, the behavior of our decorator
+        # must react accordingly. So this test passes on both python 2 and 3 and
+        # explicitly tests for the variation in behavior
+        if bytes is str:
+            expected = "String"
+        else:
+            expected = "Bytes"
+        wrapped = parameter(cmd, key="foo", type=bytes)
         assert expected == wrapped._command.get_parameter_by_key("foo").type
 
     def test_file_type_info(self, cmd):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -121,6 +121,7 @@ class TestParameter(object):
             ("Boolean", "Boolean"),
             ("Dictionary", "Dictionary"),
             ("Any", "Any"),
+            ("string", "String"),
         ],
     )
     def test_types(self, cmd, t, expected):

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -103,6 +103,11 @@ class TestCommand(object):
     def test_has_same_parameters(self, p1, p2):
         assert not Command(parameters=p1).has_different_parameters(p2)
 
+    def test_parameter_keys_by_type(self):
+        command = Command(parameters=[Parameter(key="key1", type="String")])
+        assert command.parameter_keys_by_type("String") == [["key1"]]
+        assert command.parameter_keys_by_type("Integer") == []
+
     def test_str(self):
         assert "foo" == str(Command(name="foo"))
 
@@ -214,13 +219,60 @@ class TestParameter(object):
     def test_is_not_different(self, p1, p2):
         assert not p1.is_different(p2)
 
+    @pytest.mark.parametrize(
+        "parameter,desired_type,expected",
+        [
+            (Parameter(key="key1", type="String"), "String", ["key1"]),
+            (Parameter(key="key1", type="String"), "Integer", []),
+            (
+                Parameter(
+                    key="key1",
+                    type="Dictionary",
+                    parameters=[Parameter(key="nested_key", type="String")],
+                ),
+                "String",
+                ["key1", ["nested_key"]],
+            ),
+            (
+                Parameter(
+                    key="key1",
+                    type="Dictionary",
+                    parameters=[Parameter(key="nested_key", type="Integer")],
+                ),
+                "String",
+                [],
+            ),
+            (
+                Parameter(
+                    key="key1",
+                    type="Dictionary",
+                    parameters=[
+                        Parameter(key="nested_key1", type="String"),
+                        Parameter(
+                            key="dict_key1",
+                            type="Dictionary",
+                            parameters=[
+                                Parameter(key="deep_key1", type="String"),
+                                Parameter(key="deep_key2", type="String"),
+                                Parameter(key="deep_key3", type="Integer"),
+                            ],
+                        ),
+                    ],
+                ),
+                "String",
+                ["key1", ["nested_key1"], ["dict_key1", ["deep_key1"], ["deep_key2"]]],
+            ),
+        ],
+    )
+    def test_keys_by_type(self, parameter, desired_type, expected):
+        actual = parameter.keys_by_type(desired_type)
+        assert actual == expected
+
 
 class TestRequestFile(object):
     @pytest.fixture
     def request_file(self):
-        return RequestFile(
-            storage_type="gridfs", filename="request_filename", external_link=None
-        )
+        return RequestFile(storage_type="gridfs", filename="request_filename")
 
     def test_str(self, request_file):
         assert str(request_file) == "request_filename"

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -19,6 +19,7 @@ from brewtils.models import (
     Principal,
     Role,
     RequestTemplate,
+    RequestFile,
 )
 
 
@@ -212,6 +213,25 @@ class TestParameter(object):
     )
     def test_is_not_different(self, p1, p2):
         assert not p1.is_different(p2)
+
+
+class TestRequestFile(object):
+    @pytest.fixture
+    def request_file(self):
+        return RequestFile(
+            content_type="application/json",
+            storage_type="gridfs",
+            filename="request_filename",
+            external_link=None,
+        )
+
+    def test_str(self, request_file):
+        assert str(request_file) == "request_filename"
+
+    def test_repr(self, request_file):
+        assert "request_filename" in repr(request_file)
+        assert "application/json" in repr(request_file)
+        assert "gridfs" in repr(request_file)
 
 
 class TestRequestTemplate(object):

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -219,10 +219,7 @@ class TestRequestFile(object):
     @pytest.fixture
     def request_file(self):
         return RequestFile(
-            content_type="application/json",
-            storage_type="gridfs",
-            filename="request_filename",
-            external_link=None,
+            storage_type="gridfs", filename="request_filename", external_link=None
         )
 
     def test_str(self, request_file):
@@ -230,7 +227,6 @@ class TestRequestFile(object):
 
     def test_repr(self, request_file):
         assert "request_filename" in repr(request_file)
-        assert "application/json" in repr(request_file)
         assert "gridfs" in repr(request_file)
 
 

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -97,7 +97,7 @@ class TestPluginInit(object):
         plugin = Plugin(client, bg_host="localhost", system=bg_system)
         assert plugin.working_directory is not None
 
-        new_dir = os.path.join(tmpdir, "example")
+        new_dir = os.path.join(str(tmpdir), "example")
         plugin = Plugin(
             client, bg_host="localhost", system=bg_system, working_directory=new_dir
         )

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -95,11 +95,13 @@ class TestPluginInit(object):
 
     def test_working_directory(self, client, bg_system, tmpdir):
         plugin = Plugin(client, bg_host="localhost", system=bg_system)
-        assert os.path.isdir(plugin.working_directory)
+        assert plugin.working_directory is not None
 
         new_dir = os.path.join(tmpdir, "example")
-        Plugin(client, bg_host="localhost", system=bg_system, working_directory=new_dir)
-        assert os.path.isdir(new_dir)
+        plugin = Plugin(
+            client, bg_host="localhost", system=bg_system, working_directory=new_dir
+        )
+        assert plugin.working_directory == str(new_dir)
 
     def test_defaults(self, plugin):
         assert plugin.logger == logging.getLogger("brewtils.plugin")
@@ -808,7 +810,7 @@ class TestMaxConcurrent(object):
             warnings.simplefilter("ignore")
             warnings.filterwarnings("always", module="brewtils.plugin")
 
-            Plugin(client, bg_host="localhost")
+            Plugin(client, bg_host="localhost", name="foo")
 
             assert issubclass(w[0].category, PendingDeprecationWarning)
             assert "max_concurrent" in str(w[0].message)

--- a/test/resolvers/gridfs_test.py
+++ b/test/resolvers/gridfs_test.py
@@ -23,7 +23,7 @@ def test_download(resolver):
     writer = Mock()
     param = {"id": "123"}
     resolver.download(param, writer)
-    resolver.client.stream_to_source.assert_called_with("123", writer)
+    resolver.client.stream_to_sink.assert_called_with("123", writer)
 
 
 def test_upload_unknown(resolver):

--- a/test/resolvers/gridfs_test.py
+++ b/test/resolvers/gridfs_test.py
@@ -1,12 +1,68 @@
+import os
+import pytest
 from mock import Mock
 
+from brewtils.errors import ValidationError
 from brewtils.resolvers import GridfsResolver
 
 
-def test_resolve():
-    client = Mock()
+@pytest.fixture
+def resolver():
+    return GridfsResolver(Mock())
+
+
+@pytest.fixture
+def example_file(tmpdir):
+    path = os.path.join(str(tmpdir), "foo.txt")
+    with open(path, "w") as f:
+        f.write("content")
+    return path
+
+
+def test_download(resolver):
     writer = Mock()
     param = {"id": "123"}
-    resolver = GridfsResolver(client)
-    resolver.resolve(param, writer)
-    client.stream_to_source.assert_called_with("123", writer)
+    resolver.download(param, writer)
+    resolver.client.stream_to_source.assert_called_with("123", writer)
+
+
+def test_upload_unknown(resolver):
+    with pytest.raises(ValidationError):
+        resolver.upload(123)
+
+
+def test_upload_dict_with_id(resolver):
+    value = resolver.upload({"id": "already_uploaded"})
+    assert value == {"id": "already_uploaded"}
+
+
+def test_upload_dict_no_filename(resolver):
+    with pytest.raises(ValidationError):
+        resolver.upload({})
+
+
+def test_upload_dict(resolver, example_file):
+    resolver.upload({"filename": example_file})
+    assert resolver.client.upload_file.call_count == 1
+    args = resolver.client.upload_file.call_args[0]
+    assert args[1] == "foo.txt"
+
+
+def test_upload_filename_does_not_exist(resolver):
+    with pytest.raises(ValidationError):
+        resolver.upload("DOES_NOT_EXIST")
+
+
+def test_upload_filename(resolver, example_file):
+    resolver.upload(example_file)
+    assert resolver.client.upload_file.call_count == 1
+    args = resolver.client.upload_file.call_args[0]
+    assert args[1] == "foo.txt"
+
+
+def test_upload_file_descriptor(resolver, example_file):
+    fd = open(example_file)
+    resolver.upload(fd)
+    fd.close()
+    assert resolver.client.upload_file.call_count == 1
+    resolver.client.upload_file.assert_called_with(fd, "foo.txt")

--- a/test/resolvers/gridfs_test.py
+++ b/test/resolvers/gridfs_test.py
@@ -1,0 +1,12 @@
+from mock import Mock
+
+from brewtils.resolvers import GridfsResolver
+
+
+def test_resolve():
+    client = Mock()
+    writer = Mock()
+    param = {"id": "123"}
+    resolver = GridfsResolver(client)
+    resolver.resolve(param, writer)
+    client.stream_to_source.assert_called_with("123", writer)

--- a/test/resolvers/parameter_test.py
+++ b/test/resolvers/parameter_test.py
@@ -143,13 +143,13 @@ class TestParameterResolver(object):
         request = Mock(parameters=nested_bytes_parameters, is_ephemeral=False, id="123")
         resolver = ParameterResolver(request, params_to_resolve, tmpdir, test_resolvers)
         expected_files = [
-            os.path.join(tmpdir, "123", "mb1"),
-            os.path.join(tmpdir, "123", "mb2"),
-            os.path.join(tmpdir, "123", "sb"),
-            os.path.join(tmpdir, "123", "tlb"),
-            os.path.join(tmpdir, "123", "nmb1"),
-            os.path.join(tmpdir, "123", "nmb2"),
-            os.path.join(tmpdir, "123", "dnb"),
+            os.path.join(str(tmpdir), "123", "mb1"),
+            os.path.join(str(tmpdir), "123", "mb2"),
+            os.path.join(str(tmpdir), "123", "sb"),
+            os.path.join(str(tmpdir), "123", "tlb"),
+            os.path.join(str(tmpdir), "123", "nmb1"),
+            os.path.join(str(tmpdir), "123", "nmb2"),
+            os.path.join(str(tmpdir), "123", "dnb"),
         ]
         actual_params = resolver.resolve_parameters()
         assert actual_params == {
@@ -174,7 +174,7 @@ class TestParameterResolver(object):
             request, [["bytes1"], ["bytes2"]], tmpdir, test_resolvers
         )
         resolver.resolve_parameters()
-        assert len(os.listdir(os.path.join(tmpdir, "123"))) == 2
+        assert len(os.listdir(os.path.join(str(tmpdir), "123"))) == 2
 
     def test_invalid_resolver(self, tmpdir):
         request = Mock(
@@ -191,16 +191,16 @@ class TestParameterResolver(object):
     def test_cleanup(self, tmpdir, test_resolvers):
         resolver = ParameterResolver(Mock(id=None), [], tmpdir, test_resolvers)
         resolver.cleanup()
-        assert not os.path.exists(tmpdir)
+        assert not os.path.exists(str(tmpdir))
 
     def test_with(self, tmpdir, bytes_request, test_resolvers):
         with ParameterResolver(
             bytes_request, [["bytes"]], tmpdir, test_resolvers
         ) as params:
-            assert os.path.isdir(os.path.join(tmpdir, bytes_request.id))
+            assert os.path.isdir(os.path.join(str(tmpdir), bytes_request.id))
             assert "bytes" in params
             assert os.path.isfile(params["bytes"])
-        assert not os.path.isdir(os.path.join(tmpdir, bytes_request.id))
+        assert not os.path.isdir(os.path.join(str(tmpdir), bytes_request.id))
 
     def test_with_unexpected_exception(self, tmpdir, test_resolvers, bytes_request):
         resolver = ParameterResolver(bytes_request, [["bytes"]], tmpdir, test_resolvers)

--- a/test/resolvers/parameter_test.py
+++ b/test/resolvers/parameter_test.py
@@ -1,0 +1,212 @@
+import pytest
+import os
+from mock import Mock
+
+from brewtils.models import Parameter, Command
+from brewtils.resolvers import ParameterResolver
+
+
+@pytest.fixture
+def bytes_param():
+    return {
+        "storage_type": "test",
+        "filename": "testfile",
+        "id": "5cd2152c759cb4d72646a59a",
+    }
+
+
+@pytest.fixture
+def bytes_request(bytes_param):
+    return Mock(parameters={"bytes": bytes_param}, id="123", is_ephemeral=False)
+
+
+@pytest.fixture
+def test_resolvers():
+    return {"test": Mock()}
+
+
+@pytest.fixture
+def nested_bytes_command():
+    p1 = Parameter(key="foo", type="String")
+    p2 = Parameter(key="multi_bytes", type="Bytes", multi=True)
+    nested_simple_param = Parameter(key="thing", type="Integer")
+    nested_bytes_param = Parameter(key="top_level_bytes", type="Bytes")
+    nested_multi_bytes_param = Parameter(
+        key="nested_multi_bytes", type="Bytes", multi=True
+    )
+    dnested_simple = Parameter(key="thing2", type="String")
+    dnested_bytes_param = Parameter(key="deep_nested_bytes", type="Bytes")
+    deep_dict = Parameter(
+        key="deep", type="Dictionary", parameters=[dnested_simple, dnested_bytes_param]
+    )
+    p3 = Parameter(
+        key="nested",
+        type="Dictionary",
+        parameters=[
+            nested_simple_param,
+            nested_bytes_param,
+            nested_multi_bytes_param,
+            deep_dict,
+        ],
+    )
+    p4 = Parameter(key="simple_bytes", type="Bytes")
+    return Command(name="some_name", parameters=[p1, p2, p3, p4])
+
+
+@pytest.fixture
+def nested_bytes_parameters():
+    return {
+        "foo": "bar",
+        "multi_bytes": [
+            {"storage_type": "test", "id": "123", "filename": "mb1"},
+            {"storage_type": "test", "id": "124", "filename": "mb2"},
+        ],
+        "simple_bytes": {"storage_type": "test", "id": "125", "filename": "sb"},
+        "nested": {
+            "thing": 1,
+            "top_level_bytes": {"storage_type": "test", "id": "126", "filename": "tlb"},
+            "nested_multi_bytes": [
+                {"storage_type": "test", "id": "127", "filename": "nmb1"},
+                {"storage_type": "test", "id": "128", "filename": "nmb2"},
+            ],
+            "deep": {
+                "thing2": "data",
+                "deep_nested_bytes": {
+                    "storage_type": "test",
+                    "id": "129",
+                    "filename": "dnb",
+                },
+            },
+        },
+    }
+
+
+class TestParameterResolver(object):
+    @pytest.fixture(autouse=True)
+    def clean_tmpdir(self, tmpdir):
+        tmpdir.remove()
+
+    @pytest.mark.parametrize("params", [({"foo": "bar"}), ({})])
+    def test_trivial_resolve(self, tmpdir, params, test_resolvers):
+        request = Mock(parameters=params, id="123", is_ephemeral=False)
+        resolver = ParameterResolver(request, [], tmpdir, test_resolvers)
+        assert resolver.resolve_parameters() == params
+        assert not os.path.exists(resolver._working_dir)
+        assert test_resolvers["test"].resolve.call_count == 0
+
+    def test_resolve_parameters(self, tmpdir, bytes_request, test_resolvers):
+        bytes_request.parameters["foo"] = "bar"
+        resolver = ParameterResolver(bytes_request, [["bytes"]], tmpdir, test_resolvers)
+        params = resolver.resolve_parameters()
+
+        assert "foo" in params
+        assert params["foo"] == "bar"
+        assert "bytes" in params
+        assert os.path.exists(params["bytes"])
+        assert os.path.basename(params["bytes"]) == "testfile"
+        assert test_resolvers["test"].resolve.call_count == 1
+
+    def test_invalid_resolve(self, tmpdir, test_resolvers, bytes_request):
+        bytes_request.parameters = "INVALID"
+        resolver = ParameterResolver(bytes_request, [["bytes"]], tmpdir, test_resolvers)
+        with pytest.raises(ValueError):
+            resolver.resolve_parameters()
+
+    def test_resolve_ephemeral_bytes_message(
+        self, bytes_request, test_resolvers, tmpdir
+    ):
+        bytes_request.is_ephemeral = True
+        with pytest.raises(ValueError):
+            ParameterResolver(bytes_request, [["bytes"]], tmpdir, test_resolvers)
+
+    def test_multi_bytes_resolve(self, test_resolvers, tmpdir):
+        request = Mock(
+            parameters={
+                "multi_bytes": [
+                    {"storage_type": "test", "id": "123", "filename": "f1"},
+                    {"storage_type": "test", "id": "124", "filename": "f2"},
+                ]
+            },
+            is_ephemeral=False,
+            id="123",
+        )
+        resolver = ParameterResolver(request, [["multi_bytes"]], tmpdir, test_resolvers)
+        params = resolver.resolve_parameters()
+        assert len(params["multi_bytes"]) == 2
+        for filename in params["multi_bytes"]:
+            assert os.path.isfile(filename)
+
+    def test_deep_resolve(
+        self, tmpdir, test_resolvers, nested_bytes_command, nested_bytes_parameters
+    ):
+        params_to_resolve = nested_bytes_command.parameter_keys_by_type("Bytes")
+        request = Mock(parameters=nested_bytes_parameters, is_ephemeral=False, id="123")
+        resolver = ParameterResolver(request, params_to_resolve, tmpdir, test_resolvers)
+        expected_files = [
+            os.path.join(tmpdir, "123", "mb1"),
+            os.path.join(tmpdir, "123", "mb2"),
+            os.path.join(tmpdir, "123", "sb"),
+            os.path.join(tmpdir, "123", "tlb"),
+            os.path.join(tmpdir, "123", "nmb1"),
+            os.path.join(tmpdir, "123", "nmb2"),
+            os.path.join(tmpdir, "123", "dnb"),
+        ]
+        actual_params = resolver.resolve_parameters()
+        assert actual_params == {
+            "foo": "bar",
+            "multi_bytes": [expected_files[0], expected_files[1]],
+            "simple_bytes": expected_files[2],
+            "nested": {
+                "thing": 1,
+                "top_level_bytes": expected_files[3],
+                "nested_multi_bytes": [expected_files[4], expected_files[5]],
+                "deep": {"thing2": "data", "deep_nested_bytes": expected_files[6]},
+            },
+        }
+
+    def test_resolve_conflicting_filenames(self, tmpdir, test_resolvers):
+        params = {
+            "bytes1": {"storage_type": "test", "filename": "file1", "id": "123"},
+            "bytes2": {"storage_type": "test", "filename": "file1", "id": "124"},
+        }
+        request = Mock(id="123", is_ephemeral=False, parameters=params)
+        resolver = ParameterResolver(
+            request, [["bytes1"], ["bytes2"]], tmpdir, test_resolvers
+        )
+        resolver.resolve_parameters()
+        assert len(os.listdir(os.path.join(tmpdir, "123"))) == 2
+
+    def test_invalid_resolver(self, tmpdir):
+        request = Mock(
+            id="123",
+            is_ephemeral=False,
+            parameters={
+                "bytes": {"storage_type": "INVALID", "filename": "foo", "id": "123"}
+            },
+        )
+        resolver = ParameterResolver(request, [["bytes"]], tmpdir, {})
+        with pytest.raises(KeyError):
+            resolver.resolve_parameters()
+
+    def test_cleanup(self, tmpdir, test_resolvers):
+        resolver = ParameterResolver(Mock(id=None), [], tmpdir, test_resolvers)
+        resolver.cleanup()
+        assert not os.path.exists(tmpdir)
+
+    def test_with(self, tmpdir, bytes_request, test_resolvers):
+        with ParameterResolver(
+            bytes_request, [["bytes"]], tmpdir, test_resolvers
+        ) as params:
+            assert os.path.isdir(os.path.join(tmpdir, bytes_request.id))
+            assert "bytes" in params
+            assert os.path.isfile(params["bytes"])
+        assert not os.path.isdir(os.path.join(tmpdir, bytes_request.id))
+
+    def test_with_unexpected_exception(self, tmpdir, test_resolvers, bytes_request):
+        resolver = ParameterResolver(bytes_request, [["bytes"]], tmpdir, test_resolvers)
+        resolver.resolve_parameters = Mock(side_effect=RuntimeError)
+        resolver.cleanup = Mock()
+        with pytest.raises(RuntimeError):
+            with resolver:
+                pass
+        assert resolver.cleanup.call_count == 1

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -261,6 +261,17 @@ class TestRestClient(object):
         assert client.access_token == "token"
         assert client.refresh_token == "refresh"
 
+    def test_get_file(self, client, session_mock):
+        client.get_file("id")
+        session_mock.get.assert_called_with(client.file_url + "id")
+
+    def test_post_files(self, client, session_mock):
+        open_file = Mock()
+        files = {"id": ("filename", open_file)}
+        client.post_files(files)
+        session_mock.post.assert_called_with(client.file_url, files=files)
+        open_file.seek.assert_called_with(0)
+
     def test_refresh(self, client, session_mock):
         response = Mock(ok=True)
         response.json.return_value = {"token": "new_token"}

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -119,6 +119,18 @@ class TestEasyClient(object):
         client.stream_to_source("file_id", source)
         source.write.assert_called_with("chunk")
 
+    def test_upload_file(self, client, rest_client, success):
+        file_to_upload = Mock()
+        success.json = Mock(return_value={"upload_id": "SERVER_RESPONSE"})
+        rest_client.post_files.return_value = success
+        assert client.upload_file(file_to_upload, "desired_name") == "SERVER_RESPONSE"
+
+    def test_upload_file_fail(self, client, rest_client, server_error):
+        file_to_upload = Mock()
+        rest_client.post_files.return_value = server_error
+        with pytest.raises(SaveError):
+            assert client.upload_file(file_to_upload, "desired_name")
+
 
 class EasyClientTest(unittest.TestCase):
     def setUp(self):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -98,26 +98,26 @@ class TestEasyClient(object):
         )
         assert output == parser.parse_logging_config.return_value
 
-    def test_stream_to_source_fail(self, client, rest_client, not_found):
+    def test_stream_to_sink_fail(self, client, rest_client, not_found):
         def mock_exit(_, exc_type, exc_value, traceback):
             if exc_value is not None:
                 raise exc_value
 
         mock_get = Mock(__enter__=Mock(return_value=not_found), __exit__=mock_exit)
-        source = Mock()
+        sink = Mock()
         rest_client.get_file.return_value = mock_get
         with pytest.raises(NotFoundError):
-            client.stream_to_source("file_id", source)
+            client.stream_to_sink("file_id", sink)
 
-    def test_stream_to_source(self, client, rest_client):
+    def test_stream_to_sink(self, client, rest_client):
         response = Mock(
             status_code=200, ok=True, iter_content=Mock(return_value=["chunk"])
         )
         mock_get = Mock(__enter__=Mock(return_value=response), __exit__=Mock())
-        source = Mock()
+        sink = Mock()
         rest_client.get_file.return_value = mock_get
-        client.stream_to_source("file_id", source)
-        source.write.assert_called_with("chunk")
+        client.stream_to_sink("file_id", sink)
+        sink.write.assert_called_with("chunk")
 
     def test_upload_file(self, client, rest_client, success):
         file_to_upload = Mock()

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -20,13 +20,13 @@ from brewtils.rest.system_client import BrewmasterSystemClient, SystemClient
 class TestSystemClient(object):
     @pytest.fixture
     def command_1(self):
-        mock = Mock()
+        mock = Mock(parameter_keys_by_type=Mock(return_value=[]))
         type(mock).name = PropertyMock(return_value="command_1")
         return mock
 
     @pytest.fixture
     def command_2(self):
-        mock = Mock()
+        mock = Mock(parameter_keys_by_type=Mock(return_value=[]))
         type(mock).name = PropertyMock(return_value="command_2")
         return mock
 

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -25,6 +25,7 @@ from brewtils.test.comparable import (
     assert_principal_equal,
     assert_role_equal,
     assert_job_equal,
+    assert_request_file_equal,
 )
 
 
@@ -157,6 +158,13 @@ def test_no_modify(system_dict):
             assert_job_equal,
             lazy_fixture("bg_interval_job"),
         ),
+        (
+            "parse_request_file",
+            lazy_fixture("request_file_dict"),
+            {},
+            assert_request_file_equal,
+            lazy_fixture("bg_request_file"),
+        ),
     ],
 )
 def test_parse(method, data, kwargs, assertion, expected):
@@ -274,6 +282,12 @@ def test_parse_patch_many(patch_many_dict, bg_patch1, bg_patch2):
             lazy_fixture("bg_interval_job"),
             {"to_string": False},
             lazy_fixture("interval_job_dict"),
+        ),
+        (
+            "serialize_request_file",
+            lazy_fixture("bg_request_file"),
+            {"to_string": False},
+            lazy_fixture("request_file_dict"),
         ),
     ],
 )


### PR DESCRIPTION
This PR adds support for file/bytes types in parameters.

The major thing left to do here is on the `SystemClient`. Right now, the `SystemClient` assumes that you are giving it the right parameters. So, there is no "easy" way to upload a file, you have to manually upload the file, then, using the response of the API, change your parameters to match. I plan on adding a semi-easy way to do this.