### PR TITLE
Parser

### DIFF
--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -5,27 +5,8 @@ import warnings
 
 import six
 
+import brewtils.models
 import brewtils.schemas
-from brewtils.models import (
-    System,
-    Instance,
-    Command,
-    Parameter,
-    Request,
-    PatchOperation,
-    Choices,
-    LoggingConfig,
-    Event,
-    Queue,
-    Principal,
-    Role,
-    RefreshToken,
-    Job,
-    RequestTemplate,
-    DateTrigger,
-    CronTrigger,
-    IntervalTrigger,
-)
 from brewtils.schemas import (
     SystemSchema,
     InstanceSchema,
@@ -47,24 +28,24 @@ class SchemaParser(object):
     """Serialize and deserialize Brewtils models"""
 
     _models = {
-        "SystemSchema": System,
-        "InstanceSchema": Instance,
-        "CommandSchema": Command,
-        "ParameterSchema": Parameter,
-        "RequestTemplateSchema": RequestTemplate,
-        "RequestSchema": Request,
-        "PatchSchema": PatchOperation,
-        "ChoicesSchema": Choices,
-        "LoggingConfigSchema": LoggingConfig,
-        "EventSchema": Event,
-        "QueueSchema": Queue,
-        "PrincipalSchema": Principal,
-        "RoleSchema": Role,
-        "RefreshTokenSchema": RefreshToken,
-        "JobSchema": Job,
-        "DateTriggerSchema": DateTrigger,
-        "IntervalTriggerSchema": IntervalTrigger,
-        "CronTriggerSchema": CronTrigger,
+        "SystemSchema": brewtils.models.System,
+        "InstanceSchema": brewtils.models.Instance,
+        "CommandSchema": brewtils.models.Command,
+        "ParameterSchema": brewtils.models.Parameter,
+        "RequestTemplateSchema": brewtils.models.RequestTemplate,
+        "RequestSchema": brewtils.models.Request,
+        "PatchSchema": brewtils.models.PatchOperation,
+        "ChoicesSchema": brewtils.models.Choices,
+        "LoggingConfigSchema": brewtils.models.LoggingConfig,
+        "EventSchema": brewtils.models.Event,
+        "QueueSchema": brewtils.models.Queue,
+        "PrincipalSchema": brewtils.models.Principal,
+        "RoleSchema": brewtils.models.Role,
+        "RefreshTokenSchema": brewtils.models.RefreshToken,
+        "JobSchema": brewtils.models.Job,
+        "DateTriggerSchema": brewtils.models.DateTrigger,
+        "IntervalTriggerSchema": brewtils.models.IntervalTrigger,
+        "CronTriggerSchema": brewtils.models.CronTrigger,
     }
 
     logger = logging.getLogger(__name__)
@@ -79,7 +60,9 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A System object
         """
-        return cls._do_parse(system, SystemSchema(**kwargs), from_string=from_string)
+        return cls.parse(
+            system, brewtils.models.System, from_string=from_string, **kwargs
+        )
 
     @classmethod
     def parse_instance(cls, instance, from_string=False, **kwargs):
@@ -90,8 +73,8 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: An Instance object
         """
-        return cls._do_parse(
-            instance, InstanceSchema(**kwargs), from_string=from_string
+        return cls.parse(
+            instance, brewtils.models.Instance, from_string=from_string, **kwargs
         )
 
     @classmethod
@@ -103,7 +86,9 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A Command object
         """
-        return cls._do_parse(command, CommandSchema(**kwargs), from_string=from_string)
+        return cls.parse(
+            command, brewtils.models.Command, from_string=from_string, **kwargs
+        )
 
     @classmethod
     def parse_parameter(cls, parameter, from_string=False, **kwargs):
@@ -114,8 +99,8 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: An Parameter object
         """
-        return cls._do_parse(
-            parameter, ParameterSchema(**kwargs), from_string=from_string
+        return cls.parse(
+            parameter, brewtils.models.Parameter, from_string=from_string, **kwargs
         )
 
     @classmethod
@@ -127,7 +112,9 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A Request object
         """
-        return cls._do_parse(request, RequestSchema(**kwargs), from_string=from_string)
+        return cls.parse(
+            request, brewtils.models.Request, from_string=from_string, **kwargs
+        )
 
     @classmethod
     def parse_patch(cls, patch, from_string=False, **kwargs):
@@ -148,16 +135,20 @@ class SchemaParser(object):
                 "False, this is being ignored and a list "
                 "will be returned anyway."
             )
-        return cls._do_parse(
-            patch, PatchSchema(many=True, **kwargs), from_string=from_string
+        return cls.parse(
+            patch,
+            brewtils.models.PatchOperation,
+            from_string=from_string,
+            many=True,
+            **kwargs
         )
 
     @classmethod
     def parse_logging_config(cls, logging_config, from_string=False, **kwargs):
         """Convert raw JSON string or dictionary to a logging config model object
 
-        Note: for our logging_config, many is _always_ set to False. We will always return a dict
-        from this method.
+        Note: for our logging_config, many is _always_ set to False. We will always
+        return a dict from this method.
 
         :param logging_config: The raw input
         :param from_string: True if 'input is a JSON string, False if a dictionary
@@ -171,10 +162,12 @@ class SchemaParser(object):
                 "many as True, this is being ignored and a dict will be returned "
                 "anyway."
             )
-        return cls._do_parse(
+        return cls.parse(
             logging_config,
-            LoggingConfigSchema(many=False, **kwargs),
+            brewtils.models.LoggingConfig,
             from_string=from_string,
+            many=False,
+            **kwargs
         )
 
     @classmethod
@@ -186,7 +179,9 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: An Event object
         """
-        return cls._do_parse(event, EventSchema(**kwargs), from_string=from_string)
+        return cls.parse(
+            event, brewtils.models.Event, from_string=from_string, **kwargs
+        )
 
     @classmethod
     def parse_queue(cls, queue, from_string=False, **kwargs):
@@ -197,7 +192,9 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A Queue object
         """
-        return cls._do_parse(queue, QueueSchema(**kwargs), from_string=from_string)
+        return cls.parse(
+            queue, brewtils.models.Queue, from_string=from_string, **kwargs
+        )
 
     @classmethod
     def parse_principal(cls, principal, from_string=False, **kwargs):
@@ -208,8 +205,8 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A Principal object
         """
-        return cls._do_parse(
-            principal, PrincipalSchema(**kwargs), from_string=from_string
+        return cls.parse(
+            principal, brewtils.models.Principal, from_string=from_string, **kwargs
         )
 
     @classmethod
@@ -221,7 +218,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A Role object
         """
-        return cls._do_parse(role, RoleSchema(**kwargs), from_string=from_string)
+        return cls.parse(role, brewtils.models.Role, from_string=from_string, **kwargs)
 
     @classmethod
     def parse_refresh_token(cls, refresh_token, from_string=False, **kwargs):
@@ -232,8 +229,11 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A RefreshToken object
         """
-        return cls._do_parse(
-            refresh_token, RefreshTokenSchema(**kwargs), from_string=from_string
+        return cls.parse(
+            refresh_token,
+            brewtils.models.RefreshToken,
+            from_string=from_string,
+            **kwargs
         )
 
     @classmethod
@@ -249,7 +249,7 @@ class SchemaParser(object):
             A Job object.
 
         """
-        return cls._do_parse(job, JobSchema(**kwargs), from_string=from_string)
+        return cls.parse(job, brewtils.models.Job, from_string=from_string, **kwargs)
 
     @classmethod
     def parse(cls, data, model_class, from_string=False, **kwargs):
@@ -265,18 +265,12 @@ class SchemaParser(object):
             A model object
 
         """
-        return cls._do_parse(
-            data,
-            getattr(brewtils.schemas, model_class.schema)(**kwargs),
-            from_string=from_string
-        )
-
-    @classmethod
-    def _do_parse(cls, data, schema, from_string=False):
         if from_string and not isinstance(data, six.string_types):
             raise TypeError("When from_string=True data must be a string-type")
 
+        schema = getattr(brewtils.schemas, model_class.schema)(**kwargs)
         schema.context["models"] = cls._models
+
         return schema.loads(data).data if from_string else schema.load(data).data
 
     # Serialization methods

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -5,6 +5,7 @@ import warnings
 
 import six
 
+import brewtils.schemas
 from brewtils.models import (
     System,
     Instance,
@@ -249,6 +250,26 @@ class SchemaParser(object):
 
         """
         return cls._do_parse(job, JobSchema(**kwargs), from_string=from_string)
+
+    @classmethod
+    def parse(cls, data, model_class, from_string=False, **kwargs):
+        """Convert a JSON string or dictionary into a model object
+
+        Args:
+            data: The raw input
+            model_class: Class object of the desired model type
+            from_string: True if input is a JSON string, False if a dictionary
+            **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+
+        Returns:
+            A model object
+
+        """
+        return cls._do_parse(
+            data,
+            getattr(brewtils.schemas, model_class.schema)(**kwargs),
+            from_string=from_string
+        )
 
     @classmethod
     def _do_parse(cls, data, schema, from_string=False):

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -7,21 +7,6 @@ import six
 
 import brewtils.models
 import brewtils.schemas
-from brewtils.schemas import (
-    SystemSchema,
-    InstanceSchema,
-    CommandSchema,
-    ParameterSchema,
-    RequestSchema,
-    PatchSchema,
-    LoggingConfigSchema,
-    EventSchema,
-    QueueSchema,
-    PrincipalSchema,
-    RoleSchema,
-    RefreshTokenSchema,
-    JobSchema,
-)
 
 
 class SchemaParser(object):
@@ -290,7 +275,7 @@ class SchemaParser(object):
             else:
                 kwargs["exclude"] = ("commands",)
 
-        return cls._do_serialize(SystemSchema(**kwargs), system, to_string)
+        return cls.serialize(system, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_instance(cls, instance, to_string=True, **kwargs):
@@ -301,7 +286,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of instance
         """
-        return cls._do_serialize(InstanceSchema(**kwargs), instance, to_string)
+        return cls.serialize(instance, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_command(cls, command, to_string=True, **kwargs):
@@ -312,7 +297,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of command
         """
-        return cls._do_serialize(CommandSchema(**kwargs), command, to_string)
+        return cls.serialize(command, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_parameter(cls, parameter, to_string=True, **kwargs):
@@ -323,7 +308,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of parameter
         """
-        return cls._do_serialize(ParameterSchema(**kwargs), parameter, to_string)
+        return cls.serialize(parameter, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_request(cls, request, to_string=True, **kwargs):
@@ -334,7 +319,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of request
         """
-        return cls._do_serialize(RequestSchema(**kwargs), request, to_string)
+        return cls.serialize(request, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_patch(cls, patch, to_string=True, **kwargs):
@@ -345,7 +330,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of patch
         """
-        return cls._do_serialize(PatchSchema(**kwargs), patch, to_string)
+        return cls.serialize(patch, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_logging_config(cls, logging_config, to_string=True, **kwargs):
@@ -356,9 +341,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of logging config
         """
-        return cls._do_serialize(
-            LoggingConfigSchema(**kwargs), logging_config, to_string
-        )
+        return cls.serialize(logging_config, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_event(cls, event, to_string=True, **kwargs):
@@ -369,7 +352,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of event
         """
-        return cls._do_serialize(EventSchema(**kwargs), event, to_string)
+        return cls.serialize(event, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_queue(cls, queue, to_string=True, **kwargs):
@@ -380,7 +363,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation of queue
         """
-        return cls._do_serialize(QueueSchema(**kwargs), queue, to_string)
+        return cls.serialize(queue, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_principal(cls, principal, to_string=True, **kwargs):
@@ -391,7 +374,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation
         """
-        return cls._do_serialize(PrincipalSchema(**kwargs), principal, to_string)
+        return cls.serialize(principal, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_role(cls, role, to_string=True, **kwargs):
@@ -402,7 +385,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation
         """
-        return cls._do_serialize(RoleSchema(**kwargs), role, to_string)
+        return cls.serialize(role, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_refresh_token(cls, refresh_token, to_string=True, **kwargs):
@@ -413,7 +396,7 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: Serialized representation
         """
-        return cls._do_serialize(RefreshTokenSchema(**kwargs), refresh_token, to_string)
+        return cls.serialize(refresh_token, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize_job(cls, job, to_string=True, **kwargs):
@@ -427,7 +410,7 @@ class SchemaParser(object):
         Returns:
             Serialize representation of job.
         """
-        return cls._do_serialize(JobSchema(**kwargs), job, to_string)
+        return cls.serialize(job, to_string=to_string, **kwargs)
 
     @classmethod
     def serialize(cls, model, to_string=False, **kwargs):
@@ -446,10 +429,6 @@ class SchemaParser(object):
         schema = getattr(brewtils.schemas, type(model).schema)(**kwargs)
 
         return schema.dumps(model).data if to_string else schema.dump(model).data
-
-    @staticmethod
-    def _do_serialize(schema, data, to_string):
-        return schema.dumps(data).data if to_string else schema.dump(data).data
 
 
 class BrewmasterSchemaParser(SchemaParser):

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -429,6 +429,24 @@ class SchemaParser(object):
         """
         return cls._do_serialize(JobSchema(**kwargs), job, to_string)
 
+    @classmethod
+    def serialize(cls, model, to_string=False, **kwargs):
+        """Convert a model object into a dictionary or JSON string.
+
+        Args:
+            model: The model
+            to_string: True to generate a JSON string, False to generate a dictionary
+            **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+
+        Returns:
+            A serialized model representation
+
+        """
+        # Use type(model) here because Command has an instance attribute named "schema"
+        schema = getattr(brewtils.schemas, type(model).schema)(**kwargs)
+
+        return schema.dumps(model).data if to_string else schema.dump(model).data
+
     @staticmethod
     def _do_serialize(schema, data, to_string):
         return schema.dumps(data).data if to_string else schema.dump(data).data

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -10,6 +10,7 @@ import pytest
 from marshmallow.exceptions import MarshmallowError
 from pytest_lazyfixture import lazy_fixture
 
+import brewtils.models
 from brewtils.models import System
 from brewtils.schema_parser import SchemaParser, BrewmasterSchemaParser
 from brewtils.test.comparable import (
@@ -28,273 +29,370 @@ from brewtils.test.comparable import (
 )
 
 
-@pytest.mark.parametrize(
-    "data,kwargs,error",
-    [
-        (None, {"from_string": True}, TypeError),
-        (None, {"from_string": False}, TypeError),
-        ("", {"from_string": True}, ValueError),
-        ("bad bad bad", {"from_string": True}, ValueError),
-        (["list", "is", "bad"], {"from_string": True}, TypeError),
-        ({"bad": "bad bad"}, {"from_string": True}, TypeError),
-        ({"name": None}, {}, MarshmallowError),
-        ("bad bad bad", {}, MarshmallowError),
-    ],
-)
-def test_parse_error(data, kwargs, error):
-    parser = SchemaParser()
-    with pytest.raises(error):
-        parser.parse_system(data, **kwargs)
-
-
-def test_non_strict_failure(system_dict):
-    parser = SchemaParser()
-    system_dict["name"] = None
-    value = parser.parse_system(system_dict, from_string=False, strict=False)
-    assert value.get("name") is None
-    assert value["version"] == system_dict["version"]
-
-
-def test_no_modify(system_dict):
-    system_copy = copy.deepcopy(system_dict)
-    SchemaParser().parse_system(system_dict)
-    assert system_copy == system_dict
-
-
-@pytest.mark.parametrize(
-    "method,data,kwargs,assertion,expected",
-    [
-        ("parse_system", {}, {"from_string": False}, assert_system_equal, System()),
-        ("parse_system", "{}", {"from_string": True}, assert_system_equal, System()),
-        (
-            "parse_system",
-            lazy_fixture("system_dict"),
-            {},
-            assert_system_equal,
-            lazy_fixture("bg_system"),
-        ),
-        (
-            "parse_instance",
-            lazy_fixture("instance_dict"),
-            {},
-            assert_instance_equal,
-            lazy_fixture("bg_instance"),
-        ),
-        (
-            "parse_command",
-            lazy_fixture("command_dict"),
-            {},
-            assert_command_equal,
-            lazy_fixture("bg_command"),
-        ),
-        (
-            "parse_parameter",
-            lazy_fixture("parameter_dict"),
-            {},
-            assert_parameter_equal,
-            lazy_fixture("bg_parameter"),
-        ),
-        (
-            "parse_request",
-            lazy_fixture("request_dict"),
-            {},
-            assert_request_equal,
-            lazy_fixture("bg_request"),
-        ),
-        (
-            "parse_logging_config",
-            lazy_fixture("logging_config_dict"),
-            {},
-            assert_logging_config_equal,
-            lazy_fixture("bg_logging_config"),
-        ),
-        (
-            "parse_event",
-            lazy_fixture("event_dict"),
-            {},
-            assert_event_equal,
-            lazy_fixture("bg_event"),
-        ),
-        (
-            "parse_queue",
-            lazy_fixture("queue_dict"),
-            {},
-            assert_queue_equal,
-            lazy_fixture("bg_queue"),
-        ),
-        (
-            "parse_principal",
-            lazy_fixture("principal_dict"),
-            {},
-            assert_principal_equal,
-            lazy_fixture("bg_principal"),
-        ),
-        (
-            "parse_role",
-            lazy_fixture("role_dict"),
-            {},
-            assert_role_equal,
-            lazy_fixture("bg_role"),
-        ),
-        (
-            "parse_job",
-            lazy_fixture("job_dict"),
-            {},
-            assert_job_equal,
-            lazy_fixture("bg_job"),
-        ),
-        (
-            "parse_job",
-            lazy_fixture("cron_job_dict"),
-            {},
-            assert_job_equal,
-            lazy_fixture("bg_cron_job"),
-        ),
-        (
-            "parse_job",
-            lazy_fixture("interval_job_dict"),
-            {},
-            assert_job_equal,
-            lazy_fixture("bg_interval_job"),
-        ),
-    ],
-)
-def test_parse(method, data, kwargs, assertion, expected):
-    parser = SchemaParser()
-    actual = getattr(parser, method)(data, **kwargs)
-    assertion(expected, actual)
-
-
-@pytest.mark.parametrize(
-    "data,kwargs",
-    [
-        (lazy_fixture("patch_dict"), {}),
-        (lazy_fixture("patch_dict"), {"many": False}),
-        (lazy_fixture("patch_no_envelop_dict"), {}),
-    ],
-)
-def test_parse_patch(bg_patch1, data, kwargs):
-    parser = SchemaParser()
-    actual = parser.parse_patch(data, **kwargs)[0]
-    assert_patch_equal(actual, bg_patch1)
-
-
-def test_parse_patch_many(patch_many_dict, bg_patch1, bg_patch2):
-    parser = SchemaParser()
-    patches = sorted(
-        parser.parse_patch(patch_many_dict, many=True), key=lambda x: x.operation
+class TestParse(object):
+    @pytest.mark.parametrize(
+        "data,kwargs,error",
+        [
+            (None, {"from_string": True}, TypeError),
+            (None, {"from_string": False}, TypeError),
+            ("", {"from_string": True}, ValueError),
+            ("bad bad bad", {"from_string": True}, ValueError),
+            (["list", "is", "bad"], {"from_string": True}, TypeError),
+            ({"bad": "bad bad"}, {"from_string": True}, TypeError),
+            ({"name": None}, {}, MarshmallowError),
+            ("bad bad bad", {}, MarshmallowError),
+        ],
     )
-    for index, patch in enumerate([bg_patch1, bg_patch2]):
-        assert_patch_equal(patch, patches[index])
+    def test_parse_error(self, data, kwargs, error):
+        parser = SchemaParser()
+        with pytest.raises(error):
+            parser.parse_system(data, **kwargs)
 
+    def test_non_strict_failure(self, system_dict):
+        parser = SchemaParser()
+        system_dict["name"] = None
+        value = parser.parse_system(system_dict, from_string=False, strict=False)
+        assert value.get("name") is None
+        assert value["version"] == system_dict["version"]
 
-@pytest.mark.parametrize(
-    "method,data,kwargs,expected",
-    [
-        (
-            "serialize_system",
-            lazy_fixture("bg_system"),
-            {"to_string": False},
-            lazy_fixture("system_dict"),
-        ),
-        (
-            "serialize_instance",
-            lazy_fixture("bg_instance"),
-            {"to_string": False},
-            lazy_fixture("instance_dict"),
-        ),
-        (
-            "serialize_command",
-            lazy_fixture("bg_command"),
-            {"to_string": False},
-            lazy_fixture("command_dict"),
-        ),
-        (
-            "serialize_parameter",
-            lazy_fixture("bg_parameter"),
-            {"to_string": False},
-            lazy_fixture("parameter_dict"),
-        ),
-        (
-            "serialize_request",
-            lazy_fixture("bg_request"),
-            {"to_string": False},
-            lazy_fixture("request_dict"),
-        ),
-        (
-            "serialize_patch",
-            lazy_fixture("bg_patch1"),
-            {"to_string": False},
-            lazy_fixture("patch_dict"),
-        ),
-        (
-            "serialize_logging_config",
-            lazy_fixture("bg_logging_config"),
-            {"to_string": False},
-            lazy_fixture("logging_config_dict"),
-        ),
-        (
-            "serialize_event",
-            lazy_fixture("bg_event"),
-            {"to_string": False},
-            lazy_fixture("event_dict"),
-        ),
-        (
-            "serialize_queue",
-            lazy_fixture("bg_queue"),
-            {"to_string": False},
-            lazy_fixture("queue_dict"),
-        ),
-        (
-            "serialize_principal",
-            lazy_fixture("bg_principal"),
-            {"to_string": False},
-            lazy_fixture("principal_dict"),
-        ),
-        (
-            "serialize_role",
-            lazy_fixture("bg_role"),
-            {"to_string": False},
-            lazy_fixture("role_dict"),
-        ),
-        (
-            "serialize_job",
-            lazy_fixture("bg_job"),
-            {"to_string": False},
-            lazy_fixture("job_dict"),
-        ),
-        (
-            "serialize_job",
-            lazy_fixture("bg_cron_job"),
-            {"to_string": False},
-            lazy_fixture("cron_job_dict"),
-        ),
-        (
-            "serialize_job",
-            lazy_fixture("bg_interval_job"),
-            {"to_string": False},
-            lazy_fixture("interval_job_dict"),
-        ),
-    ],
-)
-def test_serialize(method, data, kwargs, expected):
-    parser = SchemaParser()
-    actual = getattr(parser, method)(data, **kwargs)
-    assert actual == expected
+    def test_no_modify(self, system_dict):
+        system_copy = copy.deepcopy(system_dict)
+        SchemaParser().parse_system(system_dict)
+        assert system_copy == system_dict
 
-
-@pytest.mark.parametrize(
-    "keys,excludes", [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))]
-)
-def test_serialize_excludes(bg_system, system_dict, keys, excludes):
-    for key in keys:
-        system_dict.pop(key)
-
-    parser = SchemaParser()
-    actual = parser.serialize_system(
-        bg_system, to_string=False, include_commands=False, exclude=excludes
+    @pytest.mark.parametrize(
+        "model,data,kwargs,assertion,expected",
+        [
+            (brewtils.models.System, {}, {"from_string": False}, assert_system_equal, System()),
+            (brewtils.models.System, "{}", {"from_string": True}, assert_system_equal, System()),
+            (
+                brewtils.models.System,
+                lazy_fixture("system_dict"),
+                {},
+                assert_system_equal,
+                lazy_fixture("bg_system"),
+            ),
+            (
+                brewtils.models.Instance,
+                lazy_fixture("instance_dict"),
+                {},
+                assert_instance_equal,
+                lazy_fixture("bg_instance"),
+            ),
+            (
+                brewtils.models.Command,
+                lazy_fixture("command_dict"),
+                {},
+                assert_command_equal,
+                lazy_fixture("bg_command"),
+            ),
+            (
+                brewtils.models.Parameter,
+                lazy_fixture("parameter_dict"),
+                {},
+                assert_parameter_equal,
+                lazy_fixture("bg_parameter"),
+            ),
+            (
+                brewtils.models.Request,
+                lazy_fixture("request_dict"),
+                {},
+                assert_request_equal,
+                lazy_fixture("bg_request"),
+            ),
+            (
+                brewtils.models.LoggingConfig,
+                lazy_fixture("logging_config_dict"),
+                {},
+                assert_logging_config_equal,
+                lazy_fixture("bg_logging_config"),
+            ),
+            (
+                brewtils.models.Event,
+                lazy_fixture("event_dict"),
+                {},
+                assert_event_equal,
+                lazy_fixture("bg_event"),
+            ),
+            (
+                brewtils.models.Queue,
+                lazy_fixture("queue_dict"),
+                {},
+                assert_queue_equal,
+                lazy_fixture("bg_queue"),
+            ),
+            (
+                brewtils.models.Principal,
+                lazy_fixture("principal_dict"),
+                {},
+                assert_principal_equal,
+                lazy_fixture("bg_principal"),
+            ),
+            (
+                brewtils.models.Role,
+                lazy_fixture("role_dict"),
+                {},
+                assert_role_equal,
+                lazy_fixture("bg_role"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_job"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("cron_job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_cron_job"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("interval_job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_interval_job"),
+            ),
+        ],
     )
-    assert actual == system_dict
+    def test_parse(self, model, data, kwargs, assertion, expected):
+        assertion(SchemaParser.parse(data, model, **kwargs), expected)
+
+    @pytest.mark.parametrize(
+        "method,data,kwargs,assertion,expected",
+        [
+            ("parse_system", {}, {"from_string": False}, assert_system_equal, System()),
+            ("parse_system", "{}", {"from_string": True}, assert_system_equal, System()),
+            (
+                "parse_system",
+                lazy_fixture("system_dict"),
+                {},
+                assert_system_equal,
+                lazy_fixture("bg_system"),
+            ),
+            (
+                "parse_instance",
+                lazy_fixture("instance_dict"),
+                {},
+                assert_instance_equal,
+                lazy_fixture("bg_instance"),
+            ),
+            (
+                "parse_command",
+                lazy_fixture("command_dict"),
+                {},
+                assert_command_equal,
+                lazy_fixture("bg_command"),
+            ),
+            (
+                "parse_parameter",
+                lazy_fixture("parameter_dict"),
+                {},
+                assert_parameter_equal,
+                lazy_fixture("bg_parameter"),
+            ),
+            (
+                "parse_request",
+                lazy_fixture("request_dict"),
+                {},
+                assert_request_equal,
+                lazy_fixture("bg_request"),
+            ),
+            (
+                "parse_logging_config",
+                lazy_fixture("logging_config_dict"),
+                {},
+                assert_logging_config_equal,
+                lazy_fixture("bg_logging_config"),
+            ),
+            (
+                "parse_event",
+                lazy_fixture("event_dict"),
+                {},
+                assert_event_equal,
+                lazy_fixture("bg_event"),
+            ),
+            (
+                "parse_queue",
+                lazy_fixture("queue_dict"),
+                {},
+                assert_queue_equal,
+                lazy_fixture("bg_queue"),
+            ),
+            (
+                "parse_principal",
+                lazy_fixture("principal_dict"),
+                {},
+                assert_principal_equal,
+                lazy_fixture("bg_principal"),
+            ),
+            (
+                "parse_role",
+                lazy_fixture("role_dict"),
+                {},
+                assert_role_equal,
+                lazy_fixture("bg_role"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_job"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("cron_job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_cron_job"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("interval_job_dict"),
+                {},
+                assert_job_equal,
+                lazy_fixture("bg_interval_job"),
+            ),
+        ],
+    )
+    def test_parse_specific(self, method, data, kwargs, assertion, expected):
+        parser = SchemaParser()
+        actual = getattr(parser, method)(data, **kwargs)
+        assertion(expected, actual)
+
+    @pytest.mark.parametrize(
+        "data,kwargs",
+        [
+            (lazy_fixture("patch_dict"), {}),
+            (lazy_fixture("patch_dict"), {"many": False}),
+            (lazy_fixture("patch_no_envelop_dict"), {}),
+        ],
+    )
+    def test_parse_patch(self, bg_patch1, data, kwargs):
+        parser = SchemaParser()
+        actual = parser.parse_patch(data, **kwargs)[0]
+        assert_patch_equal(actual, bg_patch1)
+
+    def test_parse_patch_many(self, patch_many_dict, bg_patch1, bg_patch2):
+        parser = SchemaParser()
+        patches = sorted(
+            parser.parse_patch(patch_many_dict, many=True), key=lambda x: x.operation
+        )
+        for index, patch in enumerate([bg_patch1, bg_patch2]):
+            assert_patch_equal(patch, patches[index])
+
+
+class TestSerialize(object):
+    @pytest.mark.parametrize(
+        "method,data,kwargs,expected",
+        [
+            (
+                "serialize_system",
+                lazy_fixture("bg_system"),
+                {"to_string": False},
+                lazy_fixture("system_dict"),
+            ),
+            (
+                "serialize_instance",
+                lazy_fixture("bg_instance"),
+                {"to_string": False},
+                lazy_fixture("instance_dict"),
+            ),
+            (
+                "serialize_command",
+                lazy_fixture("bg_command"),
+                {"to_string": False},
+                lazy_fixture("command_dict"),
+            ),
+            (
+                "serialize_parameter",
+                lazy_fixture("bg_parameter"),
+                {"to_string": False},
+                lazy_fixture("parameter_dict"),
+            ),
+            (
+                "serialize_request",
+                lazy_fixture("bg_request"),
+                {"to_string": False},
+                lazy_fixture("request_dict"),
+            ),
+            (
+                "serialize_patch",
+                lazy_fixture("bg_patch1"),
+                {"to_string": False},
+                lazy_fixture("patch_dict"),
+            ),
+            (
+                "serialize_logging_config",
+                lazy_fixture("bg_logging_config"),
+                {"to_string": False},
+                lazy_fixture("logging_config_dict"),
+            ),
+            (
+                "serialize_event",
+                lazy_fixture("bg_event"),
+                {"to_string": False},
+                lazy_fixture("event_dict"),
+            ),
+            (
+                "serialize_queue",
+                lazy_fixture("bg_queue"),
+                {"to_string": False},
+                lazy_fixture("queue_dict"),
+            ),
+            (
+                "serialize_principal",
+                lazy_fixture("bg_principal"),
+                {"to_string": False},
+                lazy_fixture("principal_dict"),
+            ),
+            (
+                "serialize_role",
+                lazy_fixture("bg_role"),
+                {"to_string": False},
+                lazy_fixture("role_dict"),
+            ),
+            (
+                "serialize_job",
+                lazy_fixture("bg_job"),
+                {"to_string": False},
+                lazy_fixture("job_dict"),
+            ),
+            (
+                "serialize_job",
+                lazy_fixture("bg_cron_job"),
+                {"to_string": False},
+                lazy_fixture("cron_job_dict"),
+            ),
+            (
+                "serialize_job",
+                lazy_fixture("bg_interval_job"),
+                {"to_string": False},
+                lazy_fixture("interval_job_dict"),
+            ),
+        ],
+    )
+    def test_serialize(self, method, data, kwargs, expected):
+        parser = SchemaParser()
+        actual = getattr(parser, method)(data, **kwargs)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "keys,excludes", [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))]
+    )
+    def test_serialize_excludes(self, bg_system, system_dict, keys, excludes):
+        for key in keys:
+            system_dict.pop(key)
+
+        parser = SchemaParser()
+        actual = parser.serialize_system(
+            bg_system, to_string=False, include_commands=False, exclude=excludes
+        )
+        assert actual == system_dict
 
 
 def test_deprecation():

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -63,8 +63,20 @@ class TestParse(object):
     @pytest.mark.parametrize(
         "model,data,kwargs,assertion,expected",
         [
-            (brewtils.models.System, {}, {"from_string": False}, assert_system_equal, System()),
-            (brewtils.models.System, "{}", {"from_string": True}, assert_system_equal, System()),
+            (
+                brewtils.models.System,
+                {},
+                {"from_string": False},
+                assert_system_equal,
+                System(),
+            ),
+            (
+                brewtils.models.System,
+                "{}",
+                {"from_string": True},
+                assert_system_equal,
+                System(),
+            ),
             (
                 brewtils.models.System,
                 lazy_fixture("system_dict"),
@@ -165,7 +177,13 @@ class TestParse(object):
         "method,data,kwargs,assertion,expected",
         [
             ("parse_system", {}, {"from_string": False}, assert_system_equal, System()),
-            ("parse_system", "{}", {"from_string": True}, assert_system_equal, System()),
+            (
+                "parse_system",
+                "{}",
+                {"from_string": True},
+                assert_system_equal,
+                System(),
+            ),
             (
                 "parse_system",
                 lazy_fixture("system_dict"),
@@ -382,7 +400,8 @@ class TestSerialize(object):
         assert actual == expected
 
     @pytest.mark.parametrize(
-        "keys,excludes", [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))]
+        "keys,excludes",
+        [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))],
     )
     def test_serialize_excludes(self, bg_system, system_dict, keys, excludes):
         for key in keys:

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -306,6 +306,76 @@ class TestParse(object):
 
 class TestSerialize(object):
     @pytest.mark.parametrize(
+        "model,kwargs,expected",
+        [
+            (
+                lazy_fixture("bg_system"),
+                {"to_string": False},
+                lazy_fixture("system_dict"),
+            ),
+            (
+                lazy_fixture("bg_instance"),
+                {"to_string": False},
+                lazy_fixture("instance_dict"),
+            ),
+            (
+                lazy_fixture("bg_command"),
+                {"to_string": False},
+                lazy_fixture("command_dict"),
+            ),
+            (
+                lazy_fixture("bg_parameter"),
+                {"to_string": False},
+                lazy_fixture("parameter_dict"),
+            ),
+            (
+                lazy_fixture("bg_request"),
+                {"to_string": False},
+                lazy_fixture("request_dict"),
+            ),
+            (
+                lazy_fixture("bg_patch1"),
+                {"to_string": False},
+                lazy_fixture("patch_dict"),
+            ),
+            (
+                lazy_fixture("bg_logging_config"),
+                {"to_string": False},
+                lazy_fixture("logging_config_dict"),
+            ),
+            (
+                lazy_fixture("bg_event"),
+                {"to_string": False},
+                lazy_fixture("event_dict"),
+            ),
+            (
+                lazy_fixture("bg_queue"),
+                {"to_string": False},
+                lazy_fixture("queue_dict"),
+            ),
+            (
+                lazy_fixture("bg_principal"),
+                {"to_string": False},
+                lazy_fixture("principal_dict"),
+            ),
+            (lazy_fixture("bg_role"), {"to_string": False}, lazy_fixture("role_dict")),
+            (lazy_fixture("bg_job"), {"to_string": False}, lazy_fixture("job_dict")),
+            (
+                lazy_fixture("bg_cron_job"),
+                {"to_string": False},
+                lazy_fixture("cron_job_dict"),
+            ),
+            (
+                lazy_fixture("bg_interval_job"),
+                {"to_string": False},
+                lazy_fixture("interval_job_dict"),
+            ),
+        ],
+    )
+    def test_serialize(self, model, kwargs, expected):
+        assert SchemaParser.serialize(model, **kwargs) == expected
+
+    @pytest.mark.parametrize(
         "method,data,kwargs,expected",
         [
             (
@@ -394,7 +464,7 @@ class TestSerialize(object):
             ),
         ],
     )
-    def test_serialize(self, method, data, kwargs, expected):
+    def test_serialize_specific(self, method, data, kwargs, expected):
         parser = SchemaParser()
         actual = getattr(parser, method)(data, **kwargs)
         assert actual == expected


### PR DESCRIPTION
This PR adds generic `parse` and `serialize` methods to the `SchemaParser`, replacing the old internal methods that were used previously.