### PR TITLE
Processing

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -16,7 +16,7 @@ from brewtils.errors import (
 from brewtils.log import DEFAULT_LOGGING_CONFIG
 from brewtils.models import Instance, System
 from brewtils.request_consumer import RequestConsumer
-from brewtils.request_handling import EasyRequestUpdater, NoopUpdater, RequestProcessor
+from brewtils.request_handling import HTTPRequestUpdater, NoopUpdater, RequestProcessor
 from brewtils.rest.easy_client import EasyClient
 from brewtils.schema_parser import SchemaParser
 
@@ -239,7 +239,7 @@ class Plugin(object):
             logger=self.logger, parser=self.parser, **connection_parameters
         )
 
-        self.request_updater = EasyRequestUpdater(self.bm_client, self.shutdown_event)
+        self.request_updater = HTTPRequestUpdater(self.bm_client, self.shutdown_event)
 
         self.request_processor = RequestProcessor(
             self.client,

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -25,8 +25,8 @@ request_context = threading.local()
 
 # These are not thread-locals - they should be set in the Plugin __init__ and then never
 # touched. This allows us to do sanity checks when creating nested Requests.
-host = ""
-port = None
+_HOST = ""
+_PORT = None
 
 
 class Plugin(object):
@@ -162,7 +162,7 @@ class Plugin(object):
         bg_url_prefix=None,
         **kwargs
     ):
-        global host, port
+        global _HOST, _PORT
 
         # If a logger is specified or the logging module already has additional
         # handlers then we assume that logging has already been configured
@@ -187,8 +187,8 @@ class Plugin(object):
             client_timeout=kwargs.get("client_timeout", None),
         )
 
-        host = connection_parameters["bg_host"]
-        port = connection_parameters["bg_port"]
+        _HOST = connection_parameters["bg_host"]
+        _PORT = connection_parameters["bg_port"]
 
         self.bg_host = connection_parameters["bg_host"]
         self.bg_port = connection_parameters["bg_port"]

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -1,31 +1,22 @@
 # -*- coding: utf-8 -*-
 
-import json
 import logging
 import logging.config
 import os
-import sys
-from concurrent.futures import ThreadPoolExecutor
-
-import six
 import threading
-from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
 from brewtils.errors import (
-    ValidationError,
-    RequestProcessingError,
-    DiscardMessageException,
-    RepublishRequestException,
-    RestConnectionError,
-    PluginValidationError,
-    RestClientError,
-    parse_exception_as_json,
     ConflictError,
+    PluginValidationError,
+    ValidationError,
+    DiscardMessageException,
+    RequestProcessingError,
 )
 from brewtils.log import DEFAULT_LOGGING_CONFIG
-from brewtils.models import Instance, Request, System
+from brewtils.models import Instance, System
 from brewtils.request_consumer import RequestConsumer
+from brewtils.request_handling import EasyRequestUpdater, NoopUpdater, RequestProcessor
 from brewtils.rest.easy_client import EasyClient
 from brewtils.schema_parser import SchemaParser
 
@@ -187,6 +178,7 @@ class Plugin(object):
             password=kwargs.get("password", None),
             client_timeout=kwargs.get("client_timeout", None),
         )
+
         self.bg_host = connection_parameters["bg_host"]
         self.bg_port = connection_parameters["bg_port"]
         self.ssl_enabled = connection_parameters["ssl_enabled"]
@@ -209,7 +201,6 @@ class Plugin(object):
         self.queue_connection_params = None
         self.admin_consumer = None
         self.request_consumer = None
-        self.connection_poll_thread = None
         self.client = client
         self.shutdown_event = threading.Event()
         self.parser = parser or SchemaParser()
@@ -233,15 +224,21 @@ class Plugin(object):
             self.system.version,
         )
 
-        # Tightly manage when we're in an 'error' state, aka Brew-view is down
-        self.brew_view_error_condition = threading.Condition()
-        self.brew_view_down = False
-
-        self.pool = ThreadPoolExecutor(max_workers=self.max_concurrent)
-        self.admin_pool = ThreadPoolExecutor(max_workers=1)
-
         self.bm_client = EasyClient(
             logger=self.logger, parser=self.parser, **connection_parameters
+        )
+
+        self.request_updater = EasyRequestUpdater(self.bm_client, self.shutdown_event)
+
+        self.request_processor = RequestProcessor(
+            self.client,
+            self.request_updater,
+            validation_funcs=[self._validate_system, self._validate_running],
+            unique_name=self.unique_name,
+            max_workers=self.max_concurrent,
+        )
+        self.admin_processor = RequestProcessor(
+            self, NoopUpdater(), unique_name=self.unique_name, max_workers=1
         )
 
     def run(self):
@@ -258,10 +255,6 @@ class Plugin(object):
         self.request_consumer = self._create_standard_consumer()
         self.request_consumer.start()
 
-        self.logger.debug("Creating and starting connection poll thread")
-        self.connection_poll_thread = self._create_connection_poll_thread()
-        self.connection_poll_thread.start()
-
         self.logger.info("Plugin %s has started", self.unique_name)
 
         try:
@@ -270,8 +263,9 @@ class Plugin(object):
                     not self.admin_consumer.isAlive()
                     and not self.admin_consumer.shutdown_event.is_set()
                 ):
+                    # TODO: This is pretty useless, really need to re-initialize here
                     self.logger.warning(
-                        "Looks like admin consumer has died - attempting to " "restart"
+                        "Looks like admin consumer has died - attempting to restart"
                     )
                     self.admin_consumer = self._create_admin_consumer()
                     self.admin_consumer.start()
@@ -281,18 +275,10 @@ class Plugin(object):
                     and not self.request_consumer.shutdown_event.is_set()
                 ):
                     self.logger.warning(
-                        "Looks like request consumer has died - attempting to" "restart"
+                        "Looks like request consumer has died - attempting to restart"
                     )
                     self.request_consumer = self._create_standard_consumer()
                     self.request_consumer.start()
-
-                if not self.connection_poll_thread.isAlive():
-                    self.logger.warning(
-                        "Looks like connection poll thread has died - "
-                        "attempting to restart"
-                    )
-                    self.connection_poll_thread = self._create_connection_poll_thread()
-                    self.connection_poll_thread.start()
 
                 if (
                     self.request_consumer.shutdown_event.is_set()
@@ -310,101 +296,6 @@ class Plugin(object):
         self._shutdown()
 
         self.logger.info("Plugin %s has terminated", self.unique_name)
-
-    def process_message(self, target, request, headers):
-        """Process a message. Intended to be run on an Executor.
-
-        :param target: The object to invoke received commands on.
-            (self or self.client)
-        :param request: The parsed Request object
-        :param headers: Dictionary of headers from the
-            `brewtils.request_consumer.RequestConsumer`
-        :return: None
-        """
-        request.status = "IN_PROGRESS"
-        self._update_request(request, headers)
-
-        try:
-            # Set request context so this request will be the parent of any
-            # generated requests and update status We also need the host/port of
-            #  the current plugin. We currently don't support parent/child
-            # requests across different servers.
-            request_context.current_request = request
-            request_context.bg_host = self.bg_host
-            request_context.bg_port = self.bg_port
-
-            output = self._invoke_command(target, request)
-        except Exception as ex:
-            self.logger.log(
-                getattr(ex, "_bg_error_log_level", logging.ERROR),
-                "Plugin %s raised an exception while processing request %s: %s",
-                self.unique_name,
-                str(request),
-                ex,
-                exc_info=not getattr(ex, "_bg_suppress_stacktrace", False),
-            )
-            request.status = "ERROR"
-            request.output = self._format_error_output(request, ex)
-            request.error_class = type(ex).__name__
-        else:
-            request.status = "SUCCESS"
-            request.output = self._format_output(output)
-
-        self._update_request(request, headers)
-
-    def process_request_message(self, message, headers):
-        """Processes a message from a RequestConsumer
-
-        :param message: A valid string representation of a
-            `brewtils.models.Request`
-        :param headers: A dictionary of headers from the
-            `brewtils.request_consumer.RequestConsumer`
-        :return: A `concurrent.futures.Future`
-        """
-
-        request = self._pre_process(message)
-
-        # This message has already been processed, all it needs to do is update
-        if request.status in Request.COMPLETED_STATUSES:
-            return self.pool.submit(self._update_request, request, headers)
-        else:
-            return self.pool.submit(self.process_message, self.client, request, headers)
-
-    def process_admin_message(self, message, headers):
-
-        # Admin requests won't have a system, so don't verify it
-        request = self._pre_process(message, verify_system=False)
-
-        return self.admin_pool.submit(self.process_message, self, request, headers)
-
-    def _pre_process(self, message, verify_system=True):
-
-        if self.shutdown_event.is_set():
-            raise RequestProcessingError(
-                "Unable to process message - currently shutting down"
-            )
-
-        try:
-            request = self.parser.parse_request(message, from_string=True)
-        except Exception as ex:
-            self.logger.exception(
-                "Unable to parse message body: {0}. Exception: {1}".format(message, ex)
-            )
-            raise DiscardMessageException("Error parsing message body")
-
-        if (
-            verify_system
-            and request.command_type
-            and request.command_type.upper() != "EPHEMERAL"
-            and request.system.upper() != self.system.name.upper()
-        ):
-            raise DiscardMessageException(
-                "Received message for a different system {0}".format(
-                    request.system.upper()
-                )
-            )
-
-        return request
 
     def _initialize_system(self):
         """Let Beergarden know about System-level info
@@ -489,25 +380,21 @@ class Plugin(object):
     def _shutdown(self):
         self.shutdown_event.set()
 
-        self.logger.debug("About to stop message consuming")
+        self.logger.debug("Stopping request and admin consuming")
         self.request_consumer.stop_consuming()
         self.admin_consumer.stop_consuming()
 
-        self.logger.debug("About to wake sleeping request processing threads")
-        with self.brew_view_error_condition:
-            self.brew_view_error_condition.notify_all()
+        self.logger.debug("Shutting down request and admin processors")
+        self.request_processor.shutdown()
+        self.admin_processor.shutdown()
 
-        self.logger.debug("Shutting down request processing pool")
-        self.pool.shutdown(wait=True)
-        self.logger.debug("Shutting down admin processing pool")
-        self.admin_pool.shutdown(wait=True)
+        self.logger.debug("Shutting down request updater")
+        self.request_updater.shutdown()
 
-        self.logger.debug("Attempting to stop request queue consumer")
+        self.logger.debug("Shutting down request and admin consumers")
         self.request_consumer.stop()
-        self.request_consumer.join()
-
-        self.logger.debug("Attempting to stop admin queue consumer")
         self.admin_consumer.stop()
+        self.request_consumer.join()
         self.admin_consumer.join()
 
         self.logger.debug("Successfully shutdown plugin {0}".format(self.unique_name))
@@ -518,7 +405,7 @@ class Plugin(object):
             connection_info=self.queue_connection_params,
             amqp_url=self.instance.queue_info.get("url", None),
             queue_name=self.instance.queue_info["request"]["name"],
-            on_message_callback=self.process_request_message,
+            on_message_callback=self.request_processor.on_message_received,
             panic_event=self.shutdown_event,
             max_concurrent=self.max_concurrent,
         )
@@ -529,168 +416,15 @@ class Plugin(object):
             connection_info=self.queue_connection_params,
             amqp_url=self.instance.queue_info.get("url", None),
             queue_name=self.instance.queue_info["admin"]["name"],
-            on_message_callback=self.process_admin_message,
+            on_message_callback=self.admin_processor.on_message_received,
             panic_event=self.shutdown_event,
             max_concurrent=1,
             logger=logging.getLogger("brewtils.admin_consumer"),
         )
 
-    def _create_connection_poll_thread(self):
-        connection_poll_thread = threading.Thread(target=self._connection_poll)
-        connection_poll_thread.daemon = True
-        return connection_poll_thread
-
-    def _invoke_command(self, target, request):
-        """Invoke the function named in request.command.
-
-        :param target: The object to search for the function implementation.
-            Will be self or self.client.
-        :param request: The request to process
-        :raise RequestProcessingError: The specified target does not define a
-            callable implementation of request.command
-        :return: The output of the function invocation
-        """
-        if not callable(getattr(target, request.command, None)):
-            raise RequestProcessingError(
-                "Could not find an implementation of command '%s'" % request.command
-            )
-
-        # It's kinda weird that we need to add the object arg only if we're
-        # trying to call a function on self. In both cases the function object
-        # is bound... think it has something to do with our decorators
-        args = [self] if target is self else []
-        kwargs = request.parameters or {}
-        return getattr(target, request.command)(*args, **kwargs)
-
-    def _update_request(self, request, headers):
-        """Sends a Request update to beer-garden
-
-        Ephemeral requests do not get updated, so we simply skip them.
-
-        If brew-view appears to be down, it will wait for brew-view to come back
-         up before updating.
-
-        If this is the final attempt to update, we will attempt a known, good
-        request to give some information to the user. If this attempt fails
-        then we simply discard the message
-
-        :param request: The request to update
-        :param headers: A dictionary of headers from
-            `brewtils.request_consumer.RequestConsumer`
-        :raise RepublishMessageException: The Request update failed (any reason)
-        :return: None
-        """
-
-        if request.is_ephemeral:
-            sys.stdout.flush()
-            return
-
-        with self.brew_view_error_condition:
-
-            self._wait_for_brew_view_if_down(request)
-
-            try:
-                if not self._should_be_final_attempt(headers):
-                    self._wait_if_not_first_attempt(headers)
-                    self.bm_client.update_request(
-                        request.id,
-                        status=request.status,
-                        output=request.output,
-                        error_class=request.error_class,
-                    )
-                else:
-                    self.bm_client.update_request(
-                        request.id,
-                        status="ERROR",
-                        output="We tried to update the request, but it failed "
-                        "too many times. Please check the plugin logs "
-                        "to figure out why the request update failed. "
-                        "It is possible for this request to have "
-                        "succeeded, but we cannot update beer-garden "
-                        "with that information.",
-                        error_class="BGGivesUpError",
-                    )
-            except Exception as ex:
-                self._handle_request_update_failure(request, headers, ex)
-            finally:
-                sys.stdout.flush()
-
-    def _wait_if_not_first_attempt(self, headers):
-        if headers.get("retry_attempt", 0) > 0:
-            time_to_sleep = min(
-                headers.get("time_to_wait", self.starting_timeout), self.max_timeout
-            )
-            self.shutdown_event.wait(time_to_sleep)
-
-    def _handle_request_update_failure(self, request, headers, exc):
-
-        # If brew-view is down, we always want to try again
-        # Yes, even if it is the 'final_attempt'
-        if isinstance(exc, (RequestsConnectionError, RestConnectionError)):
-            self.brew_view_down = True
-            self.logger.error(
-                "Error updating request status: {0} exception: {1}".format(
-                    request.id, exc
-                )
-            )
-            raise RepublishRequestException(request, headers)
-
-        elif isinstance(exc, RestClientError):
-            message = (
-                "Error updating request {0} and it is a client error. Probable "
-                "cause is that this request is already updated. In which case, "
-                "ignore this message. If request {0} did not complete, please "
-                "file an issue. Discarding request to avoid an infinte loop. "
-                "exception: {1}".format(request.id, exc)
-            )
-            self.logger.error(message)
-            raise DiscardMessageException(message)
-
-        # Time to discard the message because we've given up
-        elif self._should_be_final_attempt(headers):
-            message = (
-                "Could not update request {0} even with a known good status, "
-                "output and error_class. We have reached the final attempt and "
-                "will now discard the message. Attempted to process this "
-                "message {1} times".format(request.id, headers["retry_attempt"])
-            )
-            self.logger.error(message)
-            raise DiscardMessageException(message)
-
-        else:
-            self._update_retry_attempt_information(headers)
-            self.logger.exception(
-                "Error updating request (Attempt #{0}: request: {1} exception: "
-                "{2}".format(headers.get("retry_attempt", 0), request.id, exc)
-            )
-            raise RepublishRequestException(request, headers)
-
-    def _update_retry_attempt_information(self, headers):
-        headers["retry_attempt"] = headers.get("retry_attempt", 0) + 1
-        headers["time_to_wait"] = min(
-            headers.get("time_to_wait", self.starting_timeout // 2) * 2,
-            self.max_timeout,
-        )
-
-    def _should_be_final_attempt(self, headers):
-        if self.max_attempts <= 0:
-            return False
-
-        return self.max_attempts <= headers.get("retry_attempt", 0)
-
-    def _wait_for_brew_view_if_down(self, request):
-        if self.brew_view_down and not self.shutdown_event.is_set():
-            self.logger.warning(
-                "Currently unable to communicate with Brew-view, about to wait "
-                "until connection is reestablished to update request %s",
-                request.id,
-            )
-            self.brew_view_error_condition.wait()
-
-    def _start(self, request):
+    def _start(self):
         """Handle start message by marking this instance as running.
 
-        :param request: The start message
         :return: Success output message
         """
         self.instance = self.bm_client.update_instance_status(
@@ -699,10 +433,9 @@ class Plugin(object):
 
         return "Successfully started plugin"
 
-    def _stop(self, request):
+    def _stop(self):
         """Handle stop message by marking this instance as stopped.
 
-        :param request: The stop message
         :return: Success output message
         """
         self.shutdown_event.set()
@@ -712,19 +445,24 @@ class Plugin(object):
 
         return "Successfully stopped plugin"
 
-    def _status(self, request):
-        """Handle status message by sending a heartbeat.
+    def _status(self):
+        """Handle status message by sending a heartbeat."""
+        self.request_updater.update_status(self.instance.id)
 
-        :param request: The status message
-        :return: None
-        """
-        with self.brew_view_error_condition:
-            if not self.brew_view_down:
-                try:
-                    self.bm_client.instance_heartbeat(self.instance.id)
-                except (RequestsConnectionError, RestConnectionError):
-                    self.brew_view_down = True
-                    raise
+    def _validate_system(self, request):
+        """Validate that a request is intended for this Plugin"""
+        request_system = getattr(request, "system") or ""
+        if request_system.upper() != self.system.name.upper():
+            raise DiscardMessageException(
+                "Received message for system {0}".format(request.system)
+            )
+
+    def _validate_running(self, _):
+        """Validate that this plugin is still running"""
+        if self.shutdown_event.is_set():
+            raise RequestProcessingError(
+                "Unable to process message - currently shutting down"
+            )
 
     def _setup_system(
         self,
@@ -792,43 +530,6 @@ class Plugin(object):
             )
 
         return system
-
-    def _connection_poll(self):
-        """Periodically attempt to re-connect to beer-garden"""
-
-        while not self.shutdown_event.wait(5):
-            with self.brew_view_error_condition:
-                if self.brew_view_down:
-                    try:
-                        self.bm_client.get_version()
-                    except Exception:
-                        self.logger.debug("Attempt to reconnect to Brew-view failed")
-                    else:
-                        self.logger.info(
-                            "Brew-view connection reestablished, about to "
-                            "notify any waiting requests"
-                        )
-                        self.brew_view_down = False
-                        self.brew_view_error_condition.notify_all()
-
-    @staticmethod
-    def _format_error_output(request, exc):
-        if request.is_json:
-            return parse_exception_as_json(exc)
-        else:
-            return str(exc)
-
-    @staticmethod
-    def _format_output(output):
-        """Formats output from Plugins to prevent validation errors"""
-
-        if isinstance(output, six.string_types):
-            return output
-
-        try:
-            return json.dumps(output)
-        except (TypeError, ValueError):
-            return str(output)
 
 
 # Alias old name

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-
 import logging
 import logging.config
 import os
 import threading
+
+from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
 from brewtils.errors import (
@@ -12,6 +13,7 @@ from brewtils.errors import (
     ValidationError,
     DiscardMessageException,
     RequestProcessingError,
+    RestConnectionError,
 )
 from brewtils.log import DEFAULT_LOGGING_CONFIG
 from brewtils.models import Instance, System
@@ -458,7 +460,10 @@ class Plugin(object):
 
     def _status(self):
         """Handle status message by sending a heartbeat."""
-        self.request_updater.update_status(self.instance.id)
+        try:
+            self.bm_client.instance_heartbeat(self.instance.id)
+        except (RequestsConnectionError, RestConnectionError):
+            pass
 
     def _validate_system(self, request):
         """Validate that a request is intended for this Plugin"""

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -241,11 +241,9 @@ class Plugin(object):
             logger=self.logger, parser=self.parser, **connection_parameters
         )
 
-        self.request_updater = HTTPRequestUpdater(self.bm_client, self.shutdown_event)
-
         self.request_processor = RequestProcessor(
             self.client,
-            self.request_updater,
+            HTTPRequestUpdater(self.bm_client, self.shutdown_event),
             validation_funcs=[self._validate_system, self._validate_running],
             unique_name=self.unique_name,
             max_workers=self.max_concurrent,
@@ -400,9 +398,6 @@ class Plugin(object):
         self.logger.debug("Shutting down request and admin processors")
         self.request_processor.shutdown()
         self.admin_processor.shutdown()
-
-        self.logger.debug("Shutting down request updater")
-        self.request_updater.shutdown()
 
         self.logger.debug("Shutting down request and admin consumers")
         self.request_consumer.stop()

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -20,7 +20,13 @@ from brewtils.request_handling import EasyRequestUpdater, NoopUpdater, RequestPr
 from brewtils.rest.easy_client import EasyClient
 from brewtils.schema_parser import SchemaParser
 
+# This is what enables request nesting to work easily
 request_context = threading.local()
+
+# These are not thread-locals - they should be set in the Plugin __init__ and then never
+# touched. This allows us to do sanity checks when creating nested Requests.
+host = ""
+port = None
 
 
 class Plugin(object):
@@ -156,6 +162,8 @@ class Plugin(object):
         bg_url_prefix=None,
         **kwargs
     ):
+        global host, port
+
         # If a logger is specified or the logging module already has additional
         # handlers then we assume that logging has already been configured
         if logger or len(logging.getLogger(__name__).root.handlers) > 0:
@@ -178,6 +186,9 @@ class Plugin(object):
             password=kwargs.get("password", None),
             client_timeout=kwargs.get("client_timeout", None),
         )
+
+        host = connection_parameters["bg_host"]
+        port = connection_parameters["bg_port"]
 
         self.bg_host = connection_parameters["bg_host"]
         self.bg_port = connection_parameters["bg_port"]

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -143,22 +143,16 @@ class RequestConsumerBase(threading.Thread):
 
         try:
             future = self._on_message_callback(body, properties.headers)
-            callback = partial(self.on_message_callback_complete, basic_deliver)
-            future.add_done_callback(callback)
-        except DiscardMessageException:
-            self.logger.debug(
-                "Nacking message %s, not attempting to requeue",
-                basic_deliver.delivery_tag,
+            future.add_done_callback(
+                partial(self.on_message_callback_complete, basic_deliver)
             )
-            self._channel.basic_nack(basic_deliver.delivery_tag, requeue=False)
         except Exception as ex:
+            requeue = not isinstance(ex, DiscardMessageException)
             self.logger.exception(
-                "Exception while trying to schedule message %s, about to nack "
-                "and requeue: %s",
-                basic_deliver.delivery_tag,
-                ex,
+                "Exception while trying to schedule message %s, about to nack%s: %s"
+                % (basic_deliver.delivery_tag, " and requeue" if requeue else "", ex)
             )
-            self._channel.basic_nack(basic_deliver.delivery_tag, requeue=True)
+            self._channel.basic_nack(basic_deliver.delivery_tag, requeue=requeue)
 
     def on_message_callback_complete(self, basic_deliver, future):
         """Invoked when the future returned by _on_message_callback completes.

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -92,10 +92,7 @@ class RequestProcessor(object):
             # requests across different servers.
             import brewtils.plugin
 
-            # TODO: Figure out what to do about nested requests
             brewtils.plugin.request_context.current_request = request
-            brewtils.plugin.request_context.bg_host = ""
-            brewtils.plugin.request_context.bg_port = None
 
             output = self._invoke_command(target, request)
         except Exception as ex:

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -226,7 +226,7 @@ class NoopUpdater(RequestUpdater):
         pass
 
 
-class EasyRequestUpdater(RequestUpdater):
+class HTTPRequestUpdater(RequestUpdater):
     """RequestUpdater implementation based around an EasyClient.
 
     Args:

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -9,6 +9,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 import six
 from requests import ConnectionError as RequestsConnectionError
 
+import brewtils.plugin
 from brewtils.errors import (
     DiscardMessageException,
     parse_exception_as_json,
@@ -113,8 +114,6 @@ class RequestProcessor(object):
             # generated requests and update status We also need the host/port of
             #  the current plugin. We currently don't support parent/child
             # requests across different servers.
-            import brewtils.plugin
-
             brewtils.plugin.request_context.current_request = request
 
             output = self._invoke_command(target, request)

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -265,16 +265,6 @@ class HTTPRequestUpdater(RequestUpdater):
         with self.brew_view_error_condition:
             self.brew_view_error_condition.notify_all()
 
-    def update_status(self, instance_id):
-        """Handle status message by sending a heartbeat."""
-        with self.brew_view_error_condition:
-            if not self.brew_view_down:
-                try:
-                    self._ez_client.instance_heartbeat(instance_id)
-                except (RequestsConnectionError, RestConnectionError):
-                    self.brew_view_down = True
-                    raise
-
     def update_request(self, request, headers):
         """Sends a Request update to beer-garden
 

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+import abc
 import json
 import logging
 import sys
+import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 
 import six
-import threading
 from requests import ConnectionError as RequestsConnectionError
 
 from brewtils.errors import (
@@ -177,8 +178,19 @@ class RequestProcessor(object):
             return str(output)
 
 
-class NoopUpdater(object):
-    """RequestUpdater implementation that doesn't actually update."""
+@six.add_metaclass(abc.ABCMeta)
+class RequestUpdater(object):
+    @abc.abstractmethod
+    def update_request(self, request, headers):
+        pass
+
+    @abc.abstractmethod
+    def shutdown(self):
+        pass
+
+
+class NoopUpdater(RequestUpdater):
+    """RequestUpdater implementation that explicitly does not update."""
 
     def __init__(self, *args, **kwargs):
         pass
@@ -190,7 +202,7 @@ class NoopUpdater(object):
         pass
 
 
-class EasyRequestUpdater(object):
+class EasyRequestUpdater(RequestUpdater):
     """RequestUpdater implementation based around an EasyClient.
 
     Args:

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+import sys
+from concurrent.futures.thread import ThreadPoolExecutor
+
+import six
+import threading
+from requests import ConnectionError as RequestsConnectionError
+
+from brewtils.errors import (
+    DiscardMessageException,
+    parse_exception_as_json,
+    RepublishRequestException,
+    RestConnectionError,
+    RestClientError,
+    RequestProcessingError,
+)
+from brewtils.models import Request
+from brewtils.schema_parser import SchemaParser
+
+
+class RequestProcessor(object):
+    def __init__(
+        self,
+        target,
+        updater,
+        validation_funcs=None,
+        logger=None,
+        unique_name=None,
+        max_workers=None,
+    ):
+        self.logger = logger or logging.getLogger(__name__)
+
+        self._target = target
+        self._updater = updater
+        self._unique_name = unique_name
+        self._validation_funcs = validation_funcs or []
+        self._pool = ThreadPoolExecutor(max_workers=max_workers)
+
+    def on_message_received(self, message, headers):
+        """Callback function that will be invoked for received messages
+
+        This will attempt to parse the message and then run the parsed Request through
+        all validation functions that this RequestProcessor knows about.
+
+        If the request parses cleanly and passes validation it will be submitted to this
+        RequestProcessor's ThreadPoolExecutor for processing.
+
+        Args:
+            message: The message string
+            headers: The header dictionary
+
+        Returns:
+            A future that will complete when processing finishes
+
+        Raises:
+            DiscardMessageException: The request failed to parse correctly
+            RequestProcessException: Validation failures should raise a subclass of this
+        """
+        request = self._parse(message)
+
+        for func in self._validation_funcs:
+            func(request)
+
+        # This message has already been processed, all it needs to do is update
+        if request.status in Request.COMPLETED_STATUSES:
+            return self._pool.submit(self._updater.update_request, request, headers)
+        else:
+            return self._pool.submit(
+                self.process_message, self._target, request, headers
+            )
+
+    def process_message(self, target, request, headers):
+        """Process a message. Intended to be run on an Executor.
+
+        :param target: The object to invoke received commands on.
+            (self or self.client)
+        :param request: The parsed Request
+        :param headers: Dictionary of headers from the
+            `brewtils.request_consumer.RequestConsumer`
+        :return: None
+
+        """
+        request.status = "IN_PROGRESS"
+        self._updater.update_request(request, headers)
+
+        try:
+            # Set request context so this request will be the parent of any
+            # generated requests and update status We also need the host/port of
+            #  the current plugin. We currently don't support parent/child
+            # requests across different servers.
+            import brewtils.plugin
+
+            # TODO: Figure out what to do about nested requests
+            brewtils.plugin.request_context.current_request = request
+            brewtils.plugin.request_context.bg_host = ""
+            brewtils.plugin.request_context.bg_port = None
+
+            output = self._invoke_command(target, request)
+        except Exception as ex:
+            self.logger.log(
+                getattr(ex, "_bg_error_log_level", logging.ERROR),
+                "Plugin %s raised an exception while processing request %s: %s",
+                self._unique_name,
+                str(request),
+                ex,
+                exc_info=not getattr(ex, "_bg_suppress_stacktrace", False),
+            )
+            request.status = "ERROR"
+            request.output = self._format_error_output(request, ex)
+            request.error_class = type(ex).__name__
+        else:
+            request.status = "SUCCESS"
+            request.output = self._format_output(output)
+
+        self._updater.update_request(request, headers)
+
+    def shutdown(self):
+        """Stop the RequestProcessor"""
+        self._pool.shutdown(wait=True)
+
+    def _parse(self, message):
+        """Parse a message using the standard SchemaParser
+
+        Args:
+            message: The raw (json) message body
+
+        Returns:
+            A brewtils Request model
+
+        Raises:
+            DiscardMessageException: The request failed to parse correctly
+        """
+        try:
+            return SchemaParser.parse_request(message, from_string=True)
+        except Exception as ex:
+            self.logger.exception(
+                "Unable to parse message body: {0}. Exception: {1}".format(message, ex)
+            )
+            raise DiscardMessageException("Error parsing message body")
+
+    @staticmethod
+    def _invoke_command(target, request):
+        """Invoke the function named in request.command.
+
+        :param target: The object to search for the function implementation.
+            Will be self or self.client.
+        :param request: The request to process
+        :raise RequestProcessingError: The specified target does not define a
+            callable implementation of request.command
+        :return: The output of the function invocation
+        """
+        if not callable(getattr(target, request.command, None)):
+            raise RequestProcessingError(
+                "Could not find an implementation of command '%s'" % request.command
+            )
+
+        parameters = request.parameters or {}
+
+        return getattr(target, request.command)(**parameters)
+
+    @staticmethod
+    def _format_error_output(request, exc):
+        if request.is_json:
+            return parse_exception_as_json(exc)
+        else:
+            return str(exc)
+
+    @staticmethod
+    def _format_output(output):
+        """Formats output from Plugins to prevent validation errors"""
+
+        if isinstance(output, six.string_types):
+            return output
+
+        try:
+            return json.dumps(output)
+        except (TypeError, ValueError):
+            return str(output)
+
+
+class NoopUpdater(object):
+    """RequestUpdater implementation that doesn't actually update."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def update_request(self, request, headers):
+        pass
+
+    def shutdown(self):
+        pass
+
+
+class EasyRequestUpdater(object):
+    """RequestUpdater implementation based around an EasyClient.
+
+    Args:
+        ez_client:
+        shutdown_event:
+        logger:
+        **kwargs:
+    """
+
+    def __init__(self, ez_client, shutdown_event, logger=None, **kwargs):
+        self.logger = logger or logging.getLogger(__name__)
+
+        self._ez_client = ez_client
+        self._shutdown_event = shutdown_event
+
+        self.max_attempts = kwargs.get("max_attempts", -1)
+        self.max_timeout = kwargs.get("max_timeout", 30)
+        self.starting_timeout = kwargs.get("starting_timeout", 5)
+
+        # Tightly manage when we're in an 'error' state, aka Brew-view is down
+        self.brew_view_error_condition = threading.Condition()
+        self.brew_view_down = False
+
+        self.logger.debug("Creating and starting connection poll thread")
+        self.connection_poll_thread = self._create_connection_poll_thread()
+        self.connection_poll_thread.start()
+
+    def shutdown(self):
+        self.logger.debug("Shutting down, about to wake any sleeping updater threads")
+        with self.brew_view_error_condition:
+            self.brew_view_error_condition.notify_all()
+
+    def update_status(self, instance_id):
+        """Handle status message by sending a heartbeat."""
+        with self.brew_view_error_condition:
+            if not self.brew_view_down:
+                try:
+                    self._ez_client.instance_heartbeat(instance_id)
+                except (RequestsConnectionError, RestConnectionError):
+                    self.brew_view_down = True
+                    raise
+
+    def update_request(self, request, headers):
+        """Sends a Request update to beer-garden
+
+        Ephemeral requests do not get updated, so we simply skip them.
+
+        If brew-view appears to be down, it will wait for brew-view to come back
+         up before updating.
+
+        If this is the final attempt to update, we will attempt a known, good
+        request to give some information to the user. If this attempt fails
+        then we simply discard the message
+
+        :param request: The request to update
+        :param headers: A dictionary of headers from
+            `brewtils.request_consumer.RequestConsumer`
+        :raise RepublishMessageException: The Request update failed (any reason)
+        :return: None
+
+        """
+        if request.is_ephemeral:
+            sys.stdout.flush()
+            return
+
+        with self.brew_view_error_condition:
+
+            self._wait_for_brew_view_if_down(request)
+
+            try:
+                if not self._should_be_final_attempt(headers):
+                    self._wait_if_not_first_attempt(headers)
+                    self._ez_client.update_request(
+                        request.id,
+                        status=request.status,
+                        output=request.output,
+                        error_class=request.error_class,
+                    )
+                else:
+                    self._ez_client.update_request(
+                        request.id,
+                        status="ERROR",
+                        output="We tried to update the request, but it failed "
+                        "too many times. Please check the plugin logs "
+                        "to figure out why the request update failed. "
+                        "It is possible for this request to have "
+                        "succeeded, but we cannot update beer-garden "
+                        "with that information.",
+                        error_class="BGGivesUpError",
+                    )
+            except Exception as ex:
+                self._handle_request_update_failure(request, headers, ex)
+            finally:
+                sys.stdout.flush()
+
+    def _wait_if_not_first_attempt(self, headers):
+        if headers.get("retry_attempt", 0) > 0:
+            time_to_sleep = min(
+                headers.get("time_to_wait", self.starting_timeout), self.max_timeout
+            )
+            self._shutdown_event.wait(time_to_sleep)
+
+    def _handle_request_update_failure(self, request, headers, exc):
+
+        # If brew-view is down, we always want to try again
+        # Yes, even if it is the 'final_attempt'
+        if isinstance(exc, (RequestsConnectionError, RestConnectionError)):
+            self.brew_view_down = True
+            self.logger.error(
+                "Error updating request status: {0} exception: {1}".format(
+                    request.id, exc
+                )
+            )
+            raise RepublishRequestException(request, headers)
+
+        elif isinstance(exc, RestClientError):
+            message = (
+                "Error updating request {0} and it is a client error. Probable "
+                "cause is that this request is already updated. In which case, "
+                "ignore this message. If request {0} did not complete, please "
+                "file an issue. Discarding request to avoid an infinite loop. "
+                "exception: {1}".format(request.id, exc)
+            )
+            self.logger.error(message)
+            raise DiscardMessageException(message)
+
+        # Time to discard the message because we've given up
+        elif self._should_be_final_attempt(headers):
+            message = (
+                "Could not update request {0} even with a known good status, "
+                "output and error_class. We have reached the final attempt and "
+                "will now discard the message. Attempted to process this "
+                "message {1} times".format(request.id, headers["retry_attempt"])
+            )
+            self.logger.error(message)
+            raise DiscardMessageException(message)
+
+        else:
+            self._update_retry_attempt_information(headers)
+            self.logger.exception(
+                "Error updating request (Attempt #{0}: request: {1} exception: "
+                "{2}".format(headers.get("retry_attempt", 0), request.id, exc)
+            )
+            raise RepublishRequestException(request, headers)
+
+    def _update_retry_attempt_information(self, headers):
+        headers["retry_attempt"] = headers.get("retry_attempt", 0) + 1
+        headers["time_to_wait"] = min(
+            headers.get("time_to_wait", self.starting_timeout // 2) * 2,
+            self.max_timeout,
+        )
+
+    def _should_be_final_attempt(self, headers):
+        if self.max_attempts <= 0:
+            return False
+
+        return self.max_attempts <= headers.get("retry_attempt", 0)
+
+    def _wait_for_brew_view_if_down(self, request):
+        if self.brew_view_down and not self._shutdown_event.is_set():
+            self.logger.warning(
+                "Currently unable to communicate with Brew-view, about to wait "
+                "until connection is reestablished to update request %s",
+                request.id,
+            )
+            self.brew_view_error_condition.wait()
+
+    def _create_connection_poll_thread(self):
+        connection_poll_thread = threading.Thread(target=self._connection_poll)
+        connection_poll_thread.daemon = True
+        return connection_poll_thread
+
+    def _connection_poll(self):
+        """Periodically attempt to re-connect to beer-garden"""
+
+        while not self._shutdown_event.wait(5):
+            try:
+                with self.brew_view_error_condition:
+                    if self.brew_view_down:
+                        try:
+                            self._ez_client.get_version()
+                        except Exception:
+                            self.logger.debug("Brew-view reconnection attempt failure")
+                        else:
+                            self.logger.info(
+                                "Brew-view connection reestablished, about to "
+                                "notify any waiting requests"
+                            )
+                            self.brew_view_down = False
+                            self.brew_view_error_condition.notify_all()
+            except Exception as ex:
+                self.logger.exception("Exception in connection poll thread: %s", ex)

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -137,7 +137,11 @@ class RequestProcessor(object):
 
     def shutdown(self):
         """Stop the RequestProcessor"""
+        # Finish all current actions
         self._pool.shutdown(wait=True)
+
+        # Give the updater a chance to shutdown
+        self._updater.shutdown()
 
     def _parse(self, message):
         """Parse a message using the standard SchemaParser

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-
 import logging
+import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from multiprocessing import cpu_count
 
-import time
-from functools import partial
 from packaging.version import parse
 
+import brewtils.plugin
 from brewtils.errors import (
     FetchError,
     TimeoutExceededError,
@@ -16,7 +16,6 @@ from brewtils.errors import (
     ValidationError,
 )
 from brewtils.models import Request
-from brewtils.plugin import request_context
 from brewtils.rest.easy_client import EasyClient
 
 
@@ -336,13 +335,13 @@ class SystemClient(object):
         return request
 
     def _get_parent_for_request(self):
-        parent = getattr(request_context, "current_request", None)
+        parent = getattr(brewtils.plugin.request_context, "current_request", None)
         if parent is None:
             return None
 
         if (
-            request_context.bg_host.upper() != self._bg_host.upper()
-            or request_context.bg_port != self._bg_port
+            getattr(brewtils.plugin, "host").upper() != self._bg_host.upper()
+            or getattr(brewtils.plugin, "port") != self._bg_port
         ):
             self.logger.warning(
                 "A parent request was found, but the destination beer-garden "

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -340,8 +340,8 @@ class SystemClient(object):
             return None
 
         if (
-            getattr(brewtils.plugin, "host").upper() != self._bg_host.upper()
-            or getattr(brewtils.plugin, "port") != self._bg_port
+            getattr(brewtils.plugin, "_HOST").upper() != self._bg_host.upper()
+            or getattr(brewtils.plugin, "_PORT") != self._bg_port
         ):
             self.logger.warning(
                 "A parent request was found, but the destination beer-garden "

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1,37 +1,22 @@
 # -*- coding: utf-8 -*-
-
-import json
 import logging
 import logging.config
 import os
-import sys
 
 import pytest
-import threading
 from mock import MagicMock, Mock, ANY
-from requests import ConnectionError
 
 from brewtils import get_connection_info
 from brewtils.errors import (
     ValidationError,
-    RequestProcessingError,
-    DiscardMessageException,
-    RepublishRequestException,
     PluginValidationError,
-    RestClientError,
-    ErrorLogLevelCritical,
-    ErrorLogLevelError,
-    ErrorLogLevelWarning,
-    ErrorLogLevelInfo,
-    ErrorLogLevelDebug,
-    SuppressStacktrace,
     ConflictError,
+    DiscardMessageException,
+    RequestProcessingError,
 )
 from brewtils.log import DEFAULT_LOGGING_CONFIG
-from brewtils.models import Instance, Request, System, Command
+from brewtils.models import Instance, System, Command
 from brewtils.plugin import Plugin
-from brewtils.schema_parser import SchemaParser
-from brewtils.test.comparable import assert_request_equal
 
 
 @pytest.fixture(autouse=True)
@@ -61,12 +46,17 @@ def client():
 
 
 @pytest.fixture
-def parser():
+def parser_mock():
     return Mock()
 
 
 @pytest.fixture
-def plugin(client, bm_client, parser, bg_system, bg_instance):
+def updater_mock():
+    return Mock()
+
+
+@pytest.fixture
+def plugin(client, bm_client, parser_mock, updater_mock, bg_system, bg_instance):
     plugin = Plugin(
         client,
         bg_host="localhost",
@@ -76,7 +66,8 @@ def plugin(client, bm_client, parser, bg_system, bg_instance):
     )
     plugin.instance = bg_instance
     plugin.bm_client = bm_client
-    plugin.parser = parser
+    plugin.parser = parser_mock
+    plugin.request_updater = updater_mock
 
     return plugin
 
@@ -218,17 +209,7 @@ class TestPluginInit(object):
 
 
 class TestPluginRun(object):
-    @pytest.fixture
-    def create_connection_poll(self):
-        return Mock()
-
-    @pytest.fixture
-    def plugin(self, plugin, create_connection_poll):
-        plugin._initialize = Mock()
-        plugin._create_connection_poll_thread = create_connection_poll
-        return plugin
-
-    def test_run(self, plugin, create_connection_poll):
+    def test_run(self, plugin):
         admin_mock = Mock()
         standard_mock = Mock()
 
@@ -237,7 +218,7 @@ class TestPluginRun(object):
         plugin.shutdown_event = Mock(wait=Mock(return_value=True))
 
         plugin.run()
-        for moc in (admin_mock, standard_mock, create_connection_poll):
+        for moc in (admin_mock, standard_mock):
             assert moc.called is True
             assert moc.return_value.start.called is True
 
@@ -253,17 +234,14 @@ class TestPluginRun(object):
             isAlive=Mock(return_value=False),
             shutdown_event=Mock(is_set=Mock(return_value=False)),
         )
-        poll_mock = Mock(isAlive=Mock(return_value=False))
 
         plugin._create_admin_consumer = Mock(return_value=admin_mock)
         plugin._create_standard_consumer = Mock(return_value=request_mock)
-        plugin._create_connection_poll_thread = Mock(return_value=poll_mock)
         plugin.shutdown_event = Mock(wait=Mock(side_effect=[False, True]))
 
         plugin.run()
         assert admin_mock.start.call_count == 2
         assert request_mock.start.call_count == 2
-        assert poll_mock.start.call_count == 2
 
     def test_run_consumers_closed_by_server(self, plugin):
         admin_mock = Mock(
@@ -300,271 +278,6 @@ class TestPluginRun(object):
             assert moc.called is True
             assert moc.return_value.start.called is True
             assert moc.return_value.stop.called is True
-
-
-class TestProcessMessage(object):
-    @pytest.fixture
-    def update_mock(self):
-        return Mock()
-
-    @pytest.fixture
-    def invoke_mock(self):
-        return Mock()
-
-    @pytest.fixture
-    def plugin(self, plugin, update_mock, invoke_mock):
-        plugin._update_request = update_mock
-        plugin._invoke_command = invoke_mock
-        return plugin
-
-    def test_process(self, plugin, update_mock, invoke_mock):
-        target_mock = Mock()
-        request_mock = Mock(is_ephemeral=False)
-        format_mock = Mock()
-        plugin._format_output = format_mock
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        format_mock.assert_called_once_with(invoke_mock.return_value)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "SUCCESS"
-        assert request_mock.output == format_mock.return_value
-
-    def test_invoke_exception(self, caplog, plugin, update_mock, invoke_mock):
-        target_mock = Mock()
-        request_mock = Mock(is_json=False)
-        invoke_mock.side_effect = ValueError("I am an error")
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "ValueError"
-        assert request_mock.output == "I am an error"
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].exc_info is not False
-        assert caplog.records[0].levelno == logging.ERROR
-
-    def test_invoke_exception_no_trace(self, caplog, plugin, update_mock, invoke_mock):
-        class CustomException(SuppressStacktrace):
-            pass
-
-        target_mock = Mock()
-        request_mock = Mock(is_json=False)
-        invoke_mock.side_effect = CustomException("I am exception")
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "CustomException"
-        assert request_mock.output == "I am exception"
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].exc_info is False
-        assert caplog.records[0].levelno == logging.ERROR
-
-    @pytest.mark.parametrize(
-        "base,expected_level",
-        [
-            (ErrorLogLevelCritical, logging.CRITICAL),
-            (ErrorLogLevelError, logging.ERROR),
-            (ErrorLogLevelWarning, logging.WARNING),
-            (ErrorLogLevelInfo, logging.INFO),
-            (ErrorLogLevelDebug, logging.DEBUG),
-            (Exception, logging.ERROR),
-        ],
-    )
-    def test_invoke_exception_log_level(
-        self, caplog, plugin, update_mock, invoke_mock, base, expected_level
-    ):
-        target_mock = Mock()
-        request_mock = Mock(is_json=False)
-
-        exception = type("CustomException", (base,), {})
-        invoke_mock.side_effect = exception("I am exception")
-
-        with caplog.at_level(logging.DEBUG):
-            plugin.process_message(target_mock, request_mock, {})
-
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "CustomException"
-        assert request_mock.output == "I am exception"
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].levelno == expected_level
-
-    def test_invoke_exception_json_output(self, plugin, update_mock, invoke_mock):
-        target_mock = Mock()
-        request_mock = Mock(is_json=True)
-        invoke_mock.side_effect = ValueError("Not JSON")
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "ValueError"
-        assert json.loads(request_mock.output) == {
-            "message": "Not JSON",
-            "arguments": ["Not JSON"],
-            "attributes": {},
-        }
-
-    @pytest.mark.parametrize("ex_arg", [{"foo": "bar"}, json.dumps({"foo": "bar"})])
-    def test_format_json_args(self, plugin, invoke_mock, ex_arg):
-        target_mock = Mock()
-        request_mock = Mock(is_json=True)
-        invoke_mock.side_effect = Exception(ex_arg)
-
-        plugin.process_message(target_mock, request_mock, {})
-        assert json.loads(request_mock.output) == {"foo": "bar"}
-
-    def test_invoke_exception_attributes(self, plugin, update_mock, invoke_mock):
-        class MyError(Exception):
-            def __init__(self, foo):
-                self.foo = foo
-
-        target_mock = Mock()
-        request_mock = Mock(is_json=True)
-        exc = MyError("bar")
-        invoke_mock.side_effect = exc
-
-        # On python version 2, errors with custom attributes do not list those
-        # attributes as arguments.
-        if sys.version_info.major < 3:
-            arguments = []
-        else:
-            arguments = ["bar"]
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "MyError"
-        assert json.loads(request_mock.output) == {
-            "message": str(exc),
-            "arguments": arguments,
-            "attributes": {"foo": "bar"},
-        }
-
-    def test_invoke_exception_bad_attributes(self, plugin, update_mock, invoke_mock):
-        class MyError(Exception):
-            def __init__(self, foo):
-                self.foo = foo
-
-        target_mock = Mock()
-        request_mock = Mock(is_json=True)
-        message = MyError("another object")
-        thing = MyError(message)
-        invoke_mock.side_effect = thing
-
-        # On python version 2, errors with custom attributes do not list those
-        # attributes as arguments.
-        if sys.version_info.major < 3:
-            arguments = []
-        else:
-            arguments = [str(message)]
-
-        plugin.process_message(target_mock, request_mock, {})
-        invoke_mock.assert_called_once_with(target_mock, request_mock)
-        assert update_mock.call_count == 2
-        assert request_mock.status == "ERROR"
-        assert request_mock.error_class == "MyError"
-        assert json.loads(request_mock.output) == {
-            "message": str(thing),
-            "arguments": arguments,
-            "attributes": str(thing.__dict__),
-        }
-
-    def test_request_message(self, plugin, client):
-        message_mock = Mock()
-        pool_mock = Mock()
-        pre_process_mock = Mock()
-
-        plugin.pool = pool_mock
-        plugin._pre_process = pre_process_mock
-
-        plugin.process_request_message(message_mock, {})
-        pre_process_mock.assert_called_once_with(message_mock)
-        pool_mock.submit.assert_called_once_with(
-            plugin.process_message, client, pre_process_mock.return_value, {}
-        )
-
-    def test_completed_request_message(self, plugin):
-        message_mock = Mock()
-        pool_mock = Mock()
-        pre_process_mock = Mock(return_value=Mock(status="SUCCESS"))
-
-        plugin.pool = pool_mock
-        plugin._pre_process = pre_process_mock
-
-        plugin.process_request_message(message_mock, {})
-        pre_process_mock.assert_called_once_with(message_mock)
-        pool_mock.submit.assert_called_once_with(
-            plugin._update_request, pre_process_mock.return_value, {}
-        )
-
-    def test_admin_message(self, plugin):
-        message_mock = Mock()
-        pool_mock = Mock()
-        pre_process_mock = Mock()
-
-        plugin.admin_pool = pool_mock
-        plugin._pre_process = pre_process_mock
-
-        plugin.process_admin_message(message_mock, {})
-        pre_process_mock.assert_called_once_with(message_mock, verify_system=False)
-        pool_mock.submit.assert_called_once_with(
-            plugin.process_message, plugin, pre_process_mock.return_value, {}
-        )
-
-
-class TestPreProcess(object):
-    @pytest.mark.parametrize(
-        "request_args",
-        [
-            # Normal case
-            {"system": "system", "system_version": "1.0.0", "command_type": "ACTION"},
-            # Missing or ephemeral command types should succeed even with wrong names
-            {"system": "wrong", "system_version": "1.0.0"},
-            {"system": "wrong", "system_version": "1.0.0", "command_type": "EPHEMERAL"},
-        ],
-    )
-    def test_success(self, plugin, request_args):
-        # Need to reset the real parser
-        plugin.parser = SchemaParser()
-
-        assert_request_equal(
-            plugin._pre_process(json.dumps(request_args)),
-            SchemaParser.parse_request(request_args),
-        )
-
-    @pytest.mark.parametrize(
-        "request_args",
-        [
-            # Normal case
-            {"system": "wrong", "system_version": "1.0.0", "command_type": "ACTION"}
-        ],
-    )
-    def test_wrong_system(self, plugin, request_args):
-        # Need to reset the real parser
-        plugin.parser = SchemaParser()
-
-        with pytest.raises(DiscardMessageException):
-            plugin._pre_process(json.dumps(request_args))
-
-    def test_shutting_down(self, plugin):
-        plugin.shutdown_event.set()
-        with pytest.raises(RequestProcessingError):
-            plugin._pre_process(Mock())
-
-    def test_parse_error(self, plugin, parser):
-        parser.parse_request.side_effect = ValueError
-        with pytest.raises(DiscardMessageException):
-            plugin._pre_process(Mock())
 
 
 class TestInitializeSystem(object):
@@ -706,137 +419,12 @@ def test_create_admin_consumer(plugin, bg_instance):
     assert consumer._queue_name == bg_instance.queue_info["admin"]["name"]
 
 
-def test_create_connection_poll_thread(plugin):
-    connection_poll_thread = plugin._create_connection_poll_thread()
-    assert isinstance(connection_poll_thread, threading.Thread)
-    assert connection_poll_thread.daemon is True
-
-
-class TestInvokeCommand(object):
-    def test_invoke_admin(self, plugin):
-        start_mock = Mock()
-        plugin._start = start_mock
-
-        request = Request(
-            system="test_system",
-            system_version="1.0.0",
-            command="_start",
-            parameters={"p1": "param"},
-        )
-
-        plugin._invoke_command(plugin, request)
-        start_mock.assert_called_once_with(plugin, **request.parameters)
-
-    def test_invoke_request(self, plugin, client):
-        request = Request(
-            system="test_system",
-            system_version="1.0.0",
-            command="command",
-            parameters={"p1": "param"},
-        )
-
-        plugin._invoke_command(client, request)
-        client.command.assert_called_once_with(**request.parameters)
-
-    def test_invoke_request_none_parameters(self, plugin, client):
-        request = Request(
-            system="test_system", system_version="1.0.0", command="command"
-        )
-
-        plugin._invoke_command(client, request)
-        client.command.assert_called_once_with()
-
-    @pytest.mark.parametrize(
-        "command", ["foo", "_commands"]  # Missing attribute  # Non-callable attribute
-    )
-    def test_failure(self, plugin, client, command):
-        with pytest.raises(RequestProcessingError):
-            plugin._invoke_command(
-                client,
-                Request(
-                    system="name",
-                    system_version="1.0.0",
-                    command=command,
-                    parameters={"p1": "param"},
-                ),
-            )
-
-
-class TestUpdateRequest(object):
-    @pytest.mark.parametrize("ephemeral", [False, True])
-    def test_success(self, plugin, bm_client, ephemeral):
-        plugin._update_request(Mock(is_ephemeral=ephemeral), {})
-        assert bm_client.update_request.called is not ephemeral
-
-    @pytest.mark.parametrize(
-        "ex,raised,bv_down",
-        [
-            (RestClientError, DiscardMessageException, False),
-            (ConnectionError, RepublishRequestException, True),
-            (ValueError, RepublishRequestException, False),
-        ],
-    )
-    def test_errors(self, plugin, bm_client, bg_request, ex, raised, bv_down):
-        bm_client.update_request.side_effect = ex
-
-        with pytest.raises(raised):
-            plugin._update_request(bg_request, {})
-        assert bm_client.update_request.called is True
-        assert plugin.brew_view_down is bv_down
-
-    def test_wait_during_error(self, plugin, bm_client, bg_request):
-        error_condition_mock = MagicMock()
-        plugin.brew_view_error_condition = error_condition_mock
-        plugin.brew_view_down = True
-
-        plugin._update_request(bg_request, {})
-        assert error_condition_mock.wait.called is True
-        assert bm_client.update_request.called is True
-
-    def test_final_attempt_succeeds(self, plugin, bm_client, bg_request):
-        plugin.max_attempts = 1
-
-        plugin._update_request(bg_request, {"retry_attempt": 1, "time_to_wait": 5})
-        bm_client.update_request.assert_called_with(
-            bg_request.id,
-            status="ERROR",
-            output="We tried to update the request, but "
-            "it failed too many times. Please check "
-            "the plugin logs to figure out why the request "
-            "update failed. It is possible for this request to have "
-            "succeeded, but we cannot update beer-garden with that "
-            "information.",
-            error_class="BGGivesUpError",
-        )
-
-    def test_wait_if_in_headers(self, plugin, bg_request):
-        plugin.shutdown_event = Mock(wait=Mock(return_value=True))
-
-        plugin._update_request(bg_request, {"retry_attempt": 1, "time_to_wait": 1})
-        assert plugin.shutdown_event.wait.called is True
-
-    def test_update_request_headers(self, plugin, bm_client, bg_request):
-        plugin.shutdown_event = Mock(wait=Mock(return_value=True))
-        bm_client.update_request.side_effect = ValueError
-
-        with pytest.raises(RepublishRequestException) as ex:
-            plugin._update_request(bg_request, {"retry_attempt": 1, "time_to_wait": 5})
-        assert ex.value.headers["retry_attempt"] == 2
-        assert ex.value.headers["time_to_wait"] == 10
-
-    def test_update_request_final_attempt_fails(self, plugin, bm_client, bg_request):
-        plugin.max_attempts = 1
-        bm_client.update_request.side_effect = ValueError
-        with pytest.raises(DiscardMessageException):
-            plugin._update_request(bg_request, {"retry_attempt": 1})
-
-
 class TestAdminMethods(object):
     def test_start(self, plugin, bm_client, bg_instance):
         new_instance = Mock()
         bm_client.update_instance_status.return_value = new_instance
 
-        assert plugin._start(Mock())
+        assert plugin._start()
         bm_client.update_instance_status.assert_called_once_with(
             bg_instance.id, "RUNNING"
         )
@@ -846,30 +434,37 @@ class TestAdminMethods(object):
         new_instance = Mock()
         bm_client.update_instance_status.return_value = new_instance
 
-        assert plugin._stop(Mock())
+        assert plugin._stop()
         bm_client.update_instance_status.assert_called_once_with(
             bg_instance.id, "STOPPED"
         )
         assert plugin.instance == new_instance
         assert plugin.shutdown_event.is_set() is True
 
-    def test_status(self, plugin, bm_client):
-        plugin._status(Mock())
-        bm_client.instance_heartbeat.assert_called_once_with(plugin.instance.id)
+    def test_status(self, plugin, updater_mock):
+        plugin._status()
+        updater_mock.update_status.assert_called_once_with(plugin.instance.id)
 
-    @pytest.mark.parametrize(
-        "error,bv_down", [(ConnectionError, True), (ValueError, False)]
-    )
-    def test_status_error(self, plugin, bm_client, error, bv_down):
-        bm_client.instance_heartbeat.side_effect = error
-        with pytest.raises(error):
-            plugin._status(Mock())
-        assert plugin.brew_view_down is bv_down
 
-    def test_status_brew_view_down(self, plugin, bm_client):
-        plugin.brew_view_down = True
-        plugin._status(Mock())
-        assert bm_client.instance_heartbeat.called is False
+class TestValidationFunctions(object):
+    class TestVerifySystem(object):
+        def test_success(self, plugin, bg_request):
+            assert plugin._validate_system(bg_request) is None
+
+        def test_wrong_system(self, plugin, bg_request):
+            plugin.system.name = "wrong"
+
+            with pytest.raises(DiscardMessageException):
+                plugin._validate_system(bg_request)
+
+    class TestVerifyRunning(object):
+        def test_success(self, plugin, bg_request):
+            assert plugin._validate_running(bg_request) is None
+
+        def test_shutting_down(self, plugin):
+            plugin.shutdown_event.set()
+            with pytest.raises(RequestProcessingError):
+                plugin._validate_running(Mock())
 
 
 class TestSetupSystem(object):
@@ -981,47 +576,3 @@ class TestSetupSystem(object):
         assert new_system.icon_name == "icon"
         assert new_system.metadata == {"foo": "bar"}
         assert new_system.display_name == "display_name"
-
-
-class TestConnectionPoll(object):
-    def test_shut_down(self, plugin, bm_client):
-        plugin.shutdown_event.set()
-        plugin._connection_poll()
-        assert bm_client.get_version.called is False
-
-    def test_brew_view_normal(self, plugin, bm_client):
-        plugin.shutdown_event = Mock(wait=Mock(side_effect=[False, True]))
-        plugin._connection_poll()
-        assert bm_client.get_version.called is False
-
-    def test_brew_view_down(self, plugin, bm_client):
-        plugin.shutdown_event = Mock(wait=Mock(side_effect=[False, True]))
-        plugin.brew_view_down = True
-        bm_client.get_version.side_effect = ValueError
-
-        plugin._connection_poll()
-        assert bm_client.get_version.called is True
-        assert plugin.brew_view_down is True
-
-    def test_brew_view_back(self, plugin, bm_client):
-        plugin.shutdown_event = Mock(wait=Mock(side_effect=[False, True]))
-        plugin.brew_view_down = True
-
-        plugin._connection_poll()
-        assert bm_client.get_version.called is True
-        assert plugin.brew_view_down is False
-
-
-@pytest.mark.parametrize(
-    "output,expected",
-    [
-        ("foo", "foo"),
-        (u"foo", "foo"),
-        ({"foo": "bar"}, json.dumps({"foo": "bar"})),
-        (["foo", "bar"], json.dumps(["foo", "bar"])),
-        # TypeError
-        (Request(command="foo"), str(Request(command="foo"))),
-    ],
-)
-def test_format(plugin, output, expected):
-    assert plugin._format_output(output) == expected

--- a/test/request_handling_test.py
+++ b/test/request_handling_test.py
@@ -386,27 +386,6 @@ class TestEasyRequestUpdater(object):
         )
         return HTTPRequestUpdater(client, shutdown_event)
 
-    class TestUpdateStatus(object):
-        def test_success(self, updater, client):
-            instance_id = "1234"
-
-            updater.update_status(instance_id)
-            client.instance_heartbeat.assert_called_once_with(instance_id)
-
-        @pytest.mark.parametrize(
-            "error,bv_down", [(ConnectionError, True), (ValueError, False)]
-        )
-        def test_error(self, updater, client, error, bv_down):
-            client.instance_heartbeat.side_effect = error
-            with pytest.raises(error):
-                updater.update_status(Mock())
-            assert updater.brew_view_down is bv_down
-
-        def test_brew_view_down(self, updater, client):
-            updater.brew_view_down = True
-            updater.update_status(Mock())
-            assert client.instance_heartbeat.called is False
-
     class TestUpdateRequest(object):
         @pytest.mark.parametrize("ephemeral", [False, True])
         def test_success(self, updater, client, ephemeral):

--- a/test/request_handling_test.py
+++ b/test/request_handling_test.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+import sys
+import threading
+
+import pytest
+from mock import Mock, MagicMock, ANY
+from requests import ConnectionError
+
+from brewtils.errors import (
+    RequestProcessingError,
+    DiscardMessageException,
+    ErrorLogLevelCritical,
+    ErrorLogLevelError,
+    ErrorLogLevelWarning,
+    ErrorLogLevelInfo,
+    ErrorLogLevelDebug,
+    SuppressStacktrace,
+    RestClientError,
+    RepublishRequestException,
+)
+from brewtils.models import Request
+from brewtils.request_handling import RequestProcessor, EasyRequestUpdater
+from brewtils.schema_parser import SchemaParser
+from brewtils.test.comparable import assert_request_equal
+
+
+class CustomException(SuppressStacktrace):
+    pass
+
+
+class TestRequestProcessor(object):
+    @pytest.fixture
+    def target_mock(self):
+        return Mock()
+
+    @pytest.fixture
+    def updater_mock(self):
+        return Mock()
+
+    @pytest.fixture
+    def processor(self, target_mock, updater_mock):
+        return RequestProcessor(target_mock, updater_mock, max_workers=1)
+
+    @pytest.fixture
+    def invoke_mock(self, processor):
+        invoke_mock = Mock()
+        processor._invoke_command = invoke_mock
+        return invoke_mock
+
+    @pytest.fixture
+    def format_mock(self, processor):
+        format_mock = Mock()
+        processor._format_output = format_mock
+        return format_mock
+
+    @pytest.fixture
+    def pool_mock(self, processor):
+        pool_mock = Mock()
+        processor._pool = pool_mock
+        return pool_mock
+
+    @pytest.fixture
+    def format_error_mock(self, processor):
+        format_error_mock = Mock()
+        processor._format_error_output = format_error_mock
+        return format_error_mock
+
+    class TestOnMessageReceived(object):
+        def test_completed(self, processor, pool_mock):
+            processor.on_message_received(json.dumps({"status": "SUCCESS"}), {})
+            assert pool_mock.submit.called is True
+            assert pool_mock.submit.call_args[0][0] == processor._updater.update_request
+
+        def test_non_completed(self, processor, pool_mock):
+            processor.on_message_received(json.dumps({"status": "CREATED"}), {})
+            assert pool_mock.submit.called is True
+            assert pool_mock.submit.call_args[0][0] == processor.process_message
+
+        def test_parse_error(self, processor):
+            with pytest.raises(DiscardMessageException):
+                processor.on_message_received("not json", {})
+
+        def test_validation_func(self, processor):
+            validation_mock = Mock()
+            processor._validation_funcs = [validation_mock]
+
+            processor.on_message_received("{}", {})
+            assert validation_mock.called is True
+
+    class TestProcessMessage(object):
+        def test_process(
+            self, processor, target_mock, updater_mock, invoke_mock, format_mock
+        ):
+            request_mock = Mock(is_ephemeral=False)
+
+            processor.process_message(target_mock, request_mock, {})
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            format_mock.assert_called_once_with(invoke_mock.return_value)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "SUCCESS"
+            assert request_mock.output == format_mock.return_value
+
+        @pytest.mark.parametrize(
+            "ex,has_stacktrace",
+            [
+                (ValueError("I'm an error"), True),
+                (CustomException("I'm an error"), False),
+            ],
+        )
+        def test_invoke_exception(
+            self,
+            caplog,
+            processor,
+            target_mock,
+            updater_mock,
+            invoke_mock,
+            format_error_mock,
+            ex,
+            has_stacktrace,
+        ):
+            request_mock = Mock(is_json=False)
+            invoke_mock.side_effect = ex
+
+            processor.process_message(target_mock, request_mock, {})
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "ERROR"
+            assert request_mock.error_class == type(ex).__name__
+            assert request_mock.output == format_error_mock.return_value
+
+            assert len(caplog.records) == 1
+            assert bool(caplog.records[0].exc_info) == has_stacktrace
+            assert caplog.records[0].levelno == logging.ERROR
+
+        @pytest.mark.parametrize(
+            "base,expected_level",
+            [
+                (ErrorLogLevelCritical, logging.CRITICAL),
+                (ErrorLogLevelError, logging.ERROR),
+                (ErrorLogLevelWarning, logging.WARNING),
+                (ErrorLogLevelInfo, logging.INFO),
+                (ErrorLogLevelDebug, logging.DEBUG),
+                (Exception, logging.ERROR),
+            ],
+        )
+        def test_invoke_exception_log_level(
+            self,
+            caplog,
+            processor,
+            target_mock,
+            invoke_mock,
+            updater_mock,
+            base,
+            expected_level,
+        ):
+            request_mock = Mock(is_json=False)
+
+            exception = type("CustomException", (base,), {})
+            invoke_mock.side_effect = exception("I am exception")
+
+            with caplog.at_level(logging.DEBUG):
+                processor.process_message(target_mock, request_mock, {})
+
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "ERROR"
+            assert request_mock.error_class == "CustomException"
+            assert request_mock.output == "I am exception"
+
+            assert len(caplog.records) == 1
+            assert caplog.records[0].levelno == expected_level
+
+        def test_invoke_exception_json_output(
+            self, processor, target_mock, updater_mock, invoke_mock
+        ):
+            request_mock = Mock(is_json=True)
+            invoke_mock.side_effect = ValueError("Not JSON")
+
+            processor.process_message(target_mock, request_mock, {})
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "ERROR"
+            assert request_mock.error_class == "ValueError"
+            assert json.loads(request_mock.output) == {
+                "message": "Not JSON",
+                "arguments": ["Not JSON"],
+                "attributes": {},
+            }
+
+        @pytest.mark.parametrize("ex_arg", [{"foo": "bar"}, json.dumps({"foo": "bar"})])
+        def test_format_json_args(self, processor, target_mock, invoke_mock, ex_arg):
+            request_mock = Mock(is_json=True)
+            invoke_mock.side_effect = Exception(ex_arg)
+
+            processor.process_message(target_mock, request_mock, {})
+            assert json.loads(request_mock.output) == {"foo": "bar"}
+
+        def test_invoke_exception_attributes(
+            self, processor, target_mock, updater_mock, invoke_mock
+        ):
+            class MyError(Exception):
+                def __init__(self, foo):
+                    self.foo = foo
+
+            request_mock = Mock(is_json=True)
+            exc = MyError("bar")
+            invoke_mock.side_effect = exc
+
+            # On python version 2, errors with custom attributes do not list those
+            # attributes as arguments.
+            if sys.version_info.major < 3:
+                arguments = []
+            else:
+                arguments = ["bar"]
+
+            processor.process_message(target_mock, request_mock, {})
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "ERROR"
+            assert request_mock.error_class == "MyError"
+            assert json.loads(request_mock.output) == {
+                "message": str(exc),
+                "arguments": arguments,
+                "attributes": {"foo": "bar"},
+            }
+
+        def test_invoke_exception_bad_attributes(
+            self, processor, target_mock, updater_mock, invoke_mock
+        ):
+            class MyError(Exception):
+                def __init__(self, foo):
+                    self.foo = foo
+
+            request_mock = Mock(is_json=True)
+            message = MyError("another object")
+            thing = MyError(message)
+            invoke_mock.side_effect = thing
+
+            # On python version 2, errors with custom attributes do not list those
+            # attributes as arguments.
+            if sys.version_info.major < 3:
+                arguments = []
+            else:
+                arguments = [str(message)]
+
+            processor.process_message(target_mock, request_mock, {})
+            invoke_mock.assert_called_once_with(target_mock, request_mock)
+            assert updater_mock.update_request.call_count == 2
+            assert request_mock.status == "ERROR"
+            assert request_mock.error_class == "MyError"
+            assert json.loads(request_mock.output) == {
+                "message": str(thing),
+                "arguments": arguments,
+                "attributes": str(thing.__dict__),
+            }
+
+        @pytest.mark.parametrize(
+            "output,expected",
+            [
+                ("foo", "foo"),
+                (u"foo", "foo"),
+                ({"foo": "bar"}, json.dumps({"foo": "bar"})),
+                (["foo", "bar"], json.dumps(["foo", "bar"])),
+                # TypeError
+                (Request(command="foo"), str(Request(command="foo"))),
+            ],
+        )
+        def test_format(self, processor, output, expected):
+            assert processor._format_output(output) == expected
+
+        @pytest.mark.skip
+        def test_request_message(self, plugin, client):
+            message_mock = Mock()
+            pool_mock = Mock()
+            pre_process_mock = Mock()
+
+            plugin.pool = pool_mock
+            plugin._pre_process = pre_process_mock
+
+            plugin.process_request_message(message_mock, {})
+            pre_process_mock.assert_called_once_with(message_mock)
+            pool_mock.submit.assert_called_once_with(
+                plugin.process_message, client, pre_process_mock.return_value, {}
+            )
+
+        @pytest.mark.skip
+        def test_completed_request_message(self, plugin):
+            message_mock = Mock()
+            pool_mock = Mock()
+            pre_process_mock = Mock(return_value=Mock(status="SUCCESS"))
+
+            plugin.pool = pool_mock
+            plugin._pre_process = pre_process_mock
+
+            plugin.process_request_message(message_mock, {})
+            pre_process_mock.assert_called_once_with(message_mock)
+            pool_mock.submit.assert_called_once_with(
+                plugin._update_request, pre_process_mock.return_value, {}
+            )
+
+        @pytest.mark.skip
+        def test_admin_message(self, plugin):
+            message_mock = Mock()
+            pool_mock = Mock()
+            pre_process_mock = Mock()
+
+            plugin.admin_pool = pool_mock
+            plugin._pre_process = pre_process_mock
+
+            plugin.process_admin_message(message_mock, {})
+            pre_process_mock.assert_called_once_with(message_mock, verify_system=False)
+            pool_mock.submit.assert_called_once_with(
+                plugin.process_message, plugin, pre_process_mock.return_value, {}
+            )
+
+    class TestParse(object):
+        def test_success(self, processor, bg_request):
+            serialized = SchemaParser.serialize_request(bg_request)
+            assert_request_equal(processor._parse(serialized), bg_request)
+
+        def test_parse_error(self, processor):
+            with pytest.raises(DiscardMessageException):
+                processor._parse("Not a Request")
+
+    class TestInvokeCommand(object):
+        @pytest.mark.parametrize(
+            "command,parameters", [("start", {}), ("echo", {"p1": "param"})]
+        )
+        def test_success(self, processor, target_mock, command, parameters):
+            request = Request(command=command, parameters=parameters)
+
+            ret_val = processor._invoke_command(target_mock, request)
+            assert ret_val == getattr(target_mock, command).return_value
+            getattr(target_mock, command).assert_called_once_with(**parameters)
+
+        def test_success_none_parameters(self, processor, target_mock):
+            command = "start"
+            request = Request(command=command, parameters=None)
+
+            ret_val = processor._invoke_command(target_mock, request)
+            assert ret_val == getattr(target_mock, command).return_value
+            getattr(target_mock, command).assert_called_once_with()
+
+        def test_missing_attribute(self, processor, target_mock):
+            target_mock.mock_add_spec("other_command")
+
+            request = Request(command="command", parameters={})
+
+            with pytest.raises(RequestProcessingError):
+                processor._invoke_command(target_mock, request)
+
+        def test_non_callable_attribute(self, processor, target_mock):
+            target_mock.command = "this should be a function"
+
+            request = Request(command="command", parameters={})
+
+            with pytest.raises(RequestProcessingError):
+                processor._invoke_command(target_mock, request)
+
+
+class TestEasyRequestUpdater(object):
+    @pytest.fixture
+    def client(self):
+        return Mock()
+
+    @pytest.fixture
+    def shutdown_event(self):
+        event = Mock(name="shutdown mock")
+        event.is_set.return_value = False
+        event.wait.return_value = False
+        return event
+
+    @pytest.fixture
+    def conn_poll_thread(self):
+        return Mock()
+
+    @pytest.fixture
+    def updater(self, monkeypatch, client, shutdown_event, conn_poll_thread):
+        # Unless we're testing it we don't want to create an actual conn poll thread
+        monkeypatch.setattr(
+            EasyRequestUpdater,
+            "_create_connection_poll_thread",
+            Mock(return_value=conn_poll_thread),
+        )
+        return EasyRequestUpdater(client, shutdown_event)
+
+    class TestUpdateStatus(object):
+        def test_success(self, updater, client):
+            instance_id = "1234"
+
+            updater.update_status(instance_id)
+            client.instance_heartbeat.assert_called_once_with(instance_id)
+
+        @pytest.mark.parametrize(
+            "error,bv_down", [(ConnectionError, True), (ValueError, False)]
+        )
+        def test_error(self, updater, client, error, bv_down):
+            client.instance_heartbeat.side_effect = error
+            with pytest.raises(error):
+                updater.update_status(Mock())
+            assert updater.brew_view_down is bv_down
+
+        def test_brew_view_down(self, updater, client):
+            updater.brew_view_down = True
+            updater.update_status(Mock())
+            assert client.instance_heartbeat.called is False
+
+    class TestUpdateRequest(object):
+        @pytest.mark.parametrize("ephemeral", [False, True])
+        def test_success(self, updater, client, ephemeral):
+            updater.update_request(Mock(is_ephemeral=ephemeral), {})
+            assert client.update_request.called is not ephemeral
+
+        @pytest.mark.parametrize(
+            "ex,raised,bv_down",
+            [
+                (RestClientError, DiscardMessageException, False),
+                (ConnectionError, RepublishRequestException, True),
+                (ValueError, RepublishRequestException, False),
+            ],
+        )
+        def test_errors(self, updater, client, bg_request, ex, raised, bv_down):
+            client.update_request.side_effect = ex
+
+            with pytest.raises(raised):
+                updater.update_request(bg_request, {})
+            assert client.update_request.called is True
+            assert updater.brew_view_down is bv_down
+
+        def test_wait_during_error(self, updater, client, bg_request):
+            error_condition_mock = MagicMock()
+            updater.brew_view_error_condition = error_condition_mock
+            updater.brew_view_down = True
+
+            updater.update_request(bg_request, {})
+            assert error_condition_mock.wait.called is True
+            assert client.update_request.called is True
+
+        def test_final_attempt_succeeds(self, updater, client, bg_request):
+            updater.max_attempts = 1
+
+            updater.update_request(bg_request, {"retry_attempt": 1, "time_to_wait": 5})
+            client.update_request.assert_called_with(
+                bg_request.id, status="ERROR", output=ANY, error_class="BGGivesUpError"
+            )
+
+        def test_wait_if_in_headers(self, updater, shutdown_event, bg_request):
+            updater.update_request(bg_request, {"retry_attempt": 1, "time_to_wait": 1})
+            assert shutdown_event.wait.called is True
+
+        def test_update_request_headers(self, updater, client, bg_request):
+            client.update_request.side_effect = ValueError
+
+            with pytest.raises(RepublishRequestException) as ex:
+                updater.update_request(
+                    bg_request, {"retry_attempt": 1, "time_to_wait": 5}
+                )
+            assert ex.value.headers["retry_attempt"] == 2
+            assert ex.value.headers["time_to_wait"] == 10
+
+        def test_update_request_final_attempt_fails(self, updater, client, bg_request):
+            updater.max_attempts = 1
+            client.update_request.side_effect = ValueError
+            with pytest.raises(DiscardMessageException):
+                updater.update_request(bg_request, {"retry_attempt": 1})
+
+    class TestConnectionPoll(object):
+        def test_shut_down(self, updater, client, shutdown_event):
+            shutdown_event.wait.return_value = True
+
+            updater._connection_poll()
+            assert client.get_version.called is False
+
+        def test_brew_view_normal(self, updater, client, shutdown_event):
+            shutdown_event.wait.side_effect = [False, True]
+
+            updater._connection_poll()
+            assert client.get_version.called is False
+
+        def test_brew_view_down(self, updater, client, shutdown_event):
+            shutdown_event.wait.side_effect = [False, True]
+            updater.brew_view_down = True
+            client.get_version.side_effect = ValueError
+
+            updater._connection_poll()
+            assert client.get_version.called is True
+            assert updater.brew_view_down is True
+
+        def test_brew_view_back(self, updater, client, shutdown_event):
+            shutdown_event.wait.side_effect = [False, True]
+            updater.brew_view_down = True
+
+            updater._connection_poll()
+            assert client.get_version.called is True
+            assert updater.brew_view_down is False
+
+        def test_never_die(self, monkeypatch, updater, client, shutdown_event):
+            monkeypatch.setattr(updater, "brew_view_error_condition", None)
+            shutdown_event.wait.side_effect = [False, True]
+
+            # Test passes if this doesn't raise
+            updater._connection_poll()
+
+    def test_create_connection_poll_thread(self, client):
+        shutdown_event = threading.Event()
+        updater = EasyRequestUpdater(client, shutdown_event)
+
+        assert isinstance(updater.connection_poll_thread, threading.Thread)
+        assert updater.connection_poll_thread.daemon is True
+        assert updater.connection_poll_thread.is_alive()
+
+        shutdown_event.set()
+        updater.connection_poll_thread.join()
+        assert not updater.connection_poll_thread.is_alive()

--- a/test/request_handling_test.py
+++ b/test/request_handling_test.py
@@ -21,7 +21,7 @@ from brewtils.errors import (
     RepublishRequestException,
 )
 from brewtils.models import Request
-from brewtils.request_handling import RequestProcessor, EasyRequestUpdater
+from brewtils.request_handling import RequestProcessor, HTTPRequestUpdater
 from brewtils.schema_parser import SchemaParser
 from brewtils.test.comparable import assert_request_equal
 
@@ -380,11 +380,11 @@ class TestEasyRequestUpdater(object):
     def updater(self, monkeypatch, client, shutdown_event, conn_poll_thread):
         # Unless we're testing it we don't want to create an actual conn poll thread
         monkeypatch.setattr(
-            EasyRequestUpdater,
+            HTTPRequestUpdater,
             "_create_connection_poll_thread",
             Mock(return_value=conn_poll_thread),
         )
-        return EasyRequestUpdater(client, shutdown_event)
+        return HTTPRequestUpdater(client, shutdown_event)
 
     class TestUpdateStatus(object):
         def test_success(self, updater, client):
@@ -505,7 +505,7 @@ class TestEasyRequestUpdater(object):
 
     def test_create_connection_poll_thread(self, client):
         shutdown_event = threading.Event()
-        updater = EasyRequestUpdater(client, shutdown_event)
+        updater = HTTPRequestUpdater(client, shutdown_event)
 
         assert isinstance(updater.connection_poll_thread, threading.Thread)
         assert updater.connection_poll_thread.daemon is True

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -168,8 +168,8 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(brewtils.plugin, "host", "localhost")
-        monkeypatch.setattr(brewtils.plugin, "port", 3000)
+        monkeypatch.setattr(brewtils.plugin, "_HOST", "localhost")
+        monkeypatch.setattr(brewtils.plugin, "_PORT", 3000)
 
         client.command_1()
 
@@ -184,8 +184,8 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(brewtils.plugin, "host", "OTHER_HOST")
-        monkeypatch.setattr(brewtils.plugin, "port", 3000)
+        monkeypatch.setattr(brewtils.plugin, "_HOST", "OTHER_HOST")
+        monkeypatch.setattr(brewtils.plugin, "_PORT", 3000)
 
         client.command_1()
 

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -153,7 +153,7 @@ class TestCreateRequest(object):
     @pytest.mark.parametrize("context", [None, Mock(current_request=None)])
     def test_no_context(self, monkeypatch, client, easy_client, mock_success, context):
         easy_client.create_request.return_value = mock_success
-        monkeypatch.setattr(brewtils.rest.system_client, "request_context", context)
+        monkeypatch.setattr(brewtils.plugin, "request_context", context)
 
         client.command_1()
 
@@ -165,10 +165,11 @@ class TestCreateRequest(object):
     ):
         easy_client.create_request.return_value = mock_success
 
-        context = Mock(
-            current_request=parent_request, bg_host="localhost", bg_port=3000
+        monkeypatch.setattr(
+            brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(brewtils.rest.system_client, "request_context", context)
+        monkeypatch.setattr(brewtils.plugin, "host", "localhost")
+        monkeypatch.setattr(brewtils.plugin, "port", 3000)
 
         client.command_1()
 
@@ -180,8 +181,11 @@ class TestCreateRequest(object):
     ):
         easy_client.create_request.return_value = mock_success
 
-        context = Mock(current_request=parent_request, bg_host="OTHER", bg_port=3000)
-        monkeypatch.setattr(brewtils.rest.system_client, "request_context", context)
+        monkeypatch.setattr(
+            brewtils.plugin, "request_context", Mock(current_request=parent_request)
+        )
+        monkeypatch.setattr(brewtils.plugin, "host", "OTHER_HOST")
+        monkeypatch.setattr(brewtils.plugin, "port", 3000)
 
         client.command_1()
 


### PR DESCRIPTION
This PR is is the first step for being able to support different Beergarden entry points from the plugin perspective.

Currently request processing is completely dependent on the HTTP entry point existing. This needs to be generalized in order to make alternate entry points viable.

Specifically, this PR mostly moves functionality out of the `Plugin` definition.

Previously the `Plugin` would create two `RequestConsumers` that were responsible for connecting to rabbit and listening for messages, but the `Plugin` implemented all functionality relating to parsing requests, updating their status, invoking the command, and managing the status of the brew-view connection.

This PR breaks the functionality into pieces:

- A `RequestProcessor` is now responsible for implementing coordinating request processing. There is only one implementation, but the `Plugin` will have separate instances for the admin queue and request queue. It's responsible for:
  - Defining the `on_message_received` callback that will be invoked by the `RequestConsumer`
  - Parsing the request
  - Invoking the command
  - Formatting the output
  - Passing request updates to its `RequestUpdater`
- A `RequestUpdater` is responsible for updating request status. Currently there are two concrete implementations:
  - `EasyRequestUpdater` uses an `EasyClient` and is almost identical to how request updating occurred previously.
  - `NoopUpdater` explicitly does not update requests. This is useful for dealing with ephemeral requests that don't need to be updated.
- This PR does not modify the `RequestConsumer`. 

Going forward, I would like the `RequestProcessor` to be responsible for the `RequestConsumer`(s). So the `Plugin` would only know about its `RequestProcessor`(s), and everything related to the listening, parsing, processing, and updating of messages would be the responsibility of the `RequestProcessor` class. However, that's not part of this PR.

There are a couple substantive changes in this PR:

- The sanity check that we do for making sure that nested requests are being sent to the same Beergarden (host and port check) has changed slightly. Instead of the `bg_host` and `bg_port` being put on the request context those values are now invariant globals that are set once at Plugin creation time. This prevents the `RequestProcessor` from needing to know any information about *how* the plugin is connected to Beergarden since that's no longer in its purview. Also, this will most likely be changing again as we nail down namespaces.
- The `EasyRequestUpdater` maintains the concept of a thread that will periodically poll for a connection when in the "brew-view is down" state. However, since the `EasyRequestUpdater` is not a thread itself there's no way to maintain the same periodic check to see if the connection poll thread itself has died. To mitigate this the connection poll target function has been wrapped in a try that should prevent it from dying. An alternative would be to have the Plugin itself reach into the `EasyRequestUpdater` during it's periodic aliveness checks, but I'd like to avoid that if possible as it doesn't seem very clean - we'd have to add that to the `RequestUpdater` interface.
