### PR TITLE
Base model and Patch Serialization

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -47,7 +47,11 @@ class Events(Enum):
     ALL_QUEUES_CLEARED = 15
 
 
-class Command(object):
+class BaseModel(object):
+    schema = None
+
+
+class Command(BaseModel):
 
     schema = "CommandSchema"
 
@@ -126,7 +130,7 @@ class Command(object):
         return False
 
 
-class Instance(object):
+class Instance(BaseModel):
 
     schema = "InstanceSchema"
 
@@ -171,7 +175,7 @@ class Instance(object):
         return "<Instance: name=%s, status=%s>" % (self.name, self.status)
 
 
-class Choices(object):
+class Choices(BaseModel):
 
     schema = "ChoicesSchema"
 
@@ -196,7 +200,7 @@ class Choices(object):
         )
 
 
-class Parameter(object):
+class Parameter(BaseModel):
 
     schema = "ParameterSchema"
 
@@ -290,7 +294,7 @@ class Parameter(object):
         return False
 
 
-class RequestTemplate(object):
+class RequestTemplate(BaseModel):
 
     schema = "RequestTemplateSchema"
 
@@ -424,7 +428,7 @@ class Request(RequestTemplate):
         self._status = value
 
 
-class System(object):
+class System(BaseModel):
 
     schema = "SystemSchema"
 
@@ -514,7 +518,7 @@ class System(object):
         return False
 
 
-class PatchOperation(object):
+class PatchOperation(BaseModel):
 
     schema = "PatchSchema"
 
@@ -534,7 +538,7 @@ class PatchOperation(object):
         )
 
 
-class LoggingConfig(object):
+class LoggingConfig(BaseModel):
 
     schema = "LoggingConfigSchema"
 
@@ -636,7 +640,7 @@ class LoggingConfig(object):
         )
 
 
-class Event(object):
+class Event(BaseModel):
 
     schema = "EventSchema"
 
@@ -661,7 +665,7 @@ class Event(object):
         )
 
 
-class Queue(object):
+class Queue(BaseModel):
 
     schema = "QueueSchema"
 
@@ -690,7 +694,7 @@ class Queue(object):
         return "<Queue: name=%s, size=%s>" % (self.name, self.size)
 
 
-class Principal(object):
+class Principal(BaseModel):
 
     schema = "PrincipalSchema"
 
@@ -721,7 +725,7 @@ class Principal(object):
         )
 
 
-class Role(object):
+class Role(BaseModel):
 
     schema = "RoleSchema"
 
@@ -745,7 +749,7 @@ class Role(object):
         )
 
 
-class RefreshToken(object):
+class RefreshToken(BaseModel):
 
     schema = "RefreshTokenSchema"
 
@@ -766,7 +770,7 @@ class RefreshToken(object):
         )
 
 
-class Job(object):
+class Job(BaseModel):
 
     TRIGGER_TYPES = {"interval", "date", "cron"}
     STATUS_TYPES = {"RUNNING", "PAUSED"}
@@ -807,7 +811,7 @@ class Job(object):
         return "<Job: name=%s, id=%s>" % (self.name, self.id)
 
 
-class DateTrigger(object):
+class DateTrigger(BaseModel):
     schema = "DateTriggerSchema"
 
     def __init__(self, run_date=None, timezone=None):
@@ -821,7 +825,7 @@ class DateTrigger(object):
         return "<DateTrigger: run_date=%s>" % self.run_date
 
 
-class IntervalTrigger(object):
+class IntervalTrigger(BaseModel):
     schema = "IntervalTriggerSchema"
 
     def __init__(
@@ -859,7 +863,7 @@ class IntervalTrigger(object):
         )
 
 
-class CronTrigger(object):
+class CronTrigger(BaseModel):
     schema = "CronTriggerSchema"
 
     def __init__(

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -7,6 +7,7 @@ import six
 from brewtils.errors import RequestStatusTransitionError
 
 __all__ = [
+    "BaseModel",
     "System",
     "Instance",
     "Command",

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -121,26 +121,15 @@ class SchemaParser(object):
     def parse_logging_config(cls, logging_config, from_string=False, **kwargs):
         """Convert raw JSON string or dictionary to a logging config model object
 
-        Note: for our logging_config, many is _always_ set to False. We will always
-        return a dict from this method.
-
         :param logging_config: The raw input
         :param from_string: True if 'input is a JSON string, False if a dictionary
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A LoggingConfig object
         """
-        if kwargs.pop("many", False):
-            cls.logger.warning(
-                "A logging config object should never be wrapped as a list of "
-                "objects. Thus, parsing will always return a dict. You specified "
-                "many as True, this is being ignored and a dict will be returned "
-                "anyway."
-            )
         return cls.parse(
             logging_config,
             brewtils.models.LoggingConfig,
             from_string=from_string,
-            many=False,
             **kwargs
         )
 

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -113,19 +113,8 @@ class SchemaParser(object):
         :param kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
         :return: A PatchOperation object
         """
-        if not kwargs.pop("many", True):
-            cls.logger.warning(
-                "A patch object should always be wrapped as a list of objects. "
-                "Thus, parsing will always return a list. You specified many as "
-                "False, this is being ignored and a list "
-                "will be returned anyway."
-            )
         return cls.parse(
-            patch,
-            brewtils.models.PatchOperation,
-            from_string=from_string,
-            many=True,
-            **kwargs
+            patch, brewtils.models.PatchOperation, from_string=from_string, **kwargs
         )
 
     @classmethod
@@ -252,6 +241,16 @@ class SchemaParser(object):
         """
         if from_string and not isinstance(data, six.string_types):
             raise TypeError("When from_string=True data must be a string-type")
+
+        if model_class == brewtils.models.PatchOperation:
+            if not kwargs.get("many", True):
+                cls.logger.warning(
+                    "A patch object should always be wrapped as a list of objects. "
+                    "Thus, parsing will always return a list. You specified many as "
+                    "False, this is being ignored and a list "
+                    "will be returned anyway."
+                )
+            kwargs["many"] = True
 
         schema = getattr(brewtils.schemas, model_class.schema)(**kwargs)
         schema.context["models"] = cls._models

--- a/brewtils/test/comparable.py
+++ b/brewtils/test/comparable.py
@@ -86,10 +86,16 @@ def _assert_equal(obj1, obj2, expected_type=None, deep_fields=None):
 
     if expected_type is not None:
         _assert(
-            isinstance(obj1, expected_type), "obj1 was not an {0}".format(expected_type)
+            isinstance(obj1, expected_type),
+            "type mismatch for obj1: expected '{0}' but was '{1}'".format(
+                expected_type, type(obj1)
+            ),
         )
         _assert(
-            isinstance(obj2, expected_type), "obj2 was not an {0}".format(expected_type)
+            isinstance(obj2, expected_type),
+            "type mismatch for obj2: expected '{0}' but was '{1}'".format(
+                expected_type, type(obj2)
+            ),
         )
     _assert(type(obj1) is type(obj2), "obj1 and obj2 are not the same type.")
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -338,40 +338,39 @@ def bg_request(request_dict, parent_request, child_request, ts_dt):
 
 
 @pytest.fixture
-def patch_dict():
-    """A patch represented as a dictionary."""
-    return {
-        "operations": [{"operation": "replace", "path": "/status", "value": "RUNNING"}]
-    }
-
-
-@pytest.fixture
-def patch_many_dict():
-    """Multiple patches represented as a dictionary."""
-    return {
-        "operations": [
-            {"operation": "replace", "path": "/status", "value": "RUNNING"},
-            {"operation": "replace2", "path": "/status2", "value": "RUNNING2"},
-        ]
-    }
-
-
-@pytest.fixture
-def patch_no_envelop_dict():
+def patch_dict_no_envelop():
     """A patch without an envelope represented as a dictionary."""
     return {"operation": "replace", "path": "/status", "value": "RUNNING"}
 
 
 @pytest.fixture
-def bg_patch1(patch_many_dict):
-    """A patch as a model."""
-    return PatchOperation(**patch_many_dict["operations"][0])
+def patch_dict_no_envelop2():
+    """A patch without an envelope represented as a dictionary."""
+    return {"operation": "replace2", "path": "/status2", "value": "RUNNING2"}
 
 
 @pytest.fixture
-def bg_patch2(patch_many_dict):
+def patch_dict(patch_dict_no_envelop):
+    """A patch represented as a dictionary."""
+    return {"operations": [patch_dict_no_envelop]}
+
+
+@pytest.fixture
+def patch_many_dict(patch_dict_no_envelop, patch_dict_no_envelop2):
+    """Multiple patches represented as a dictionary."""
+    return {"operations": [patch_dict_no_envelop, patch_dict_no_envelop2]}
+
+
+@pytest.fixture
+def bg_patch(patch_dict_no_envelop):
     """A patch as a model."""
-    return PatchOperation(**patch_many_dict["operations"][1])
+    return PatchOperation(**patch_dict_no_envelop)
+
+
+@pytest.fixture
+def bg_patch2(patch_dict_no_envelop2):
+    """A patch as a model."""
+    return PatchOperation(**patch_dict_no_envelop2)
 
 
 @pytest.fixture

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -43,15 +43,13 @@ class TestParse(object):
             ("bad bad bad", {}, MarshmallowError),
         ],
     )
-    def test_parse_error(self, data, kwargs, error):
-        parser = SchemaParser()
+    def test_error(self, data, kwargs, error):
         with pytest.raises(error):
-            parser.parse_system(data, **kwargs)
+            SchemaParser.parse_system(data, **kwargs)
 
     def test_non_strict_failure(self, system_dict):
-        parser = SchemaParser()
         system_dict["name"] = None
-        value = parser.parse_system(system_dict, from_string=False, strict=False)
+        value = SchemaParser.parse_system(system_dict, from_string=False, strict=False)
         assert value.get("name") is None
         assert value["version"] == system_dict["version"]
 
@@ -61,427 +59,401 @@ class TestParse(object):
         assert system_copy == system_dict
 
     @pytest.mark.parametrize(
-        "model,data,kwargs,assertion,expected",
+        "model,data,assertion,expected",
         [
-            (
-                brewtils.models.System,
-                {},
-                {"from_string": False},
-                assert_system_equal,
-                System(),
-            ),
-            (
-                brewtils.models.System,
-                "{}",
-                {"from_string": True},
-                assert_system_equal,
-                System(),
-            ),
+            (brewtils.models.System, {}, assert_system_equal, System()),
             (
                 brewtils.models.System,
                 lazy_fixture("system_dict"),
-                {},
                 assert_system_equal,
                 lazy_fixture("bg_system"),
             ),
             (
                 brewtils.models.Instance,
                 lazy_fixture("instance_dict"),
-                {},
                 assert_instance_equal,
                 lazy_fixture("bg_instance"),
             ),
             (
                 brewtils.models.Command,
                 lazy_fixture("command_dict"),
-                {},
                 assert_command_equal,
                 lazy_fixture("bg_command"),
             ),
             (
                 brewtils.models.Parameter,
                 lazy_fixture("parameter_dict"),
-                {},
                 assert_parameter_equal,
                 lazy_fixture("bg_parameter"),
             ),
             (
                 brewtils.models.Request,
                 lazy_fixture("request_dict"),
-                {},
                 assert_request_equal,
                 lazy_fixture("bg_request"),
             ),
             (
                 brewtils.models.LoggingConfig,
                 lazy_fixture("logging_config_dict"),
-                {},
                 assert_logging_config_equal,
                 lazy_fixture("bg_logging_config"),
             ),
             (
                 brewtils.models.Event,
                 lazy_fixture("event_dict"),
-                {},
                 assert_event_equal,
                 lazy_fixture("bg_event"),
             ),
             (
                 brewtils.models.Queue,
                 lazy_fixture("queue_dict"),
-                {},
                 assert_queue_equal,
                 lazy_fixture("bg_queue"),
             ),
             (
                 brewtils.models.Principal,
                 lazy_fixture("principal_dict"),
-                {},
                 assert_principal_equal,
                 lazy_fixture("bg_principal"),
             ),
             (
                 brewtils.models.Role,
                 lazy_fixture("role_dict"),
-                {},
                 assert_role_equal,
                 lazy_fixture("bg_role"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_job"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("cron_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_cron_job"),
             ),
             (
                 brewtils.models.Job,
                 lazy_fixture("interval_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_interval_job"),
             ),
         ],
     )
-    def test_parse(self, model, data, kwargs, assertion, expected):
-        assertion(SchemaParser.parse(data, model, **kwargs), expected)
+    def test_single(self, model, data, assertion, expected):
+        assertion(SchemaParser.parse(data, model, from_string=False), expected)
+
+    def test_single_from_string(self):
+        assert_system_equal(
+            SchemaParser.parse("{}", brewtils.models.System, from_string=True), System()
+        )
 
     @pytest.mark.parametrize(
-        "method,data,kwargs,assertion,expected",
+        "method,data,assertion,expected",
         [
-            ("parse_system", {}, {"from_string": False}, assert_system_equal, System()),
-            (
-                "parse_system",
-                "{}",
-                {"from_string": True},
-                assert_system_equal,
-                System(),
-            ),
+            ("parse_system", {}, assert_system_equal, System()),
             (
                 "parse_system",
                 lazy_fixture("system_dict"),
-                {},
                 assert_system_equal,
                 lazy_fixture("bg_system"),
             ),
             (
                 "parse_instance",
                 lazy_fixture("instance_dict"),
-                {},
                 assert_instance_equal,
                 lazy_fixture("bg_instance"),
             ),
             (
                 "parse_command",
                 lazy_fixture("command_dict"),
-                {},
                 assert_command_equal,
                 lazy_fixture("bg_command"),
             ),
             (
                 "parse_parameter",
                 lazy_fixture("parameter_dict"),
-                {},
                 assert_parameter_equal,
                 lazy_fixture("bg_parameter"),
             ),
             (
                 "parse_request",
                 lazy_fixture("request_dict"),
-                {},
                 assert_request_equal,
                 lazy_fixture("bg_request"),
             ),
             (
                 "parse_logging_config",
                 lazy_fixture("logging_config_dict"),
-                {},
                 assert_logging_config_equal,
                 lazy_fixture("bg_logging_config"),
             ),
             (
                 "parse_event",
                 lazy_fixture("event_dict"),
-                {},
                 assert_event_equal,
                 lazy_fixture("bg_event"),
             ),
             (
                 "parse_queue",
                 lazy_fixture("queue_dict"),
-                {},
                 assert_queue_equal,
                 lazy_fixture("bg_queue"),
             ),
             (
                 "parse_principal",
                 lazy_fixture("principal_dict"),
-                {},
                 assert_principal_equal,
                 lazy_fixture("bg_principal"),
             ),
             (
                 "parse_role",
                 lazy_fixture("role_dict"),
-                {},
                 assert_role_equal,
                 lazy_fixture("bg_role"),
             ),
             (
                 "parse_job",
                 lazy_fixture("job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_job"),
             ),
             (
                 "parse_job",
                 lazy_fixture("cron_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_cron_job"),
             ),
             (
                 "parse_job",
                 lazy_fixture("interval_job_dict"),
-                {},
                 assert_job_equal,
                 lazy_fixture("bg_interval_job"),
             ),
         ],
     )
-    def test_parse_specific(self, method, data, kwargs, assertion, expected):
-        parser = SchemaParser()
-        actual = getattr(parser, method)(data, **kwargs)
+    def test_single_specific(self, method, data, assertion, expected):
+        actual = getattr(SchemaParser, method)(data, from_string=False)
         assertion(expected, actual)
+
+    def test_single_specific_from_string(self):
+        assert_system_equal(SchemaParser.parse_system("{}", from_string=True), System())
 
     @pytest.mark.parametrize(
         "data,kwargs",
         [
             (lazy_fixture("patch_dict"), {}),
             (lazy_fixture("patch_dict"), {"many": False}),
-            (lazy_fixture("patch_no_envelop_dict"), {}),
+            (lazy_fixture("patch_dict_no_envelop"), {}),
         ],
     )
-    def test_parse_patch(self, bg_patch1, data, kwargs):
+    def test_patch(self, bg_patch, data, kwargs):
         parser = SchemaParser()
         actual = parser.parse_patch(data, **kwargs)[0]
-        assert_patch_equal(actual, bg_patch1)
+        assert_patch_equal(actual, bg_patch)
 
-    def test_parse_patch_many(self, patch_many_dict, bg_patch1, bg_patch2):
+    def test_patch_many(self, patch_many_dict, bg_patch, bg_patch2):
         parser = SchemaParser()
         patches = sorted(
             parser.parse_patch(patch_many_dict, many=True), key=lambda x: x.operation
         )
-        for index, patch in enumerate([bg_patch1, bg_patch2]):
+        for index, patch in enumerate([bg_patch, bg_patch2]):
             assert_patch_equal(patch, patches[index])
 
 
 class TestSerialize(object):
     @pytest.mark.parametrize(
-        "model,kwargs,expected",
+        "model,expected",
         [
-            (
-                lazy_fixture("bg_system"),
-                {"to_string": False},
-                lazy_fixture("system_dict"),
-            ),
-            (
-                lazy_fixture("bg_instance"),
-                {"to_string": False},
-                lazy_fixture("instance_dict"),
-            ),
-            (
-                lazy_fixture("bg_command"),
-                {"to_string": False},
-                lazy_fixture("command_dict"),
-            ),
-            (
-                lazy_fixture("bg_parameter"),
-                {"to_string": False},
-                lazy_fixture("parameter_dict"),
-            ),
-            (
-                lazy_fixture("bg_request"),
-                {"to_string": False},
-                lazy_fixture("request_dict"),
-            ),
-            (
-                lazy_fixture("bg_patch1"),
-                {"to_string": False},
-                lazy_fixture("patch_dict"),
-            ),
-            (
-                lazy_fixture("bg_logging_config"),
-                {"to_string": False},
-                lazy_fixture("logging_config_dict"),
-            ),
-            (
-                lazy_fixture("bg_event"),
-                {"to_string": False},
-                lazy_fixture("event_dict"),
-            ),
-            (
-                lazy_fixture("bg_queue"),
-                {"to_string": False},
-                lazy_fixture("queue_dict"),
-            ),
-            (
-                lazy_fixture("bg_principal"),
-                {"to_string": False},
-                lazy_fixture("principal_dict"),
-            ),
-            (lazy_fixture("bg_role"), {"to_string": False}, lazy_fixture("role_dict")),
-            (lazy_fixture("bg_job"), {"to_string": False}, lazy_fixture("job_dict")),
-            (
-                lazy_fixture("bg_cron_job"),
-                {"to_string": False},
-                lazy_fixture("cron_job_dict"),
-            ),
-            (
-                lazy_fixture("bg_interval_job"),
-                {"to_string": False},
-                lazy_fixture("interval_job_dict"),
-            ),
+            (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
+            (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
+            (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
+            (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
+            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
+            (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
+            (lazy_fixture("bg_principal"), lazy_fixture("principal_dict")),
+            (lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            (lazy_fixture("bg_job"), lazy_fixture("job_dict")),
+            (lazy_fixture("bg_cron_job"), lazy_fixture("cron_job_dict")),
+            (lazy_fixture("bg_interval_job"), lazy_fixture("interval_job_dict")),
         ],
     )
-    def test_serialize(self, model, kwargs, expected):
-        assert SchemaParser.serialize(model, **kwargs) == expected
+    def test_single(self, model, expected):
+        assert SchemaParser.serialize(model, to_string=False) == expected
 
     @pytest.mark.parametrize(
-        "method,data,kwargs,expected",
+        "method,data,expected",
         [
             (
                 "serialize_system",
                 lazy_fixture("bg_system"),
-                {"to_string": False},
                 lazy_fixture("system_dict"),
             ),
             (
                 "serialize_instance",
                 lazy_fixture("bg_instance"),
-                {"to_string": False},
                 lazy_fixture("instance_dict"),
             ),
             (
                 "serialize_command",
                 lazy_fixture("bg_command"),
-                {"to_string": False},
                 lazy_fixture("command_dict"),
             ),
             (
                 "serialize_parameter",
                 lazy_fixture("bg_parameter"),
-                {"to_string": False},
                 lazy_fixture("parameter_dict"),
             ),
             (
                 "serialize_request",
                 lazy_fixture("bg_request"),
-                {"to_string": False},
                 lazy_fixture("request_dict"),
             ),
-            (
-                "serialize_patch",
-                lazy_fixture("bg_patch1"),
-                {"to_string": False},
-                lazy_fixture("patch_dict"),
-            ),
+            ("serialize_patch", lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
             (
                 "serialize_logging_config",
                 lazy_fixture("bg_logging_config"),
-                {"to_string": False},
                 lazy_fixture("logging_config_dict"),
             ),
-            (
-                "serialize_event",
-                lazy_fixture("bg_event"),
-                {"to_string": False},
-                lazy_fixture("event_dict"),
-            ),
-            (
-                "serialize_queue",
-                lazy_fixture("bg_queue"),
-                {"to_string": False},
-                lazy_fixture("queue_dict"),
-            ),
+            ("serialize_event", lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            ("serialize_queue", lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
             (
                 "serialize_principal",
                 lazy_fixture("bg_principal"),
-                {"to_string": False},
                 lazy_fixture("principal_dict"),
             ),
-            (
-                "serialize_role",
-                lazy_fixture("bg_role"),
-                {"to_string": False},
-                lazy_fixture("role_dict"),
-            ),
-            (
-                "serialize_job",
-                lazy_fixture("bg_job"),
-                {"to_string": False},
-                lazy_fixture("job_dict"),
-            ),
+            ("serialize_role", lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            ("serialize_job", lazy_fixture("bg_job"), lazy_fixture("job_dict")),
             (
                 "serialize_job",
                 lazy_fixture("bg_cron_job"),
-                {"to_string": False},
                 lazy_fixture("cron_job_dict"),
             ),
             (
                 "serialize_job",
                 lazy_fixture("bg_interval_job"),
-                {"to_string": False},
                 lazy_fixture("interval_job_dict"),
             ),
         ],
     )
-    def test_serialize_specific(self, method, data, kwargs, expected):
-        parser = SchemaParser()
-        actual = getattr(parser, method)(data, **kwargs)
+    def test_single_specific(self, method, data, expected):
+        actual = getattr(SchemaParser, method)(data, to_string=False)
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
+            (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
+            (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
+            (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
+            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
+            (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
+            (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
+            (lazy_fixture("bg_principal"), lazy_fixture("principal_dict")),
+            (lazy_fixture("bg_role"), lazy_fixture("role_dict")),
+            (lazy_fixture("bg_job"), lazy_fixture("job_dict")),
+            (lazy_fixture("bg_cron_job"), lazy_fixture("cron_job_dict")),
+            (lazy_fixture("bg_interval_job"), lazy_fixture("interval_job_dict")),
+        ],
+    )
+    def test_many(self, model, expected):
+        assert SchemaParser.serialize([model] * 2, to_string=False) == [expected] * 2
+
+    def test_double_nested(self, bg_system, system_dict):
+        model_list = [bg_system, [bg_system, bg_system]]
+        expected = [system_dict, [system_dict, system_dict]]
+        assert SchemaParser.serialize(model_list, to_string=False) == expected
 
     @pytest.mark.parametrize(
         "keys,excludes",
         [(["commands"], ()), (["commands", "icon_name"], ("icon_name",))],
     )
-    def test_serialize_excludes(self, bg_system, system_dict, keys, excludes):
+    def test_excludes(self, bg_system, system_dict, keys, excludes):
         for key in keys:
             system_dict.pop(key)
 
-        parser = SchemaParser()
-        actual = parser.serialize_system(
+        actual = SchemaParser.serialize_system(
             bg_system, to_string=False, include_commands=False, exclude=excludes
         )
         assert actual == system_dict
+
+
+class TestRoundTrip(object):
+    @pytest.mark.parametrize(
+        "model,assertion,data",
+        [
+            (brewtils.models.System, assert_system_equal, lazy_fixture("bg_system")),
+            (
+                brewtils.models.Instance,
+                assert_instance_equal,
+                lazy_fixture("bg_instance"),
+            ),
+            (brewtils.models.Command, assert_command_equal, lazy_fixture("bg_command")),
+            (
+                brewtils.models.Parameter,
+                assert_parameter_equal,
+                lazy_fixture("bg_parameter"),
+            ),
+            (brewtils.models.Request, assert_request_equal, lazy_fixture("bg_request")),
+            (
+                brewtils.models.LoggingConfig,
+                assert_logging_config_equal,
+                lazy_fixture("bg_logging_config"),
+            ),
+            (brewtils.models.Event, assert_event_equal, lazy_fixture("bg_event")),
+            (brewtils.models.Queue, assert_queue_equal, lazy_fixture("bg_queue")),
+            (
+                brewtils.models.Principal,
+                assert_principal_equal,
+                lazy_fixture("bg_principal"),
+            ),
+            (brewtils.models.Role, assert_role_equal, lazy_fixture("bg_role")),
+            (brewtils.models.Job, assert_job_equal, lazy_fixture("bg_job")),
+            (brewtils.models.Job, assert_job_equal, lazy_fixture("bg_cron_job")),
+            (brewtils.models.Job, assert_job_equal, lazy_fixture("bg_interval_job")),
+        ],
+    )
+    def test_parsed_start(self, model, assertion, data):
+        assertion(
+            SchemaParser.parse(
+                SchemaParser.serialize(data, to_string=False), model, from_string=False
+            ),
+            data,
+        )
+
+    @pytest.mark.parametrize(
+        "model,data",
+        [
+            (brewtils.models.System, lazy_fixture("system_dict")),
+            (brewtils.models.Instance, lazy_fixture("instance_dict")),
+            (brewtils.models.Command, lazy_fixture("command_dict")),
+            (brewtils.models.Parameter, lazy_fixture("parameter_dict")),
+            (brewtils.models.Request, lazy_fixture("request_dict")),
+            (brewtils.models.LoggingConfig, lazy_fixture("logging_config_dict")),
+            (brewtils.models.Event, lazy_fixture("event_dict")),
+            (brewtils.models.Queue, lazy_fixture("queue_dict")),
+            (brewtils.models.Principal, lazy_fixture("principal_dict")),
+            (brewtils.models.Role, lazy_fixture("role_dict")),
+            (brewtils.models.Job, lazy_fixture("job_dict")),
+            (brewtils.models.Job, lazy_fixture("cron_job_dict")),
+            (brewtils.models.Job, lazy_fixture("interval_job_dict")),
+        ],
+    )
+    def test_serialized_start(self, model, data):
+        assert (
+            SchemaParser.serialize(
+                SchemaParser.parse(data, model, from_string=False), to_string=False
+            )
+            == data
+        )
 
 
 def test_deprecation():

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -272,7 +272,7 @@ class TestSerialize(object):
             (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
             (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
             (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
-            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict_no_envelop")),
             (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
             (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
             (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
@@ -314,7 +314,11 @@ class TestSerialize(object):
                 lazy_fixture("bg_request"),
                 lazy_fixture("request_dict"),
             ),
-            ("serialize_patch", lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
+            (
+                "serialize_patch",
+                lazy_fixture("bg_patch"),
+                lazy_fixture("patch_dict_no_envelop"),
+            ),
             (
                 "serialize_logging_config",
                 lazy_fixture("bg_logging_config"),
@@ -353,7 +357,7 @@ class TestSerialize(object):
             (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
             (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
             (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
-            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict")),
+            (lazy_fixture("bg_patch"), lazy_fixture("patch_dict_no_envelop")),
             (lazy_fixture("bg_logging_config"), lazy_fixture("logging_config_dict")),
             (lazy_fixture("bg_event"), lazy_fixture("event_dict")),
             (lazy_fixture("bg_queue"), lazy_fixture("queue_dict")),
@@ -386,16 +390,17 @@ class TestSerialize(object):
         assert actual == system_dict
 
     @pytest.mark.parametrize("kwargs", [{}, {"many": False}])
-    def test_patch(self, patch_dict, bg_patch, kwargs):
+    def test_patch(self, patch_dict_no_envelop, bg_patch, kwargs):
         actual = SchemaParser.serialize_patch(bg_patch, to_string=False, **kwargs)
-        assert actual == patch_dict
+        assert actual == patch_dict_no_envelop
 
-    @pytest.mark.xfail
-    def test_patch_many(self, patch_many_dict, bg_patch, bg_patch2):
+    def test_patch_many(
+        self, patch_dict_no_envelop, patch_dict_no_envelop2, bg_patch, bg_patch2
+    ):
         actual = SchemaParser.serialize_patch(
             [bg_patch, bg_patch2], to_string=False, many=True
         )
-        assert actual == patch_many_dict
+        assert actual == [patch_dict_no_envelop, patch_dict_no_envelop2]
 
 
 class TestRoundTrip(object):

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -242,6 +242,186 @@ class TestParse(object):
         assert_system_equal(SchemaParser.parse_system("{}", from_string=True), System())
 
     @pytest.mark.parametrize(
+        "model,data,assertion,expected",
+        [
+            (brewtils.models.System, {}, assert_system_equal, System()),
+            (
+                brewtils.models.System,
+                lazy_fixture("system_dict"),
+                assert_system_equal,
+                lazy_fixture("bg_system"),
+            ),
+            (
+                brewtils.models.Instance,
+                lazy_fixture("instance_dict"),
+                assert_instance_equal,
+                lazy_fixture("bg_instance"),
+            ),
+            (
+                brewtils.models.Command,
+                lazy_fixture("command_dict"),
+                assert_command_equal,
+                lazy_fixture("bg_command"),
+            ),
+            (
+                brewtils.models.Parameter,
+                lazy_fixture("parameter_dict"),
+                assert_parameter_equal,
+                lazy_fixture("bg_parameter"),
+            ),
+            (
+                brewtils.models.Request,
+                lazy_fixture("request_dict"),
+                assert_request_equal,
+                lazy_fixture("bg_request"),
+            ),
+            (
+                brewtils.models.LoggingConfig,
+                lazy_fixture("logging_config_dict"),
+                assert_logging_config_equal,
+                lazy_fixture("bg_logging_config"),
+            ),
+            (
+                brewtils.models.Event,
+                lazy_fixture("event_dict"),
+                assert_event_equal,
+                lazy_fixture("bg_event"),
+            ),
+            (
+                brewtils.models.Queue,
+                lazy_fixture("queue_dict"),
+                assert_queue_equal,
+                lazy_fixture("bg_queue"),
+            ),
+            (
+                brewtils.models.Principal,
+                lazy_fixture("principal_dict"),
+                assert_principal_equal,
+                lazy_fixture("bg_principal"),
+            ),
+            (
+                brewtils.models.Role,
+                lazy_fixture("role_dict"),
+                assert_role_equal,
+                lazy_fixture("bg_role"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_job"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("cron_job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_cron_job"),
+            ),
+            (
+                brewtils.models.Job,
+                lazy_fixture("interval_job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_interval_job"),
+            ),
+        ],
+    )
+    def test_many(self, model, data, assertion, expected):
+        parsed = SchemaParser.parse([data] * 2, model, from_string=False, many=True)
+
+        for parsed_model in parsed:
+            assertion(parsed_model, expected)
+
+    @pytest.mark.parametrize(
+        "method,data,assertion,expected",
+        [
+            ("parse_system", {}, assert_system_equal, System()),
+            (
+                "parse_system",
+                lazy_fixture("system_dict"),
+                assert_system_equal,
+                lazy_fixture("bg_system"),
+            ),
+            (
+                "parse_instance",
+                lazy_fixture("instance_dict"),
+                assert_instance_equal,
+                lazy_fixture("bg_instance"),
+            ),
+            (
+                "parse_command",
+                lazy_fixture("command_dict"),
+                assert_command_equal,
+                lazy_fixture("bg_command"),
+            ),
+            (
+                "parse_parameter",
+                lazy_fixture("parameter_dict"),
+                assert_parameter_equal,
+                lazy_fixture("bg_parameter"),
+            ),
+            (
+                "parse_request",
+                lazy_fixture("request_dict"),
+                assert_request_equal,
+                lazy_fixture("bg_request"),
+            ),
+            (
+                "parse_logging_config",
+                lazy_fixture("logging_config_dict"),
+                assert_logging_config_equal,
+                lazy_fixture("bg_logging_config"),
+            ),
+            (
+                "parse_event",
+                lazy_fixture("event_dict"),
+                assert_event_equal,
+                lazy_fixture("bg_event"),
+            ),
+            (
+                "parse_queue",
+                lazy_fixture("queue_dict"),
+                assert_queue_equal,
+                lazy_fixture("bg_queue"),
+            ),
+            (
+                "parse_principal",
+                lazy_fixture("principal_dict"),
+                assert_principal_equal,
+                lazy_fixture("bg_principal"),
+            ),
+            (
+                "parse_role",
+                lazy_fixture("role_dict"),
+                assert_role_equal,
+                lazy_fixture("bg_role"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_job"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("cron_job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_cron_job"),
+            ),
+            (
+                "parse_job",
+                lazy_fixture("interval_job_dict"),
+                assert_job_equal,
+                lazy_fixture("bg_interval_job"),
+            ),
+        ],
+    )
+    def test_many_specific(self, method, data, assertion, expected):
+        parsed = getattr(SchemaParser, method)([data] * 2, from_string=False, many=True)
+
+        for parsed_model in parsed:
+            assertion(parsed_model, expected)
+
+    @pytest.mark.parametrize(
         "data,kwargs",
         [
             (lazy_fixture("patch_dict"), {}),
@@ -250,17 +430,17 @@ class TestParse(object):
         ],
     )
     def test_patch(self, bg_patch, data, kwargs):
-        parser = SchemaParser()
-        actual = parser.parse_patch(data, **kwargs)[0]
-        assert_patch_equal(actual, bg_patch)
+        """Parametrize for the 'many' kwarg because the parser should ignore it"""
+        assert_patch_equal(SchemaParser.parse_patch(data, **kwargs)[0], bg_patch)
 
-    def test_patch_many(self, patch_many_dict, bg_patch, bg_patch2):
-        parser = SchemaParser()
-        patches = sorted(
-            parser.parse_patch(patch_many_dict, many=True), key=lambda x: x.operation
-        )
+    @pytest.mark.parametrize("kwargs", [{}, {"many": True}, {"many": False}])
+    def test_patch_many(self, patch_many_dict, bg_patch, bg_patch2, kwargs):
+        """Parametrize for the 'many' kwarg because the parser should ignore it"""
+        patches = SchemaParser.parse_patch(patch_many_dict, **kwargs)
+        sorted_patches = sorted(patches, key=lambda x: x.operation)
+
         for index, patch in enumerate([bg_patch, bg_patch2]):
-            assert_patch_equal(patch, patches[index])
+            assert_patch_equal(patch, sorted_patches[index])
 
 
 class TestSerialize(object):

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -472,6 +472,27 @@ class TestRoundTrip(object):
             == data
         )
 
+    def test_patch_model_start(self, bg_patch):
+        """Patches are always parsed into a list, so they need a tweak to test"""
+        parsed = SchemaParser.parse(
+            SchemaParser.serialize(bg_patch, to_string=False),
+            brewtils.models.PatchOperation,
+            from_string=False,
+        )
+
+        assert len(parsed) == 1
+        assert_patch_equal(parsed[0], bg_patch)
+
+    def test_patch_serialized_start(self, patch_dict_no_envelop):
+        """Patches are always parsed into a list, so they need a tweak to test"""
+        serialized = SchemaParser.serialize(
+            SchemaParser.parse_patch(patch_dict_no_envelop, from_string=False),
+            to_string=False,
+        )
+
+        assert len(serialized) == 1
+        assert serialized[0] == patch_dict_no_envelop
+
 
 def test_deprecation():
     with warnings.catch_warnings(record=True) as w:

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -385,6 +385,18 @@ class TestSerialize(object):
         )
         assert actual == system_dict
 
+    @pytest.mark.parametrize("kwargs", [{}, {"many": False}])
+    def test_patch(self, patch_dict, bg_patch, kwargs):
+        actual = SchemaParser.serialize_patch(bg_patch, to_string=False, **kwargs)
+        assert actual == patch_dict
+
+    @pytest.mark.xfail
+    def test_patch_many(self, patch_many_dict, bg_patch, bg_patch2):
+        actual = SchemaParser.serialize_patch(
+            [bg_patch, bg_patch2], to_string=False, many=True
+        )
+        assert actual == patch_many_dict
+
 
 class TestRoundTrip(object):
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds support for easily serializing collections of models using the SchemaParser.

It also basically removes the potential to screw up the many parameter when serializing. Marshmallow (at least version 2, IDK about 3) requires you to specify many when serializing or de-serializing, and we basically passed that responsibility on the caller: previously when calling something like serialize_system you could pass either a specific System or a List[System], but the many kwarg needed to match what you passed.

We don't need to do that for serialization (we can set that value correctly based on if the data to be serialized is an iterable). This has the side effect of allowing us to correctly serialize nested iterables of model objects (we don't currently ever do this, though).

However, there's no way to do the same thing for the parse side of things - the client still needs to tell the parser if the data is expected to be many or not.

In order to accomplish this all models now inherit from a base class. I originally tried to go the other way (first check to see if the data to be serialized is a collection), but this fails for the Mongo models because mongoengine documents are basically collections themselves (they implement an `__iter__` that iterates through the fields. IDK why they do this).

It also removes the weird "operations" envelope from the `Patch` serialization. They used to be serialized like this:
```
{
    "operations": [
        {"operation": "replace", ...},
        {"operation": "replace", ...}
        ...
    ]
}
```

They are now serialized like a normal thing:
```
[
    {"operation": "replace", ...},
    {"operation": "replace", ...}
    ...
]
```

The parsing side can already handle both forms, so there's no compatibility problem here.