### PR TITLE
Adding scheduler translation to trigger models

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 
+import pytz
 import six
 
 from brewtils.errors import RequestStatusTransitionError
@@ -837,6 +838,16 @@ class DateTrigger(BaseModel):
     def __repr__(self):
         return "<DateTrigger: run_date=%s>" % self.run_date
 
+    @property
+    def scheduler_attributes(self):
+        return ["run_date", "timezone"]
+
+    @property
+    def scheduler_kwargs(self):
+        tz = pytz.timezone(self.timezone)
+
+        return {"timezone": tz, "run_date": tz.localize(self.run_date)}
+
 
 class IntervalTrigger(BaseModel):
     schema = "IntervalTriggerSchema"
@@ -874,6 +885,36 @@ class IntervalTrigger(BaseModel):
             "minutes=%d, seconds=%d>"
             % (self.weeks, self.days, self.hours, self.minutes, self.seconds)
         )
+
+    @property
+    def scheduler_attributes(self):
+        return [
+            "weeks",
+            "days",
+            "hours",
+            "minutes",
+            "seconds",
+            "start_date",
+            "end_date",
+            "timezone",
+            "jitter",
+            "reschedule_on_finish",
+        ]
+
+    @property
+    def scheduler_kwargs(self):
+        tz = pytz.timezone(self.timezone)
+
+        kwargs = {key: getattr(self, key) for key in self.scheduler_attributes}
+        kwargs.update(
+            {
+                "timezone": tz,
+                "start_date": tz.localize(self.start_date) if self.start_date else None,
+                "end_date": tz.localize(self.start_date) if self.start_date else None,
+            }
+        )
+
+        return kwargs
 
 
 class CronTrigger(BaseModel):
@@ -918,3 +959,35 @@ class CronTrigger(BaseModel):
             self.month,
             self.day,
         )
+
+    @property
+    def scheduler_attributes(self):
+        return [
+            "year",
+            "month",
+            "day",
+            "week",
+            "day_of_week",
+            "hour",
+            "minute",
+            "second",
+            "start_date",
+            "end_date",
+            "timezone",
+            "jitter",
+        ]
+
+    @property
+    def scheduler_kwargs(self):
+        tz = pytz.timezone(self.timezone)
+
+        kwargs = {key: getattr(self, key) for key in self.scheduler_attributes}
+        kwargs.update(
+            {
+                "timezone": tz,
+                "start_date": tz.localize(self.start_date) if self.start_date else None,
+                "end_date": tz.localize(self.start_date) if self.start_date else None,
+            }
+        )
+
+        return kwargs

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -45,6 +45,12 @@ def ts_dt():
 
 
 @pytest.fixture
+def ts_dt_utc():
+    """Timezone-aware datetime (UTC)."""
+    return datetime(2016, 1, 1, tzinfo=pytz.utc)
+
+
+@pytest.fixture
 def ts_dt_with_tz():
     """Timezone-aware datetime (US/Eastern)."""
     return datetime(2016, 1, 1, tzinfo=pytz.timezone("US/Eastern"))

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
 import pytest
+import pytz
 from mock import Mock, PropertyMock
 from pytest_lazyfixture import lazy_fixture
 
@@ -19,6 +19,8 @@ from brewtils.models import (
     Principal,
     Role,
     RequestTemplate,
+    CronTrigger,
+    IntervalTrigger,
 )
 
 
@@ -502,6 +504,64 @@ class TestRole(object):
             repr(role) == "<Role: name=bg-admin, roles=['bg-anonymous'], "
             "permissions=['bg-all']>"
         )
+
+
+class TestDateTrigger(object):
+    def test_scheduler_kwargs(self, bg_date_trigger, ts_dt_utc):
+        assert bg_date_trigger.scheduler_kwargs == {
+            "timezone": pytz.utc,
+            "run_date": ts_dt_utc,
+        }
+
+
+class TestIntervalTrigger(object):
+    def test_scheduler_kwargs_default(self):
+        assert IntervalTrigger(timezone="utc").scheduler_kwargs == {
+            "weeks": None,
+            "days": None,
+            "hours": None,
+            "minutes": None,
+            "seconds": None,
+            "start_date": None,
+            "end_date": None,
+            "timezone": pytz.utc,
+            "jitter": None,
+            "reschedule_on_finish": None,
+        }
+
+    def test_scheduler_kwargs(
+        self, bg_interval_trigger, interval_trigger_dict, ts_dt_utc
+    ):
+        expected = interval_trigger_dict
+        expected.update(
+            {"timezone": pytz.utc, "start_date": ts_dt_utc, "end_date": ts_dt_utc}
+        )
+        assert bg_interval_trigger.scheduler_kwargs == expected
+
+
+class TestCronTrigger(object):
+    def test_scheduler_kwargs_default(self):
+        assert CronTrigger(timezone="utc").scheduler_kwargs == {
+            "year": None,
+            "month": None,
+            "day": None,
+            "week": None,
+            "day_of_week": None,
+            "hour": None,
+            "minute": None,
+            "second": None,
+            "start_date": None,
+            "end_date": None,
+            "timezone": pytz.utc,
+            "jitter": None,
+        }
+
+    def test_scheduler_kwargs(self, bg_cron_trigger, cron_trigger_dict, ts_dt_utc):
+        expected = cron_trigger_dict
+        expected.update(
+            {"timezone": pytz.utc, "start_date": ts_dt_utc, "end_date": ts_dt_utc}
+        )
+        assert bg_cron_trigger.scheduler_kwargs == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR moves the Beergarden model -> APScheduler model translation into the brewtils models.

As we move towards supporting multiple DB backends all the logic that currently lives in the mongo models needs to move somewhere more general. For this case I think the brewtils models are the best place.