### PR TITLE
Issue/359

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -265,24 +265,14 @@ class Plugin(object):
 
         try:
             while not self.shutdown_event.wait(0.1):
-                if (
-                    not self.admin_consumer.isAlive()
-                    and not self.admin_consumer.shutdown_event.is_set()
-                ):
-                    self.logger.warning(
-                        "Looks like admin consumer has died - attempting to restart"
-                    )
+                if not self.admin_consumer.isAlive():
+                    self.logger.warning("Admin consumer has died, restarting")
                     self.shutdown_event.wait(5)
                     self.admin_consumer = self._create_admin_consumer()
                     self.admin_consumer.start()
 
-                if (
-                    not self.request_consumer.isAlive()
-                    and not self.request_consumer.shutdown_event.is_set()
-                ):
-                    self.logger.warning(
-                        "Looks like request consumer has died - attempting to restart"
-                    )
+                if not self.request_consumer.isAlive():
+                    self.logger.warning("Request consumer has died, restarting")
                     self.shutdown_event.wait(5)
                     self.request_consumer = self._create_standard_consumer()
                     self.request_consumer.start()
@@ -294,12 +284,6 @@ class Plugin(object):
                     )
                     self.connection_poll_thread = self._create_connection_poll_thread()
                     self.connection_poll_thread.start()
-
-                if (
-                    self.request_consumer.shutdown_event.is_set()
-                    and self.admin_consumer.shutdown_event.is_set()
-                ):
-                    self.shutdown_event.set()
 
         except KeyboardInterrupt:
             self.logger.debug("Received KeyboardInterrupt - shutting down")

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -270,7 +270,7 @@ class Plugin(object):
                     and not self.admin_consumer.shutdown_event.is_set()
                 ):
                     self.logger.warning(
-                        "Looks like admin consumer has died - attempting to " "restart"
+                        "Looks like admin consumer has died - attempting to restart"
                     )
                     self.admin_consumer = self._create_admin_consumer()
                     self.admin_consumer.start()
@@ -280,7 +280,7 @@ class Plugin(object):
                     and not self.request_consumer.shutdown_event.is_set()
                 ):
                     self.logger.warning(
-                        "Looks like request consumer has died - attempting to" "restart"
+                        "Looks like request consumer has died - attempting to restart"
                     )
                     self.request_consumer = self._create_standard_consumer()
                     self.request_consumer.start()

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -136,6 +136,12 @@ class Plugin(object):
     :param int max_timeout: Maximum amount of time to wait before retrying to
         update a request.
     :param int starting_timeout: Initial time to wait before the first retry.
+    :param int mq_max_attempts: Number of times to attempt reconnection to message queue
+        before giving up (default -1 aka never).
+    :param int mq_max_timeout: Maximum amount of time to wait before retrying to
+        connect to message queue.
+    :param int mq_starting_timeout: Initial time to wait before the first message queue
+        connection retry.
     :param int max_instances: Max number of instances allowed for the system.
     :param bool ca_verify: Verify server certificate when making a request.
     :param str username: The username for Beergarden authentication
@@ -199,6 +205,12 @@ class Plugin(object):
         self.max_attempts = kwargs.get("max_attempts", -1)
         self.max_timeout = kwargs.get("max_timeout", 30)
         self.starting_timeout = kwargs.get("starting_timeout", 5)
+
+        self._mq_max_attempts = kwargs.get("mq_max_attempts", -1)
+        self._mq_max_timeout = kwargs.get("mq_max_timeout", 30)
+        self._mq_starting_timeout = kwargs.get("mq_starting_timeout", 5)
+        self._mq_retry_attempt = 0
+        self._mq_timeout = self._mq_starting_timeout
 
         self.max_concurrent = self._setup_max_concurrent(multithreaded, max_concurrent)
         self.instance_name = instance_name or os.environ.get(
@@ -265,26 +277,8 @@ class Plugin(object):
 
         try:
             while not self.shutdown_event.wait(0.1):
-                if not self.admin_consumer.isAlive():
-                    self.logger.warning("Admin consumer has died, restarting")
-                    self.shutdown_event.wait(5)
-                    self.admin_consumer = self._create_admin_consumer()
-                    self.admin_consumer.start()
-
-                if not self.request_consumer.isAlive():
-                    self.logger.warning("Request consumer has died, restarting")
-                    self.shutdown_event.wait(5)
-                    self.request_consumer = self._create_standard_consumer()
-                    self.request_consumer.start()
-
-                if not self.connection_poll_thread.isAlive():
-                    self.logger.warning(
-                        "Looks like connection poll thread has died - "
-                        "attempting to restart"
-                    )
-                    self.connection_poll_thread = self._create_connection_poll_thread()
-                    self.connection_poll_thread.start()
-
+                self._check_connection_poll_thread()
+                self._check_consumers()
         except KeyboardInterrupt:
             self.logger.debug("Received KeyboardInterrupt - shutting down")
         except Exception as ex:
@@ -653,6 +647,48 @@ class Plugin(object):
                 request.id,
             )
             self.brew_view_error_condition.wait()
+
+    def _check_connection_poll_thread(self):
+        """Ensure the connection poll thread is alive"""
+        if not self.connection_poll_thread.isAlive():
+            self.logger.warning(
+                "Looks like connection poll thread has died - attempting to restart"
+            )
+            self.connection_poll_thread = self._create_connection_poll_thread()
+            self.connection_poll_thread.start()
+
+    def _check_consumers(self):
+        """Ensure the RequestConsumers are both alive"""
+        if self.admin_consumer.is_connected() and self.request_consumer.is_connected():
+            if self._mq_retry_attempt != 0:
+                self.logger.info("Admin and request consumers successfully reconnected")
+
+            self._mq_retry_attempt = 0
+            self._mq_timeout = self._mq_starting_timeout
+        else:
+            if 0 < self._mq_max_attempts < self._mq_retry_attempt:
+                self.logger.warning("Max consumer connection failures, shutting down")
+                self.shutdown_event.set()
+                return
+
+            if not self.admin_consumer.is_connected():
+                self.logger.warning("Looks like admin consumer has died")
+            if not self.request_consumer.is_connected():
+                self.logger.warning("Looks like request consumer has died")
+
+            self.logger.warning("Waiting %i seconds before restart", self._mq_timeout)
+            self.shutdown_event.wait(self._mq_timeout)
+
+            if not self.admin_consumer.is_connected():
+                self.admin_consumer = self._create_admin_consumer()
+                self.admin_consumer.start()
+
+            if not self.request_consumer.is_connected():
+                self.request_consumer = self._create_standard_consumer()
+                self.request_consumer.start()
+
+            self._mq_timeout = min(self._mq_timeout * 2, self._mq_max_timeout)
+            self._mq_retry_attempt += 1
 
     def _start(self, request):
         """Handle start message by marking this instance as running.

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -272,6 +272,7 @@ class Plugin(object):
                     self.logger.warning(
                         "Looks like admin consumer has died - attempting to restart"
                     )
+                    self.shutdown_event.wait(5)
                     self.admin_consumer = self._create_admin_consumer()
                     self.admin_consumer.start()
 
@@ -282,6 +283,7 @@ class Plugin(object):
                     self.logger.warning(
                         "Looks like request consumer has died - attempting to restart"
                     )
+                    self.shutdown_event.wait(5)
                     self.request_consumer = self._create_standard_consumer()
                     self.request_consumer.start()
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -661,7 +661,7 @@ class Plugin(object):
         """Ensure the RequestConsumers are both alive"""
         if self.admin_consumer.is_connected() and self.request_consumer.is_connected():
             if self._mq_retry_attempt != 0:
-                self.logger.info("Admin and request consumers successfully reconnected")
+                self.logger.info("Admin and request consumer connections OK")
 
             self._mq_retry_attempt = 0
             self._mq_timeout = self._mq_starting_timeout

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -51,7 +51,6 @@ class RequestConsumer(threading.Thread):
         self._panic_event = panic_event
         self._max_concurrent = kwargs.get("max_concurrent", 1)
         self.logger = logger or logging.getLogger(__name__)
-        self.shutdown_event = threading.Event()
 
         if kwargs.get("connection_info", None):
             pika_base = PikaClient(**kwargs["connection_info"])
@@ -90,7 +89,6 @@ class RequestConsumer(threading.Thread):
             None
         """
         self.logger.debug("Stopping request consumer")
-        self.shutdown_event.set()
         self._connection.ioloop.add_callback_threadsafe(partial(self.close_channel))
 
     def on_message(self, channel, basic_deliver, properties, body):

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -2,7 +2,6 @@
 import logging
 import threading
 from functools import partial
-from time import sleep
 
 from pika import BlockingConnection, URLParameters, BasicProperties, SelectConnection
 
@@ -50,8 +49,6 @@ class RequestConsumer(threading.Thread):
         self._queue_name = queue_name
         self._on_message_callback = on_message_callback
         self._panic_event = panic_event
-        self._max_connect_retries = kwargs.get("max_connect_retries", -1)
-        self._max_connect_backoff = kwargs.get("max_connect_backoff", 30)
         self._max_concurrent = kwargs.get("max_concurrent", 1)
         self.logger = logger or logging.getLogger(__name__)
         self.shutdown_event = threading.Event()
@@ -309,12 +306,6 @@ class RequestConsumer(threading.Thread):
             None
         """
         self.logger.debug("Connection %s closed: %s", connection, args)
-
-        if not self.shutdown_event.is_set():
-            self.logger.warning("Connection unexpectedly closed: %s", args)
-            self.logger.warning("About to sleep for 5 seconds before stopping IOLoop")
-            sleep(5)
-
         self._connection.ioloop.stop()
 
     def open_channel(self):

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -52,9 +52,13 @@ class RequestConsumer(threading.Thread):
         self._max_concurrent = kwargs.get("max_concurrent", 1)
         self.logger = logger or logging.getLogger(__name__)
 
-        if kwargs.get("connection_info", None):
-            pika_base = PikaClient(**kwargs["connection_info"])
-            self._connection_parameters = pika_base.connection_parameters()
+        if "connection_info" in kwargs:
+            params = kwargs["connection_info"]
+
+            # Default to one attempt as the Plugin implements its own retry logic
+            params["connection_attempts"] = params.get("connection_attempts", 1)
+
+            self._connection_parameters = PikaClient(**params).connection_parameters()
         else:
             self._connection_parameters = URLParameters(amqp_url)
 

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -89,7 +89,7 @@ class RequestConsumer(threading.Thread):
             None
         """
         self.logger.debug("Stopping request consumer")
-        self._connection.ioloop.add_callback_threadsafe(partial(self.close_channel))
+        self._connection.ioloop.add_callback_threadsafe(partial(self._connection.close))
 
     def on_message(self, channel, basic_deliver, properties, body):
         """Invoked when a message is delivered from the queueing service
@@ -330,13 +330,6 @@ class RequestConsumer(threading.Thread):
 
         self.start_consuming()
 
-    def close_channel(self):
-        """Cleanly close the channel"""
-        self.logger.debug("Closing the channel")
-
-        if self._channel and self._channel.is_open:
-            self._channel.close()
-
     def on_channel_closed(self, channel, *args):
         """Channel closed callback
 
@@ -427,4 +420,4 @@ class RequestConsumer(threading.Thread):
         self.logger.debug("Consumer was cancelled: %r", method_frame)
 
         if self._channel:
-            self.close_channel()
+            self._connection.close()

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -91,6 +91,14 @@ class RequestConsumer(threading.Thread):
         self.logger.debug("Stopping request consumer")
         self._connection.ioloop.add_callback_threadsafe(partial(self._connection.close))
 
+    def is_connected(self):
+        """Determine if the underlying connection is open
+
+        Returns:
+            True if the connection exists and is open, False otherwise
+        """
+        return self._connection and self._connection.is_open
+
     def on_message(self, channel, basic_deliver, properties, body):
         """Invoked when a message is delivered from the queueing service
 

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -1,27 +1,17 @@
 # -*- coding: utf-8 -*-
-import abc
 import logging
-
-import six
 import threading
 from functools import partial
+from time import sleep
+
 from pika import BlockingConnection, URLParameters, BasicProperties, SelectConnection
-from pika.exceptions import AMQPConnectionError
 
 from brewtils.errors import DiscardMessageException, RepublishRequestException
 from brewtils.queues import PikaClient, PIKA_ONE
 from brewtils.schema_parser import SchemaParser
 
-if PIKA_ONE:
-    from pika.exceptions import (
-        ConnectionClosed,
-        ChannelClosedByBroker,
-        ChannelClosedByClient,
-    )
 
-
-@six.add_metaclass(abc.ABCMeta)
-class RequestConsumerBase(threading.Thread):
+class RequestConsumer(threading.Thread):
     """RabbitMQ message consumer
 
     This consumer is designed to be fault-tolerant - if RabbitMQ closes the
@@ -32,21 +22,15 @@ class RequestConsumerBase(threading.Thread):
     Unexpected channel closures can indicate a problem with a command that was
     issued.
 
-    :param str amqp_url: The AMQP url to connection with
-    :param str queue_name: The name of the queue to connect to
-    :param func on_message_callback: The function called to invoke message
+    Args:
+        amqp_url: (str) The AMQP url to connect to
+        queue_name: (str) The name of the queue to connect to
+        on_message_callback (func): function called to invoke message
         processing. Must return a Future.
-    :param event panic_event: An event to be set in the event of a catastrophic
-        failure
-    :type event: :py:class:`threading.Event`
-    :param logger: A configured logger
-    :type logger: :py:class:`logging.Logger`
-    :param str thread_name: The name to use for this thread
-    :param int max_connect_retries: Number of connection retry attempts before
-        failure. Default is -1 (retry forever).
-    :param int max_connect_backoff: Maximum amount of time to wait between
-        connection retry attempts. Default 30.
-    :param int max_concurrent: Maximum requests to process concurrently
+        panic_event (threading.Event): Event to be set on a catastrophic failure
+        logger (logging.Logger): A configured Logger
+        thread_name (str): Name to use for this thread
+        max_concurrent: (int) Maximum requests to process concurrently
     """
 
     def __init__(
@@ -78,33 +62,35 @@ class RequestConsumerBase(threading.Thread):
         else:
             self._connection_parameters = URLParameters(amqp_url)
 
-        super(RequestConsumerBase, self).__init__(name=thread_name)
+        super(RequestConsumer, self).__init__(name=thread_name)
 
     def run(self):
         """Run the consumer
 
-        Creates a connection to RabbitMQ and starts the IOLoop. The IOLoop will
-        block and allow the SelectConnection to operate.
+        Creates a connection to RabbitMQ and starts the IOLoop.
 
-        :return:
+        The IOLoop will block and allow the SelectConnection to operate. This means that
+        to stop the RequestConsumer we just need to stop the IOLoop.
+
+        Returns:
+            None
         """
         self._connection = self.open_connection()
-
-        # It is possible to return from open_connection without acquiring a
-        # connection. This usually happens if no max_connect_retries was set
-        # and we are constantly trying to connect to a queue that does not
-        # exist. For those cases, there is no reason to start an ioloop.
-        if self._connection:
-            self._connection.ioloop.start()
+        self._connection.ioloop.start()
 
     def stop(self):
-        """Cleanly shutdown the connection
+        """Cleanly shutdown
 
-        Assumes the stop_consuming method has already been called. When the
-        queueing service acknowledges the closure, the connection is closed
-        which will end the RequestConsumer.
+        It's a good idea to call stop_consuming before this to prevent new messages from
+        being processed during shutdown.
 
-        :return:
+        This sets the shutdown_event to let callbacks know that this is an orderly
+        (requested) shutdown. It then schedules a channel close on the IOLoop - the
+        channel's on_close callback will close the connection, and the connection's
+        on_close callback will terminate the IOLoop which will end the RequestConsumer.
+
+        Returns:
+            None
         """
         self.logger.debug("Stopping request consumer")
         self.shutdown_event.set()
@@ -120,10 +106,11 @@ class RequestConsumerBase(threading.Thread):
         BasicProperties with the message properties and the body is the message
         that was sent.
 
-        :param pika.channel.Channel channel: The channel object
-        :param pika.Spec.Basic.Deliver basic_deliver: basic_deliver method
-        :param pika.Spec.BasicProperties properties: properties
-        :param bytes body: The message body
+        Args:
+            channel (pika.channel.Channel): The channel object
+            basic_deliver (pika.Spec.Basic.Deliver): basic_deliver method
+            properties (pika.Spec.BasicProperties): Message properties
+            body (bytes): The message body
         """
         self.logger.debug(
             "Received message #%s from %s on channel %s: %s",
@@ -263,136 +250,128 @@ class RequestConsumerBase(threading.Thread):
     def open_connection(self):
         """Opens a connection to RabbitMQ
 
-        This method connects to RabbitMQ, returning the connection handle. The
-        on_connection_open method will be invoked when the connection opens.
+        This method immediately returns the connection object. However, whether the
+        connection was successful is not know until a callback is invoked (either
+        on_open_callback or on_open_error_callback).
 
-        :rtype: pika.SelectConnection
+        Returns:
+            The SelectConnection object
         """
-        time_to_wait = 0.1
-        retries = 0
-        while not self.shutdown_event.is_set():
-            try:
-                return SelectConnection(
-                    self._connection_parameters,
-                    self.on_connection_open,
-                    **self._select_kwargs()
-                )
-            except AMQPConnectionError as ex:
-                if 0 <= self._max_connect_retries <= retries:
-                    raise ex
-                self.logger.warning(
-                    "Error attempting to connect, waiting %s seconds and "
-                    "attempting again" % time_to_wait
-                )
-                self.shutdown_event.wait(time_to_wait)
-                time_to_wait = min(time_to_wait * 2, self._max_connect_backoff)
-                retries += 1
+        extra_kwargs = {}
+        if not PIKA_ONE:
+            extra_kwargs["stop_ioloop_on_close"] = False
 
-    def on_connection_open(self, unused_connection):
-        """Invoked when the connection has been established
+        return SelectConnection(
+            parameters=self._connection_parameters,
+            on_open_callback=self.on_connection_open,
+            on_close_callback=self.on_connection_closed,
+            on_open_error_callback=self.on_connection_closed,
+            **extra_kwargs
+        )
+
+    def on_connection_open(self, connection):
+        """Connection open success callback
 
         This method is called by pika once the connection to RabbitMQ has been
-        established. It passes the handle to the connection object in case we
-        need it, but in this case, we'll just mark it unused.
+        established.
 
-        :type unused_connection: pika.SelectConnection
+        The only thing this actually does is call the open_channel method.
+
+        Args:
+            connection: The connection object
+
+        Returns:
+            None
         """
-        self.logger.debug("Connection opened: %s", unused_connection)
-        self._connection.add_on_close_callback(self.on_connection_closed)
+        self.logger.debug("Connection opened: %s", connection)
         self.open_channel()
 
-    def close_connection(self):
-        """This method closes the connection to RabbitMQ"""
-        self.logger.debug("Closing connection")
-        self._connection.close()
+    def on_connection_closed(self, connection, *args):
+        """Connection closed callback
 
-    def do_on_connection_closed(self, connection, reply_code, reply_text):
-        """Invoked when the connection is closed
+        This method is invoked by pika when the connection to RabbitMQ is closed.
 
-        This method is invoked by pika when the connection to RabbitMQ is closed
-        unexpectedly. This method will attempt to reconnect.
+        If the connection is closed we terminate its IOLoop to stop the RequestConsumer.
+        In the case of an unexpected connection closure we'll wait 5 seconds before
+        terminating with the expectation that the plugin will attempt to restart the
+        consumer once it's dead.
 
-        :param pika.connection.Connection connection: the closed connection
-        :param int reply_code: The server provided reply_code if given
-        :param basestring reply_text: The server provided reply_text if given
+        Args:
+            connection: The connection
+            args: Tuple of arguments describing why the connection closed
+                pika < 1:
+                    reply_code: Numeric code indicating close reason
+                    reply_text: String describing close reason
+                pika >= 1:
+                    exc: Exception describing close
+
+        Returns:
+            None
         """
-        self.logger.debug(
-            'Connection "%s" closed: (%s) %s' % (connection, reply_code, reply_text)
-        )
-        self._channel = None
-
-        # A 320 is the server forcing the connection to close
-        if reply_code == 320:
-            self.shutdown_event.set()
-
-        if self.shutdown_event.is_set():
-            self._connection.ioloop.stop()
-        else:
-            self.logger.warning(
-                "Connection unexpectedly closed: (%s) %s" % (reply_code, reply_text)
-            )
-            self.logger.warning("Attempting to reopen connection in 5 seconds")
-            self._connection.add_timeout(5, self.reconnect)
-
-    def reconnect(self):
-        """Will be invoked by the IOLoop timer if the connection is closed"""
-
-        # This is the old connection IOLoop instance, stop its ioloop
-        self._connection.ioloop.stop()
+        self.logger.debug("Connection %s closed: %s", connection, args)
 
         if not self.shutdown_event.is_set():
-            # Creates a new connection
-            self._connection = self.open_connection()
+            self.logger.warning("Connection unexpectedly closed: %s", args)
+            self.logger.warning("About to sleep for 5 seconds before stopping IOLoop")
+            sleep(5)
 
-            # There is now a new connection, needs a new ioloop to run
-            if self._connection:
-                self._connection.ioloop.start()
+        self._connection.ioloop.stop()
 
     def open_channel(self):
-        """Open a channel using the connection
-
-        When RabbitMQ responds that the channel is open, the on_channel_open
-        callback will be invoked.
-        """
+        """Open a channel"""
         self.logger.debug("Opening a new channel")
         self._connection.channel(on_open_callback=self.on_channel_open)
 
     def on_channel_open(self, channel):
-        """Invoked when the channel has been opened
+        """Channel open success callback
 
-        Immediately start consuming since the queue bindings are not the
-        consumer's responsibility.
+        This will add a close callback (on_channel_closed) the channel and will call
+        start_consuming to begin receiving messages.
 
-        :param pika.channel.Channel channel: The channel object
+        Args:
+            channel: The opened channel object
+
+        Returns:
+            None
         """
         self.logger.debug("Channel opened: %s", channel)
+
         self._channel = channel
         self._channel.add_on_close_callback(self.on_channel_closed)
+
         self.start_consuming()
 
     def close_channel(self):
         """Cleanly close the channel"""
         self.logger.debug("Closing the channel")
-        self._channel.close()
 
-    def do_on_channel_closed(self, channel, reply_code, reply_text):
-        """Invoked when the connection is closed
+        if self._channel and self._channel.is_open:
+            self._channel.close()
 
-        Invoked by pika when RabbitMQ unexpectedly closes the channel. Channels
+    def on_channel_closed(self, channel, *args):
+        """Channel closed callback
+
+        This method is invoked by pika when the channel is closed. Channels
         are usually closed as a result of something that violates the protocol,
         such as attempting to re-declare an exchange or queue with different
         parameters.
 
-        This indicates that something has gone wrong, so close the connection
+        This indicates that something has gone wrong, so just close the connection
         to reset.
 
-        :param pika.channel.Channel channel: The closed channel
-        :param int reply_code: The numeric reason the channel was closed
-        :param str reply_text: The text reason the channel was closed
+        Args:
+            channel: The channel
+            args: Tuple of arguments describing why the channel closed
+                pika < 1:
+                    reply_code: Numeric code indicating close reason
+                    reply_text: String describing close reason
+                pika >= 1:
+                    exc: Exception describing close
+
+        Returns:
+            None
         """
-        self.logger.debug(
-            "Channel %i was closed: (%s) %s" % (int(channel), reply_code, reply_text)
-        )
+        self.logger.debug("Channel %i closed: %s", channel, args)
         self._connection.close()
 
     def start_consuming(self):
@@ -404,102 +383,57 @@ class RequestConsumerBase(threading.Thread):
 
         An on_cancel_callback is registered so that the consumer is notified if
         it is canceled by the broker.
+
+        Returns:
+            None
         """
         self.logger.debug("Issuing consumer related RPC commands")
 
         self._channel.basic_qos(prefetch_count=self._max_concurrent)
         self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
-        self._consumer_tag = self._channel.basic_consume(**self._consume_kwargs())
+
+        consume_kwargs = {"queue": self._queue_name}
+        if PIKA_ONE:
+            consume_kwargs["on_message_callback"] = self.on_message
+        else:
+            consume_kwargs["consumer_callback"] = self.on_message
+
+        self._consumer_tag = self._channel.basic_consume(**consume_kwargs)
 
     def stop_consuming(self):
-        """Stop consuming messages"""
-        self.logger.debug("Stopping consuming on channel %s", self._channel)
+        """Stop consuming messages
+
+        Sends a Basic.Cancel command to the broker, which causes the broker to stop
+        sending the consumer messages.
+
+        Returns:
+            None
+        """
+        self.logger.debug("Stopping message consuming on channel %i", self._channel)
+
         if self._channel:
-            self.logger.debug("Sending a Basic.Cancel RPC command to RabbitMQ")
             self._connection.ioloop.add_callback_threadsafe(
                 partial(
                     self._channel.basic_cancel,
-                    callback=self.on_cancelok,
                     consumer_tag=self._consumer_tag,
+                    callback=lambda *args: None,
                 )
             )
 
     def on_consumer_cancelled(self, method_frame):
-        """Invoked when the consumer is canceled by the broker
+        """Consumer cancelled callback
 
-        This method will simply close the channel if it exists.
+        This is only invoked if the consumer is cancelled by the broker. Since that
+        effectively ends the request consuming we close the channel to start the
+        process of terminating the RequestConsumer.
 
-        :param pika.frame.Method method_frame: The Basic.Cancel frame
+        Args:
+            method_frame (pika.frame.Method): The Basic.Cancel frame
+
+        Returns:
+            None
         """
-        self.logger.debug(
-            "Consumer was cancelled remotely, shutting down: %r" % method_frame
-        )
+        self.logger.debug("Consumer was cancelled: %r", method_frame)
+
         if self._channel:
             self.close_channel()
-
-    def on_cancelok(self, unused_frame):
-        """Invoked when RabbitMq acknowledges consumer cancellation
-
-        This method is invoked when RabbitMQ acknowledges the cancellation of a
-        consumer. It is unused except for logging purposes.
-
-        :param pika.frame.Method unused_frame: The Basic.CancelOK frame
-        """
-        self.logger.debug(unused_frame)
-        self.logger.debug("RabbitMQ acknowledged consumer cancellation")
-
-
-class RequestConsumerPika0(RequestConsumerBase):
-    """Implementation of a Pika v0 RequestConsumer
-
-    This exists because some kwargs and callback signatures changed between version
-    0 and version 1. This is essentially a wrapper that delegates to the
-    RequestConsumerBase methods.
-
-    """
-
-    def on_connection_closed(self, *args):
-        self.do_on_connection_closed(*args)
-
-    def on_channel_closed(self, *args):
-        self.do_on_channel_closed(*args)
-
-    @staticmethod
-    def _select_kwargs():
-        return {"stop_ioloop_on_close": False}
-
-    def _consume_kwargs(self):
-        return {"queue": self._queue_name, "consumer_callback": self.on_message}
-
-
-class RequestConsumerPika1(RequestConsumerBase):
-    """Implementation of a Pika v1 RequestConsumer
-
-    This exists because some kwargs and callback signatures changed between version
-    0 and version 1. This is essentially a wrapper that delegates to the
-    RequestConsumerBase methods after translating arguments.
-
-    """
-
-    def on_connection_closed(self, connection, exc):
-        if isinstance(exc, ConnectionClosed):
-            self.do_on_connection_closed(connection, exc.reply_code, exc.reply_text)
-        else:
-            raise exc
-
-    def on_channel_closed(self, channel, exc):
-        if isinstance(exc, (ChannelClosedByBroker, ChannelClosedByClient)):
-            self.do_on_channel_closed(channel, exc.reply_code, exc.reply_text)
-        else:
-            raise exc
-
-    @staticmethod
-    def _select_kwargs():
-        return {}
-
-    def _consume_kwargs(self):
-        return {"queue": self._queue_name, "on_message_callback": self.on_message}
-
-
-# The real RequestConsumer is based on the pika version
-RequestConsumer = RequestConsumerPika1 if PIKA_ONE else RequestConsumerPika0

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -346,7 +346,7 @@ class RequestConsumer(threading.Thread):
         parameters.
 
         This indicates that something has gone wrong, so just close the connection
-        to reset.
+        (if it's still open) to reset.
 
         Args:
             channel: The channel
@@ -361,7 +361,9 @@ class RequestConsumer(threading.Thread):
             None
         """
         self.logger.debug("Channel %i closed: %s", channel, args)
-        self._connection.close()
+
+        if self._connection.is_open:
+            self._connection.close()
 
     def start_consuming(self):
         """Begin consuming messages

--- a/brewtils/request_consumer.py
+++ b/brewtils/request_consumer.py
@@ -264,16 +264,11 @@ class RequestConsumer(threading.Thread):
         Returns:
             The SelectConnection object
         """
-        extra_kwargs = {}
-        if not PIKA_ONE:
-            extra_kwargs["stop_ioloop_on_close"] = False
-
         return SelectConnection(
             parameters=self._connection_parameters,
             on_open_callback=self.on_connection_open,
             on_close_callback=self.on_connection_closed,
             on_open_error_callback=self.on_connection_closed,
-            **extra_kwargs
         )
 
     def on_connection_open(self, connection):

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ lark-parser < 0.7
 marshmallow < 3
 marshmallow-polyfield < 4
 packaging < 20
-pika < 1.1, >= 0.11
+pika <= 1.1, >= 0.11
 pyjwt < 2
 requests < 3
 simplejson < 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ packaging==19.0
 pathlib2==2.3.3           # via pytest
 pathtools==0.1.2          # via watchdog
 pbr==5.1.3                # via mock
-pika==1.0.1
+pika==1.1.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.9.0             # via pytest, tox
 py==1.8.0                 # via pytest, tox

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "marshmallow<3",
         "marshmallow-polyfield<4",
         "packaging<20",
-        "pika<1.1,>=0.11",
+        "pika<=1.1,>=0.11",
         "pyjwt<2",
         "requests<3",
         "simplejson<4",


### PR DESCRIPTION
This fixes beer-garden/beer-garden#359, but should be merged after #155.

This PR adds progressive backoff logic for when the `RequestConsumers` become disconnected. It adds additional flags to the `Plugin` argument list that mirror the flags used to control the retry behavior when the connection to brew-view dies.