### PR TITLE
Plugin init

### DIFF
--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -277,12 +277,13 @@ class EasyClient(object):
         return self.client.post_systems(self.parser.serialize_system(system))
 
     @wrap_response(parse_method="parse_system", parse_many=False, default_exc=SaveError)
-    def update_system(self, system_id, new_commands=None, **kwargs):
+    def update_system(self, system_id, new_commands=None, add_instance=None, **kwargs):
         """Update a System
 
         Args:
             system_id (str): The System ID
             new_commands (Optional[List[Command]]): New System commands
+            add_instance (Optional[Instance]): An instance to append
 
         Keyword Args:
             metadata (dict): New System metadata
@@ -302,6 +303,10 @@ class EasyClient(object):
                 new_commands, to_string=False, many=True
             )
             operations.append(PatchOperation("replace", "/commands", commands))
+
+        if add_instance:
+            instance = self.parser.serialize_instance(add_instance, to_string=False)
+            operations.append(PatchOperation("add", "/instance", instance))
 
         if metadata:
             operations.append(PatchOperation("update", "/metadata", metadata))

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -277,15 +277,15 @@ class EasyClient(object):
         return self.client.post_systems(self.parser.serialize_system(system))
 
     @wrap_response(parse_method="parse_system", parse_many=False, default_exc=SaveError)
-    def update_system(self, system_id, new_commands=None, add_instance=None, **kwargs):
+    def update_system(self, system_id, new_commands=None, **kwargs):
         """Update a System
 
         Args:
             system_id (str): The System ID
             new_commands (Optional[List[Command]]): New System commands
-            add_instance (Optional[Instance]): An instance to append
 
         Keyword Args:
+            add_instance (Instance): An Instance to append
             metadata (dict): New System metadata
             description (str): New System description
             display_name (str): New System display name
@@ -297,6 +297,7 @@ class EasyClient(object):
         """
         operations = []
         metadata = kwargs.pop("metadata", {})
+        add_instance = kwargs.pop("add_instance", None)
 
         if new_commands:
             commands = self.parser.serialize_command(

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -251,6 +251,18 @@ class EasyClientTest(unittest.TestCase):
 
     @patch("brewtils.rest.easy_client.PatchOperation")
     @patch("brewtils.rest.client.RestClient.patch_system")
+    def test_update_system_add_instance(self, mock_patch, MockPatch):
+        MockPatch.return_value = "patch"
+        mock_patch.return_value = self.fake_success_response
+        self.parser.serialize_instance = Mock(return_value="new_instance")
+
+        self.client.update_system("id", add_instance="new_instance")
+        MockPatch.assert_called_with("add", "/instance", "new_instance")
+        self.parser.serialize_patch.assert_called_with(["patch"], many=True)
+        self.parser.parse_system.assert_called_with("payload", many=False)
+
+    @patch("brewtils.rest.easy_client.PatchOperation")
+    @patch("brewtils.rest.client.RestClient.patch_system")
     def test_update_system_metadata(self, mock_patch, MockPatch):
         MockPatch.return_value = "patch"
         mock_patch.return_value = self.fake_success_response


### PR DESCRIPTION
I'm going through and breaking apart the original v3 branch into manageable chunks. This is the first.

This PR is a refactoring of the plugin initialization process. It splits the current `initialize` method into three methods for better separation of concerns and testability. It also better positions the plugin for when we need to start supporting non-rabbitmq message queue connections.

This also adds an `add_instance` keyword parameter to `EasyClient.update_system` in order to support the changes.