### PR TITLE
Template members

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -306,17 +306,21 @@ class RequestTemplate(BaseModel):
         system_version=None,
         instance_name=None,
         command=None,
+        command_type=None,
         parameters=None,
         comment=None,
         metadata=None,
+        output_type=None,
     ):
         self.system = system
         self.system_version = system_version
         self.instance_name = instance_name
         self.command = command
+        self.command_type = command_type
         self.parameters = parameters
         self.comment = comment
         self.metadata = metadata or {}
+        self.output_type = output_type
 
     def __str__(self):
         return self.command
@@ -365,17 +369,17 @@ class Request(RequestTemplate):
             system_version=system_version,
             instance_name=instance_name,
             command=command,
+            command_type=command_type,
             parameters=parameters,
             comment=comment,
             metadata=metadata,
+            output_type=output_type,
         )
         self.id = id
         self.parent = parent
         self.children = children
         self.output = output
-        self.output_type = output_type
         self._status = status
-        self.command_type = command_type
         self.created_at = created_at
         self.updated_at = updated_at
         self.error_class = error_class
@@ -389,9 +393,11 @@ class Request(RequestTemplate):
             system_version=template.system_version,
             instance_name=template.instance_name,
             command=template.command,
+            command_type=template.command_type,
             parameters=template.parameters,
             comment=template.comment,
             metadata=template.metadata,
+            output_type=template.output_type,
         )
 
     def __repr__(self):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -399,18 +399,21 @@ class Request(RequestTemplate):
         self.requester = requester
 
     @classmethod
-    def from_template(cls, template):
-        return Request(
-            system=template.system,
-            system_version=template.system_version,
-            instance_name=template.instance_name,
-            command=template.command,
-            command_type=template.command_type,
-            parameters=template.parameters,
-            comment=template.comment,
-            metadata=template.metadata,
-            output_type=template.output_type,
-        )
+    def from_template(cls, template, **kwargs):
+        """Create a Request instance from a RequestTemplate
+
+        Args:
+            template: The RequestTemplate to use
+            **kwargs: Optional overrides to use in place of the template's attributes
+
+        Returns:
+            The new Request instance
+        """
+        request_params = {
+            k: kwargs.get(k, getattr(template, k))
+            for k in RequestTemplate.TEMPLATE_FIELDS
+        }
+        return Request(**request_params)
 
     def __repr__(self):
         return (

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -300,6 +300,18 @@ class RequestTemplate(BaseModel):
 
     schema = "RequestTemplateSchema"
 
+    TEMPLATE_FIELDS = [
+        "system",
+        "system_version",
+        "instance_name",
+        "command",
+        "command_type",
+        "parameters",
+        "comment",
+        "metadata",
+        "output_type",
+    ]
+
     def __init__(
         self,
         system=None,

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -165,9 +165,11 @@ class RequestTemplateSchema(BaseSchema):
     system_version = fields.Str(allow_none=True)
     instance_name = fields.Str(allow_none=True)
     command = fields.Str(allow_none=True)
+    command_type = fields.Str(allow_none=True)
     parameters = fields.Dict(allow_none=True)
     comment = fields.Str(allow_none=True)
     metadata = fields.Dict(allow_none=True)
+    output_type = fields.Str(allow_none=True)
 
 
 class RequestSchema(RequestTemplateSchema):
@@ -178,9 +180,7 @@ class RequestSchema(RequestTemplateSchema):
         "self", exclude=("parent", "children"), many=True, default=None, allow_none=True
     )
     output = fields.Str(allow_none=True)
-    output_type = fields.Str(allow_none=True)
     status = fields.Str(allow_none=True)
-    command_type = fields.Str(allow_none=True)
     error_class = fields.Str(allow_none=True)
     created_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
     updated_at = DateTime(allow_none=True, format="epoch", example="1500065932000")

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -294,9 +294,11 @@ def request_template_dict():
         "system_version": "1.0.0",
         "instance_name": "default",
         "command": "speak",
+        "command_type": "ACTION",
         "parameters": {"message": "hey!"},
         "comment": "hi!",
         "metadata": {"request": "stuff"},
+        "output_type": "STRING",
     }
 
 

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -218,15 +218,20 @@ class TestParameter(object):
 
 class TestRequestTemplate(object):
     @pytest.fixture
-    def request_template(self):
+    def test_template(self):
         return RequestTemplate(command="command", system="system")
 
-    def test_str(self, request_template):
-        assert str(request_template) == "command"
+    def test_str(self, test_template):
+        assert str(test_template) == "command"
 
-    def test_repr(self, request_template):
-        assert "name" in repr(request_template)
-        assert "system" in repr(request_template)
+    def test_repr(self, test_template):
+        assert "name" in repr(test_template)
+        assert "system" in repr(test_template)
+
+    def test_template_fields(self, bg_request_template):
+        """This will hopefully prevent forgetting to add things to TEMPLATE_FIELDS"""
+        template_keys = set(bg_request_template.__dict__.keys())
+        assert template_keys == set(RequestTemplate.TEMPLATE_FIELDS)
 
 
 class TestRequest(object):
@@ -273,6 +278,13 @@ class TestRequest(object):
         request = Request.from_template(bg_request_template)
         for key in bg_request_template.__dict__:
             assert getattr(request, key) == getattr(bg_request_template, key)
+
+    def test_from_template_overrides(self, bg_request_template):
+        request = Request.from_template(bg_request_template, command_type="INFO")
+        assert request.command_type == "INFO"
+        for key in bg_request_template.__dict__:
+            if key != "command_type":
+                assert getattr(request, key) == getattr(bg_request_template, key)
 
 
 class TestSystem(object):


### PR DESCRIPTION
This PR moves the `command_type` and `output_type` fields from the `Request` into the `RequestTemplate`.

This has no effect on the way `Request`s are serialized, so there's no external API change.

The driver for this is that plugin start, stop, and status requests should really be `RequestTemplate`s and not `Request`s, but they need to be able to specify that their `command_type` should be EPHEMERAL. 