### PR TITLE
Moving functionality out of brewtils init

### DIFF
--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -1,20 +1,12 @@
 # -*- coding: utf-8 -*-
-
-import warnings
-from argparse import ArgumentParser
-
-from yapconf import YapconfSpec
-from yapconf.exceptions import YapconfItemNotFound
-
+from brewtils.config import get_argument_parser, get_connection_info, load_config
 from brewtils.decorators import command, parameter, system
-from brewtils.errors import ValidationError
 from brewtils.log import configure_logging
 from brewtils.plugin import Plugin, RemotePlugin
 from brewtils.rest import normalize_url_prefix
-from brewtils.rest.easy_client import EasyClient
+from brewtils.rest.easy_client import get_easy_client, EasyClient
 from brewtils.rest.system_client import SystemClient
 from ._version import __version__ as generated_version
-from .specification import SPECIFICATION
 
 __all__ = [
     "command",
@@ -30,192 +22,10 @@ __all__ = [
     "load_config",
     "get_bg_connection_parameters",
     "configure_logging",
+    "normalize_url_prefix",
 ]
 
 __version__ = generated_version
-
-
-def get_easy_client(**kwargs):
-    """Easy way to get an EasyClient
-
-    The benefit to this method over creating an EasyClient directly is that
-    this method will also search the environment for parameters. Kwargs passed
-    to this method will take priority, however.
-
-    Args:
-        **kwargs: Options for configuring the EasyClient
-
-    Returns:
-        :obj:`brewtils.rest.easy_client.EasyClient`: The configured client
-    """
-    from brewtils.rest.easy_client import EasyClient
-
-    parser = kwargs.pop("parser", None)
-    logger = kwargs.pop("logger", None)
-
-    return EasyClient(logger=logger, parser=parser, **get_connection_info(**kwargs))
-
-
-def get_argument_parser():
-    """Get an ArgumentParser pre-populated with Brewtils arguments
-
-    This is helpful if you're expecting additional command line arguments to
-    a plugin startup script.
-
-    This enables doing something like::
-
-        def main():
-            parser = get_argument_parser()
-            parser.add_argument('positional_arg')
-
-            parsed_args = parser.parse_args(sys.argv[1:])
-
-            # Now you can use the extra argument
-            client = MyClient(parsed_args.positional_arg)
-
-            # But you'll need to be careful when using the 'normal' Brewtils
-            # configuration loading methods:
-
-            # Option 1: Tell Brewtils about your customized parser
-            connection = get_connection_info(cli_args=sys.argv[1:],
-                                             argument_parser=parser)
-
-            # Option 2: Use the parsed CLI as a dictionary
-            connection = get_connection_info(**vars(parsed_args))
-
-            # Now specify connection kwargs like normal
-            plugin = RemotePlugin(client, name=...
-                                  **connection)
-
-    IMPORTANT: Note that in both cases the returned ``connection`` object **will
-    not** contain your new value. Both options just prevent normal CLI parsing
-    from failing on the unknown argument.
-
-    Returns:
-        :ArgumentParser: Argument parser with Brewtils arguments loaded
-    """
-    parser = ArgumentParser()
-
-    YapconfSpec(SPECIFICATION).add_arguments(parser)
-
-    return parser
-
-
-def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
-    """Wrapper around ``load_config`` that returns only connection parameters
-
-    Args:
-        cli_args (list, optional): List of command line arguments for
-            configuration loading
-        argument_parser (ArgumentParser, optional): Argument parser to use when
-            parsing cli_args. Supplying this allows adding additional arguments
-            prior to loading the configuration. This can be useful if your
-            startup script takes additional arguments.
-        **kwargs: Additional configuration overrides
-
-    Returns:
-        :dict: Parameters needed to make a connection to Beergarden
-    """
-    config = load_config(cli_args=cli_args, argument_parser=argument_parser, **kwargs)
-
-    return {
-        key: config[key]
-        for key in (
-            "bg_host",
-            "bg_port",
-            "ssl_enabled",
-            "api_version",
-            "ca_cert",
-            "client_cert",
-            "url_prefix",
-            "ca_verify",
-            "username",
-            "password",
-            "access_token",
-            "refresh_token",
-            "client_timeout",
-        )
-    }
-
-
-def load_config(cli_args=None, argument_parser=None, **kwargs):
-    """Load configuration using Yapconf
-
-    Configuration will be loaded from these sources, with earlier sources having
-    higher priority:
-
-        1. ``**kwargs`` passed to this method
-        2. ``cli_args`` passed to this method
-        3. Environment variables using the ``BG_`` prefix
-        4. Default values in the brewtils specification
-
-    Args:
-        cli_args (list, optional): List of command line arguments for
-            configuration loading
-        argument_parser (ArgumentParser, optional): Argument parser to use when
-            parsing cli_args. Supplying this allows adding additional arguments
-            prior to loading the configuration. This can be useful if your
-            startup script takes additional arguments. See get_argument_parser
-            for additional information.
-        **kwargs: Additional configuration overrides
-
-    Returns:
-        :obj:`box.Box`: The resolved configuration object
-    """
-    spec = YapconfSpec(SPECIFICATION, env_prefix="BG_")
-
-    sources = []
-
-    if kwargs:
-        # Do a little kwarg massaging for backwards compatibility
-        if "bg_host" not in kwargs and "host" in kwargs:
-            warnings.warn(
-                "brewtils.load_config called with 'host' keyword "
-                "argument. This name will be removed in version 3.0, "
-                "please use 'bg_host' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            kwargs["bg_host"] = kwargs.pop("host")
-        if "bg_port" not in kwargs and "port" in kwargs:
-            warnings.warn(
-                "brewtils.load_config called with 'port' keyword "
-                "argument. This name will be removed in version 3.0, "
-                "please use 'bg_port' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            kwargs["bg_port"] = kwargs.pop("port")
-
-        sources.append(("kwargs", kwargs))
-
-    if cli_args:
-        if not argument_parser:
-            argument_parser = ArgumentParser()
-            spec.add_arguments(argument_parser)
-
-        parsed_args = argument_parser.parse_args(cli_args)
-        sources.append(("cli_args", vars(parsed_args)))
-
-    sources.append("ENVIRONMENT")
-
-    try:
-        config = spec.load_config(*sources)
-    except YapconfItemNotFound as ex:
-        if ex.item.name == "bg_host":
-            raise ValidationError(
-                "Unable to create a plugin without a "
-                "beer-garden host. Please specify one on the "
-                "command line (--bg-host), in the "
-                "environment (BG_HOST), or in kwargs "
-                "(bg_host)"
-            )
-        raise
-
-    # Make sure the url_prefix is normal
-    config.url_prefix = normalize_url_prefix(config.url_prefix)
-
-    return config
 
 
 # Alias old names for compatibility

--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+from argparse import ArgumentParser
+
+from yapconf import YapconfSpec
+from yapconf.exceptions import YapconfItemNotFound
+
+from brewtils.errors import ValidationError
+from brewtils.specification import SPECIFICATION
+from brewtils.rest import normalize_url_prefix
+
+
+def get_argument_parser():
+    """Get an ArgumentParser pre-populated with Brewtils arguments
+
+    This is helpful if you're expecting additional command line arguments to
+    a plugin startup script.
+
+    This enables doing something like::
+
+        def main():
+            parser = get_argument_parser()
+            parser.add_argument('positional_arg')
+
+            parsed_args = parser.parse_args(sys.argv[1:])
+
+            # Now you can use the extra argument
+            client = MyClient(parsed_args.positional_arg)
+
+            # But you'll need to be careful when using the 'normal' Brewtils
+            # configuration loading methods:
+
+            # Option 1: Tell Brewtils about your customized parser
+            connection = get_connection_info(cli_args=sys.argv[1:],
+                                             argument_parser=parser)
+
+            # Option 2: Use the parsed CLI as a dictionary
+            connection = get_connection_info(**vars(parsed_args))
+
+            # Now specify connection kwargs like normal
+            plugin = RemotePlugin(client, name=...
+                                  **connection)
+
+    IMPORTANT: Note that in both cases the returned ``connection`` object **will
+    not** contain your new value. Both options just prevent normal CLI parsing
+    from failing on the unknown argument.
+
+    Returns:
+        :ArgumentParser: Argument parser with Brewtils arguments loaded
+    """
+    parser = ArgumentParser()
+
+    YapconfSpec(SPECIFICATION).add_arguments(parser)
+
+    return parser
+
+
+def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
+    """Wrapper around ``load_config`` that returns only connection parameters
+
+    Args:
+        cli_args (list, optional): List of command line arguments for
+            configuration loading
+        argument_parser (ArgumentParser, optional): Argument parser to use when
+            parsing cli_args. Supplying this allows adding additional arguments
+            prior to loading the configuration. This can be useful if your
+            startup script takes additional arguments.
+        **kwargs: Additional configuration overrides
+
+    Returns:
+        :dict: Parameters needed to make a connection to Beergarden
+    """
+    config = load_config(cli_args=cli_args, argument_parser=argument_parser, **kwargs)
+
+    return {
+        key: config[key]
+        for key in (
+            "bg_host",
+            "bg_port",
+            "ssl_enabled",
+            "api_version",
+            "ca_cert",
+            "client_cert",
+            "url_prefix",
+            "ca_verify",
+            "username",
+            "password",
+            "access_token",
+            "refresh_token",
+            "client_timeout",
+        )
+    }
+
+
+def load_config(cli_args=None, argument_parser=None, **kwargs):
+    """Load configuration using Yapconf
+
+    Configuration will be loaded from these sources, with earlier sources having
+    higher priority:
+
+        1. ``**kwargs`` passed to this method
+        2. ``cli_args`` passed to this method
+        3. Environment variables using the ``BG_`` prefix
+        4. Default values in the brewtils specification
+
+    Args:
+        cli_args (list, optional): List of command line arguments for
+            configuration loading
+        argument_parser (ArgumentParser, optional): Argument parser to use when
+            parsing cli_args. Supplying this allows adding additional arguments
+            prior to loading the configuration. This can be useful if your
+            startup script takes additional arguments. See get_argument_parser
+            for additional information.
+        **kwargs: Additional configuration overrides
+
+    Returns:
+        :obj:`box.Box`: The resolved configuration object
+    """
+    spec = YapconfSpec(SPECIFICATION, env_prefix="BG_")
+
+    sources = []
+
+    if kwargs:
+        # Do a little kwarg massaging for backwards compatibility
+        if "bg_host" not in kwargs and "host" in kwargs:
+            warnings.warn(
+                "brewtils.load_config called with 'host' keyword "
+                "argument. This name will be removed in version 3.0, "
+                "please use 'bg_host' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            kwargs["bg_host"] = kwargs.pop("host")
+        if "bg_port" not in kwargs and "port" in kwargs:
+            warnings.warn(
+                "brewtils.load_config called with 'port' keyword "
+                "argument. This name will be removed in version 3.0, "
+                "please use 'bg_port' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            kwargs["bg_port"] = kwargs.pop("port")
+
+        sources.append(("kwargs", kwargs))
+
+    if cli_args:
+        if not argument_parser:
+            argument_parser = ArgumentParser()
+            spec.add_arguments(argument_parser)
+
+        parsed_args = argument_parser.parse_args(cli_args)
+        sources.append(("cli_args", vars(parsed_args)))
+
+    sources.append("ENVIRONMENT")
+
+    try:
+        config = spec.load_config(*sources)
+    except YapconfItemNotFound as ex:
+        if ex.item.name == "bg_host":
+            raise ValidationError(
+                "Unable to create a plugin without a "
+                "beer-garden host. Please specify one on the "
+                "command line (--bg-host), in the "
+                "environment (BG_HOST), or in kwargs "
+                "(bg_host)"
+            )
+        raise
+
+    # Make sure the url_prefix is normal
+    config.url_prefix = normalize_url_prefix(config.url_prefix)
+
+    return config

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -5,6 +5,7 @@ import warnings
 import requests.exceptions
 import wrapt
 
+from brewtils.config import get_connection_info
 from brewtils.errors import (
     FetchError,
     ValidationError,
@@ -19,6 +20,25 @@ from brewtils.errors import (
 from brewtils.models import Event, PatchOperation
 from brewtils.rest.client import RestClient
 from brewtils.schema_parser import SchemaParser
+
+
+def get_easy_client(**kwargs):
+    """Easy way to get an EasyClient
+
+    The benefit to this method over creating an EasyClient directly is that
+    this method will also search the environment for parameters. Kwargs passed
+    to this method will take priority, however.
+
+    Args:
+        **kwargs: Options for configuring the EasyClient
+
+    Returns:
+        :obj:`brewtils.rest.easy_client.EasyClient`: The configured client
+    """
+    parser = kwargs.pop("parser", None)
+    logger = kwargs.pop("logger", None)
+
+    return EasyClient(logger=logger, parser=parser, **get_connection_info(**kwargs))
 
 
 def handle_response_failure(response, default_exc=RestError, raise_404=True):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
-
 import copy
 import os
 import warnings
 
 import pytest
 
-import brewtils
-import brewtils.rest
+from brewtils.config import load_config, get_argument_parser, get_connection_info
 from brewtils.errors import ValidationError
-from brewtils.rest.easy_client import EasyClient
 
 
-class TestBrewtils(object):
+class TestGetConnectionInfo(object):
     @pytest.fixture
     def params(self):
         return {
@@ -37,50 +34,10 @@ class TestBrewtils(object):
     def teardown_method(self):
         os.environ = self.safe_copy
 
-    def test_load_config_cli(self):
-        cli_args = ["--bg-host", "the_host"]
+    def test_kwargs(self, params):
+        assert params == get_connection_info(**params)
 
-        config = brewtils.load_config(cli_args)
-        assert config.bg_host == "the_host"
-
-    def test_load_config_cli_custom_argument_parser_vars(self):
-        parser = brewtils.get_argument_parser()
-        parser.add_argument("some_parameter")
-
-        cli_args = ["param", "--bg-host", "the_host"]
-        parsed_args = parser.parse_args(cli_args)
-
-        config = brewtils.load_config(**vars(parsed_args))
-        assert config.bg_host == "the_host"
-        assert parsed_args.some_parameter == "param"
-        assert "some_parameter" not in config
-
-    def test_load_config_cli_custom_argument_parser_cli(self):
-        parser = brewtils.get_argument_parser()
-        parser.add_argument("some_parameter")
-
-        cli_args = ["param", "--bg-host", "the_host"]
-        parsed_args = parser.parse_args(cli_args)
-
-        config = brewtils.load_config(cli_args=cli_args, argument_parser=parser)
-        assert config.bg_host == "the_host"
-        assert parsed_args.some_parameter == "param"
-        assert "some_parameter" not in config
-
-    def test_load_config_environment(self):
-        os.environ["BG_HOST"] = "the_host"
-
-        config = brewtils.load_config([])
-        assert config.bg_host == "the_host"
-
-    def test_get_easy_client(self):
-        client = brewtils.get_easy_client(bg_host="bg_host")
-        assert isinstance(client, EasyClient) is True
-
-    def test_get_connection_info_kwargs(self, params):
-        assert params == brewtils.get_connection_info(**params)
-
-    def test_get_connection_info_env(self, params):
+    def test_env(self, params):
         os.environ["BG_HOST"] = "bg_host"
         os.environ["BG_PORT"] = "1234"
         os.environ["BG_SSL_ENABLED"] = "False"
@@ -89,33 +46,33 @@ class TestBrewtils(object):
         os.environ["BG_URL_PREFIX"] = "/beer/"
         os.environ["BG_CA_VERIFY"] = "True"
 
-        assert params == brewtils.get_connection_info()
+        assert params == get_connection_info()
 
-    def test_get_connection_info_deprecated_kwarg_host(self, params):
+    def test_deprecated_kwarg_host(self, params):
         deprecated_params = copy.copy(params)
         deprecated_params["host"] = deprecated_params.pop("bg_host")
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            assert params == brewtils.get_connection_info(**deprecated_params)
+            assert params == get_connection_info(**deprecated_params)
 
             assert issubclass(w[0].category, DeprecationWarning)
             assert "host" in str(w[0].message)
 
-    def test_get_connection_info_deprecated_kwarg_port(self, params):
+    def test_deprecated_kwarg_port(self, params):
         deprecated_params = copy.copy(params)
         deprecated_params["port"] = deprecated_params.pop("bg_port")
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            assert params == brewtils.get_connection_info(**deprecated_params)
+            assert params == get_connection_info(**deprecated_params)
 
             assert issubclass(w[0].category, DeprecationWarning)
             assert "port" in str(w[0].message)
 
-    def test_get_connection_info_deprecated_env(self, params):
+    def test_deprecated_env(self, params):
         deprecated_params = copy.copy(params)
         deprecated_params["bg_host"] = None
         deprecated_params["bg_port"] = None
@@ -127,15 +84,59 @@ class TestBrewtils(object):
         os.environ["BG_WEB_HOST"] = "bg_host"
         os.environ["BG_WEB_PORT"] = "1234"
 
-        assert params == brewtils.get_connection_info(**deprecated_params)
+        assert params == get_connection_info(**deprecated_params)
 
-    def test_get_connection_info_no_host(self):
+    def test_no_host(self):
         with pytest.raises(ValidationError):
-            brewtils.get_connection_info()
+            get_connection_info()
 
     def test_normalize_url_prefix(self, params):
         os.environ["BG_WEB_HOST"] = "bg_host"
         os.environ["BG_URL_PREFIX"] = "/beer"
 
-        generated_params = brewtils.get_connection_info()
+        generated_params = get_connection_info()
         assert generated_params["url_prefix"] == params["url_prefix"]
+
+
+class TestLoadConfig(object):
+    def setup_method(self):
+        self.safe_copy = os.environ.copy()
+
+    def teardown_method(self):
+        os.environ = self.safe_copy
+
+    def test_cli(self):
+        cli_args = ["--bg-host", "the_host"]
+
+        config = load_config(cli_args)
+        assert config.bg_host == "the_host"
+
+    def test_cli_custom_argument_parser_vars(self):
+        parser = get_argument_parser()
+        parser.add_argument("some_parameter")
+
+        cli_args = ["param", "--bg-host", "the_host"]
+        parsed_args = parser.parse_args(cli_args)
+
+        config = load_config(**vars(parsed_args))
+        assert config.bg_host == "the_host"
+        assert parsed_args.some_parameter == "param"
+        assert "some_parameter" not in config
+
+    def test_cli_custom_argument_parser_cli(self):
+        parser = get_argument_parser()
+        parser.add_argument("some_parameter")
+
+        cli_args = ["param", "--bg-host", "the_host"]
+        parsed_args = parser.parse_args(cli_args)
+
+        config = load_config(cli_args=cli_args, argument_parser=parser)
+        assert config.bg_host == "the_host"
+        assert parsed_args.some_parameter == "param"
+        assert "some_parameter" not in config
+
+    def test_environment(self):
+        os.environ["BG_HOST"] = "the_host"
+
+        config = load_config([])
+        assert config.bg_host == "the_host"

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -19,8 +19,13 @@ from brewtils.errors import (
     WaitExceededError,
 )
 from brewtils.models import System
-from brewtils.rest.easy_client import EasyClient, BrewmasterEasyClient
+from brewtils.rest.easy_client import get_easy_client, EasyClient, BrewmasterEasyClient
 from brewtils.schema_parser import SchemaParser
+
+
+def test_get_easy_client():
+    client = get_easy_client(bg_host="bg_host")
+    assert isinstance(client, EasyClient)
 
 
 class TestEasyClient(object):


### PR DESCRIPTION
This PR moves all functionality out of the `brewtils.__init__` module.

This does introduce a potentially breaking change - previously we imported `ValidationError` and `SPECIFICATION` as top-level imports because we needed to use them. So it was possible to do something like:

```python
from brewtils import ValidationError
from brewtils import SPECIFICATION
```

You'd get a warning from your IDE because those names are not in `__all__`, but it would still actually work.

This would not work for any other error classes, only `ValidationError`.

This is also an issue for some other things we're no longer importing in that module as well, like `YapconfSpec`, but if you were doing something like

```python
from brewtils import YapconfSpec
```

that is just incorrect and I don't feel bad about breaking it.

These changes have been added to beer-garden/brewtils#92 for inclusion in the documentation, but if we feel strongly about it I can add the import statements back.