### PR TITLE
SchemaParser serialize now works for collections of models

### DIFF
--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
+import json
 import logging
 import warnings
+from collections import Iterable
 
 import six
 
@@ -414,17 +415,26 @@ class SchemaParser(object):
 
     @classmethod
     def serialize(cls, model, to_string=False, **kwargs):
-        """Convert a model object into a dictionary or JSON string.
+        """Convert a model object or list of models into a dictionary or JSON string.
 
         Args:
-            model: The model
+            model: The model or model list
             to_string: True to generate a JSON string, False to generate a dictionary
-            **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+            **kwargs: Additional parameters to be passed to the Schema.
+                Note that the 'many' parameter will be set correctly automatically.
 
         Returns:
             A serialized model representation
 
         """
+        if isinstance(model, Iterable):
+            # Explicitly force to_string to False so only original call returns a string
+            multiple = [cls.serialize(x, to_string=False, **kwargs) for x in model]
+            return json.dumps(multiple) if to_string else multiple
+
+        # At this point we know model is not an iterable, so force this to False
+        kwargs["many"] = False
+
         # Use type(model) here because Command has an instance attribute named "schema"
         schema = getattr(brewtils.schemas, type(model).schema)(**kwargs)
 

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -43,7 +43,7 @@ class TestParse(object):
             ("bad bad bad", {}, MarshmallowError),
         ],
     )
-    def test_parse_error(self, data, kwargs, error):
+    def test_error(self, data, kwargs, error):
         parser = SchemaParser()
         with pytest.raises(error):
             parser.parse_system(data, **kwargs)
@@ -61,226 +61,188 @@ class TestParse(object):
         assert system_copy == system_dict
 
     @pytest.mark.parametrize(
-        "model,data,kwargs,assertion,expected",
+        "model,data,assertion,expected",
         [
-            (
-                brewtils.models.System,
-                {},
-                {"from_string": False},
-                assert_system_equal,
-                System(),
-            ),
-            (
-                brewtils.models.System,
-                "{}",
-                {"from_string": True},
-                assert_system_equal,
-                System(),
-            ),
+            (brewtils.models.System, {}, assert_system_equal, System()),
             (
                 brewtils.models.System,
                 lazy_fixture("system_dict"),
-                {},
                 assert_system_equal,
                 lazy_fixture("bg_system"),
             ),
             (
                 brewtils.models.Instance,
                 lazy_fixture("instance_dict"),
-                {},
                 assert_instance_equal,
                 lazy_fixture("bg_instance"),
             ),
             (
                 brewtils.models.Command,
                 lazy_fixture("command_dict"),
-                {},
                 assert_command_equal,
                 lazy_fixture("bg_command"),
             ),
             (
                 brewtils.models.Parameter,
                 lazy_fixture("parameter_dict"),
-                {},
                 assert_parameter_equal,
                 lazy_fixture("bg_parameter"),
             ),
             (
                 brewtils.models.Request,
                 lazy_fixture("request_dict"),
-                {},
                 assert_request_equal,
                 lazy_fixture("bg_request"),
             ),
             (
                 brewtils.models.LoggingConfig,
                 lazy_fixture("logging_config_dict"),
-                {},
                 assert_logging_config_equal,
                 lazy_fixture("bg_logging_config"),
             ),
             (
                 brewtils.models.Event,
                 lazy_fixture("event_dict"),
-                {},
                 assert_event_equal,
                 lazy_fixture("bg_event"),
             ),
             (
                 brewtils.models.Queue,
                 lazy_fixture("queue_dict"),
-                {},
                 assert_queue_equal,
                 lazy_fixture("bg_queue"),
             ),
             (
                 brewtils.models.Principal,
                 lazy_fixture("principal_dict"),
-                {},
                 assert_principal_equal,
                 lazy_fixture("bg_principal"),
             ),
             (
                 brewtils.models.Role,
                 lazy_fixture("role_dict"),
-                {},
                 assert_role_equal,
                 lazy_fixture("bg_role"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_job"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("cron_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_cron_job"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("interval_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_interval_job"),
             ),
         ],
     )
-    def test_parse(self, model, data, kwargs, assertion, expected):
-        assertion(SchemaParser.parse(data, model, **kwargs), expected)
+    def test_single(self, model, data, assertion, expected):
+        assertion(SchemaParser.parse(data, model, from_string=False), expected)
+
+    def test_single_from_string(self):
+        assert_system_equal(
+            SchemaParser.parse("{}", brewtils.models.System, from_string=True), System()
+        )
 
     @pytest.mark.parametrize(
-        "method,data,kwargs,assertion,expected",
+        "method,data,assertion,expected",
         [
-            ("parse_system", {}, {"from_string": False}, assert_system_equal, System()),
-            (
-                "parse_system",
-                "{}",
-                {"from_string": True},
-                assert_system_equal,
-                System(),
-            ),
+            ("parse_system", {}, assert_system_equal, System()),
             (
                 "parse_system",
                 lazy_fixture("system_dict"),
-                {},
                 assert_system_equal,
                 lazy_fixture("bg_system"),
             ),
             (
                 "parse_instance",
                 lazy_fixture("instance_dict"),
-                {},
                 assert_instance_equal,
                 lazy_fixture("bg_instance"),
             ),
             (
                 "parse_command",
                 lazy_fixture("command_dict"),
-                {},
                 assert_command_equal,
                 lazy_fixture("bg_command"),
             ),
             (
                 "parse_parameter",
                 lazy_fixture("parameter_dict"),
-                {},
                 assert_parameter_equal,
                 lazy_fixture("bg_parameter"),
             ),
             (
                 "parse_request",
                 lazy_fixture("request_dict"),
-                {},
                 assert_request_equal,
                 lazy_fixture("bg_request"),
             ),
             (
                 "parse_logging_config",
                 lazy_fixture("logging_config_dict"),
-                {},
                 assert_logging_config_equal,
                 lazy_fixture("bg_logging_config"),
             ),
             (
                 "parse_event",
                 lazy_fixture("event_dict"),
-                {},
                 assert_event_equal,
                 lazy_fixture("bg_event"),
             ),
             (
                 "parse_queue",
                 lazy_fixture("queue_dict"),
-                {},
                 assert_queue_equal,
                 lazy_fixture("bg_queue"),
             ),
             (
                 "parse_principal",
                 lazy_fixture("principal_dict"),
-                {},
                 assert_principal_equal,
                 lazy_fixture("bg_principal"),
             ),
             (
                 "parse_role",
                 lazy_fixture("role_dict"),
-                {},
                 assert_role_equal,
                 lazy_fixture("bg_role"),
             ),
             (
                 "parse_job",
                 lazy_fixture("job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_job"),
             ),
             (
                 "parse_job",
                 lazy_fixture("cron_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_cron_job"),
             ),
             (
                 "parse_job",
                 lazy_fixture("interval_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_interval_job"),
             ),
         ],
     )
-    def test_parse_specific(self, method, data, kwargs, assertion, expected):
+    def test_single_specific(self, method, data, assertion, expected):
         parser = SchemaParser()
-        actual = getattr(parser, method)(data, **kwargs)
+        actual = getattr(parser, method)(data, from_string=False)
         assertion(expected, actual)
+
+    def test_single_specific_from_string(self):
+        assert_system_equal(SchemaParser.parse_system("{}", from_string=True), System())
 
     @pytest.mark.parametrize(
         "data,kwargs",
@@ -290,12 +252,12 @@ class TestParse(object):
             (lazy_fixture("patch_no_envelop_dict"), {}),
         ],
     )
-    def test_parse_patch(self, bg_patch1, data, kwargs):
+    def test_patch(self, bg_patch1, data, kwargs):
         parser = SchemaParser()
         actual = parser.parse_patch(data, **kwargs)[0]
         assert_patch_equal(actual, bg_patch1)
 
-    def test_parse_patch_many(self, patch_many_dict, bg_patch1, bg_patch2):
+    def test_patch_many(self, patch_many_dict, bg_patch1, bg_patch2):
         parser = SchemaParser()
         patches = sorted(
             parser.parse_patch(patch_many_dict, many=True), key=lambda x: x.operation
@@ -306,174 +268,119 @@ class TestParse(object):
 
 class TestSerialize(object):
     @pytest.mark.parametrize(
-        "model,kwargs,expected",
+        "model,expected",
         [
-            (
-                lazy_fixture("bg_system"),
-                {"to_string": False},
-                lazy_fixture("system_dict"),
-            ),
-            (
-                lazy_fixture("bg_instance"),
-                {"to_string": False},
-                lazy_fixture("instance_dict"),
-            ),
-            (
-                lazy_fixture("bg_command"),
-                {"to_string": False},
-                lazy_fixture("command_dict"),
-            ),
-            (
-                lazy_fixture("bg_parameter"),
-                {"to_string": False},
-                lazy_fixture("parameter_dict"),
-            ),
-            (
-                lazy_fixture("bg_request"),
-                {"to_string": False},
-                lazy_fixture("request_dict"),
-            ),
-            (
-                lazy_fixture("bg_patch1"),
-                {"to_string": False},
-                lazy_fixture("patch_dict"),
-            ),
-            (
-                lazy_fixture("bg_logging_config"),
-                {"to_string": False},
-                lazy_fixture("logging_config_dict"),
-            ),
-            (
-                lazy_fixture("bg_event"),
-                {"to_string": False},
-                lazy_fixture("event_dict"),
-            ),
-            (
-                lazy_fixture("bg_queue"),
-                {"to_string": False},
-                lazy_fixture("queue_dict"),
-            ),
-            (
-                lazy_fixture("bg_principal"),
-                {"to_string": False},
-                lazy_fixture("principal_dict"),
-            ),
-            (lazy_fixture("bg_role"), {"to_string": False}, lazy_fixture("role_dict")),
-            (lazy_fixture("bg_job"), {"to_string": False}, lazy_fixture("job_dict")),
-            (
-                lazy_fixture("bg_cron_job"),
-                {"to_string": False},
-                lazy_fixture("cron_job_dict"),
-            ),
-            (
-                lazy_fixture("bg_interval_job"),
-                {"to_string": False},
-                lazy_fixture("interval_job_dict"),
-            ),
+            (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
+            (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
+            (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
+            (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
+            (lazy_fixture("bg_patch1"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
+            (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
+            (lazy_fixture("bg_principal"), lazy_fixture("principal_dict")),
+            (lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            (lazy_fixture("bg_job"), lazy_fixture("job_dict")),
+            (lazy_fixture("bg_cron_job"), lazy_fixture("cron_job_dict")),
+            (lazy_fixture("bg_interval_job"), lazy_fixture("interval_job_dict")),
         ],
     )
-    def test_serialize(self, model, kwargs, expected):
-        assert SchemaParser.serialize(model, **kwargs) == expected
+    def test_single(self, model, expected):
+        assert SchemaParser.serialize(model, to_string=False) == expected
 
     @pytest.mark.parametrize(
-        "method,data,kwargs,expected",
+        "method,data,expected",
         [
             (
                 "serialize_system",
                 lazy_fixture("bg_system"),
-                {"to_string": False},
                 lazy_fixture("system_dict"),
             ),
             (
                 "serialize_instance",
                 lazy_fixture("bg_instance"),
-                {"to_string": False},
                 lazy_fixture("instance_dict"),
             ),
             (
                 "serialize_command",
                 lazy_fixture("bg_command"),
-                {"to_string": False},
                 lazy_fixture("command_dict"),
             ),
             (
                 "serialize_parameter",
                 lazy_fixture("bg_parameter"),
-                {"to_string": False},
                 lazy_fixture("parameter_dict"),
             ),
             (
                 "serialize_request",
                 lazy_fixture("bg_request"),
-                {"to_string": False},
                 lazy_fixture("request_dict"),
             ),
-            (
-                "serialize_patch",
-                lazy_fixture("bg_patch1"),
-                {"to_string": False},
-                lazy_fixture("patch_dict"),
-            ),
+            ("serialize_patch", lazy_fixture("bg_patch1"), lazy_fixture("patch_dict")),
             (
                 "serialize_logging_config",
                 lazy_fixture("bg_logging_config"),
-                {"to_string": False},
                 lazy_fixture("logging_config_dict"),
             ),
-            (
-                "serialize_event",
-                lazy_fixture("bg_event"),
-                {"to_string": False},
-                lazy_fixture("event_dict"),
-            ),
-            (
-                "serialize_queue",
-                lazy_fixture("bg_queue"),
-                {"to_string": False},
-                lazy_fixture("queue_dict"),
-            ),
+            ("serialize_event", lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            ("serialize_queue", lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
             (
                 "serialize_principal",
                 lazy_fixture("bg_principal"),
-                {"to_string": False},
                 lazy_fixture("principal_dict"),
             ),
-            (
-                "serialize_role",
-                lazy_fixture("bg_role"),
-                {"to_string": False},
-                lazy_fixture("role_dict"),
-            ),
-            (
-                "serialize_job",
-                lazy_fixture("bg_job"),
-                {"to_string": False},
-                lazy_fixture("job_dict"),
-            ),
+            ("serialize_role", lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            ("serialize_job", lazy_fixture("bg_job"), lazy_fixture("job_dict")),
             (
                 "serialize_job",
                 lazy_fixture("bg_cron_job"),
-                {"to_string": False},
                 lazy_fixture("cron_job_dict"),
             ),
             (
                 "serialize_job",
                 lazy_fixture("bg_interval_job"),
-                {"to_string": False},
                 lazy_fixture("interval_job_dict"),
             ),
         ],
     )
-    def test_serialize_specific(self, method, data, kwargs, expected):
+    def test_single_specific(self, method, data, expected):
         parser = SchemaParser()
-        actual = getattr(parser, method)(data, **kwargs)
+        actual = getattr(parser, method)(data, to_string=False)
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
+            (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
+            (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
+            (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
+            (lazy_fixture("bg_patch1"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
+            (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
+            (lazy_fixture("bg_principal"), lazy_fixture("principal_dict")),
+            (lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            (lazy_fixture("bg_job"), lazy_fixture("job_dict")),
+            (lazy_fixture("bg_cron_job"), lazy_fixture("cron_job_dict")),
+            (lazy_fixture("bg_interval_job"), lazy_fixture("interval_job_dict")),
+        ],
+    )
+    def test_many(self, model, expected):
+        assert SchemaParser.serialize([model] * 2, to_string=False) == [expected] * 2
+
+    def test_double_nested(self, bg_system, system_dict):
+        model_list = [bg_system, [bg_system, bg_system]]
+        expected = [system_dict, [system_dict, system_dict]]
+        assert SchemaParser.serialize(model_list, to_string=False) == expected
 
     @pytest.mark.parametrize(
         "keys,excludes",
         [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))],
     )
-    def test_serialize_excludes(self, bg_system, system_dict, keys, excludes):
+    def test_excludes(self, bg_system, system_dict, keys, excludes):
         for key in keys:
             system_dict.pop(key)
 


### PR DESCRIPTION
This PR adds support for easily serializing collections of models using the `SchemaParser`.

It also basically removes the potential to screw up the `many` parameter when serializing. Marshmallow (at least version 2, IDK about 3) requires you to specify `many` when serializing or de-serializing, and we basically passed that responsibility on the caller: previously when calling something like `serialize_system` you could pass either a specific `System` or a `List[System]`, but the `many` kwarg needed to match what you passed.

We don't need to do that for serialization (we can set that value correctly based on if the data to be serialized is an iterable). This has the side effect of allowing us to correctly serialize nested iterables of model objects (we don't currently ever do this, though).

However, there's no way to do the same thing for the `parse` side of things - the client still needs to tell the parser if the data is expected to be `many` or not.