### PR TITLE
Plugin cleanup

### DIFF
--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -78,11 +78,11 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
         for key in (
             "bg_host",
             "bg_port",
+            "bg_url_prefix",
             "ssl_enabled",
             "api_version",
             "ca_cert",
             "client_cert",
-            "url_prefix",
             "ca_verify",
             "username",
             "password",
@@ -168,6 +168,6 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
         raise
 
     # Make sure the url_prefix is normal
-    config.url_prefix = normalize_url_prefix(config.url_prefix)
+    config.bg_url_prefix = normalize_url_prefix(config.bg_url_prefix)
 
     return config

--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -93,7 +93,7 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
     }
 
 
-def load_config(cli_args=None, argument_parser=None, **kwargs):
+def load_config(cli_args=True, argument_parser=None, **kwargs):
     """Load configuration using Yapconf
 
     Configuration will be loaded from these sources, with earlier sources having
@@ -105,10 +105,13 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
         4. Default values in the brewtils specification
 
     Args:
-        cli_args (list, optional): List of command line arguments for
-            configuration loading
-        argument_parser (ArgumentParser, optional): Argument parser to use when
-            parsing cli_args. Supplying this allows adding additional arguments
+        cli_args (Union[bool, list], optional): Specifies whether command line should be
+            used as a configuration source.
+            - True: Argparse will use the standard sys.argv[1:]
+            - False: Command line arguments will be ignored when loading configuration
+            - List of strings: Will be parsed as CLI args (instead of using sys.argv)
+        argument_parser (ArgumentParser, optional, deprecated): Argument parser to use
+            when parsing cli_args. Supplying this allows adding additional arguments
             prior to loading the configuration. This can be useful if your
             startup script takes additional arguments. See get_argument_parser
             for additional information.
@@ -145,12 +148,15 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
         sources.append(("kwargs", kwargs))
 
     if cli_args:
-        if not argument_parser:
-            argument_parser = ArgumentParser()
-            spec.add_arguments(argument_parser)
+        if cli_args is True:
+            sources.append("CLI")
+        else:
+            if not argument_parser:
+                argument_parser = ArgumentParser()
+                spec.add_arguments(argument_parser)
 
-        parsed_args, _ = argument_parser.parse_known_args(cli_args)
-        sources.append(("cli_args", vars(parsed_args)))
+            parsed_args, unknown = argument_parser.parse_known_args(cli_args)
+            sources.append(("cli_args", vars(parsed_args)))
 
     sources.append("ENVIRONMENT")
 

--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -93,23 +93,26 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
     }
 
 
-def load_config(cli_args=True, argument_parser=None, **kwargs):
+def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs):
     """Load configuration using Yapconf
 
     Configuration will be loaded from these sources, with earlier sources having
     higher priority:
 
         1. ``**kwargs`` passed to this method
-        2. ``cli_args`` passed to this method
-        3. Environment variables using the ``BG_`` prefix
+        2. Command line arguments (if ``cli_args`` argument is not False)
+        3. Environment variables using the ``BG_`` prefix (if ``environment`` argument
+            is not False)
         4. Default values in the brewtils specification
 
     Args:
         cli_args (Union[bool, list], optional): Specifies whether command line should be
-            used as a configuration source.
+            used as a configuration source
             - True: Argparse will use the standard sys.argv[1:]
             - False: Command line arguments will be ignored when loading configuration
             - List of strings: Will be parsed as CLI args (instead of using sys.argv)
+        environment (bool): Specifies whether environment variables (with the ``BG_``
+            prefix) should be used when loading configuration
         argument_parser (ArgumentParser, optional, deprecated): Argument parser to use
             when parsing cli_args. Supplying this allows adding additional arguments
             prior to loading the configuration. This can be useful if your
@@ -158,7 +161,8 @@ def load_config(cli_args=True, argument_parser=None, **kwargs):
             parsed_args, unknown = argument_parser.parse_known_args(cli_args)
             sources.append(("cli_args", vars(parsed_args)))
 
-    sources.append("ENVIRONMENT")
+    if environment:
+        sources.append("ENVIRONMENT")
 
     try:
         config = spec.load_config(*sources)

--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -149,7 +149,7 @@ def load_config(cli_args=None, argument_parser=None, **kwargs):
             argument_parser = ArgumentParser()
             spec.add_arguments(argument_parser)
 
-        parsed_args = argument_parser.parse_args(cli_args)
+        parsed_args, _ = argument_parser.parse_known_args(cli_args)
         sources.append(("cli_args", vars(parsed_args)))
 
     sources.append("ENVIRONMENT")

--- a/brewtils/errors.py
+++ b/brewtils/errors.py
@@ -2,8 +2,13 @@
 
 import json
 import logging
+import warnings
+from functools import partial
 
 from six import string_types
+
+# Helper to make deprecation easy
+_deprecate = partial(warnings.warn, category=DeprecationWarning, stacklevel=2)
 
 
 class BrewtilsException(Exception):

--- a/brewtils/log.py
+++ b/brewtils/log.py
@@ -27,7 +27,6 @@ Example:
 
 import copy
 import logging.config
-import os
 import warnings
 
 import brewtils
@@ -66,15 +65,17 @@ DEFAULT_PLUGIN_LOGGING_TEMPLATE = {
     "loggers": DEFAULT_LOGGERS,
 }
 
-# If no logging was configured, this will be used as the logging configuration
-DEFAULT_LOGGING_CONFIG = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": DEFAULT_FORMATTERS,
-    "handlers": DEFAULT_HANDLERS,
-    "loggers": DEFAULT_LOGGERS,
-    "root": {"level": os.environ.get("BG_LOG_LEVEL", "INFO"), "handlers": ["default"]},
-}
+
+def default_config(level="INFO"):
+    """Will be used if no logging configuration was specified"""
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": DEFAULT_FORMATTERS,
+        "handlers": DEFAULT_HANDLERS,
+        "loggers": DEFAULT_LOGGERS,
+        "root": {"level": level, "handlers": ["default"]},
+    }
 
 
 def configure_logging(system_name=None, **kwargs):

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -24,7 +24,6 @@ from brewtils.request_handling import (
     RequestProcessor,
 )
 from brewtils.rest.easy_client import EasyClient
-from brewtils.schema_parser import SchemaParser
 
 # This is what enables request nesting to work easily
 request_context = threading.local()
@@ -153,9 +152,7 @@ class Plugin(object):
     :param refresh_token: Refresh token for Beergarden authentication
     """
 
-    def __init__(
-        self, client, system=None, logger=None, parser=None, metadata=None, **kwargs
-    ):
+    def __init__(self, client, system=None, logger=None, metadata=None, **kwargs):
         # Load config before setting up logging so level is configurable
         # TODO - can change to load_config(**kwargs) if yapconf supports CLI source
         self.config = load_config(cli_args=sys.argv[1:], **kwargs)
@@ -180,13 +177,10 @@ class Plugin(object):
         self.admin_processor = None
         self.request_processor = None
         self.shutdown_event = threading.Event()
-        self.parser = parser or SchemaParser()
 
         self.system = self._setup_system(system, metadata, kwargs)
 
-        self.bm_client = EasyClient(
-            logger=self.logger, parser=self.parser, **self.config
-        )
+        self.bm_client = EasyClient(logger=self.logger, **self.config)
 
     def run(self):
         self._startup()

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -277,20 +277,21 @@ class Plugin(object):
         }
 
         # And if this particular instance doesn't exist we want to add it
-        if not existing_system.has_instance(self.instance_name):
-            update_kwargs["add_instance"] = Instance(name=self.instance_name)
+        if not existing_system.has_instance(self.config.instance_name):
+            update_kwargs["add_instance"] = Instance(name=self.config.instance_name)
 
         return self._ez_client.update_system(existing_system.id, **update_kwargs)
 
     def _initialize_instance(self):
         # Sanity check to make sure an instance with this name was registered
-        if not self._system.has_instance(self.instance_name):
+        if not self._system.has_instance(self.config.instance_name):
             raise PluginValidationError(
-                'Unable to find registered instance with name "%s"' % self.instance_name
+                "Unable to find registered instance with name '%s'"
+                % self.config.instance_name
             )
 
         return self._ez_client.initialize_instance(
-            self._system.get_instance(self.instance_name).id
+            self._system.get_instance(self.config.instance_name).id
         )
 
     def _initialize_processors(self):
@@ -325,7 +326,7 @@ class Plugin(object):
         request_consumer = RequestConsumer.create(
             thread_name="Request Consumer",
             queue_name=self._instance.queue_info["request"]["name"],
-            max_concurrent=self.max_concurrent,
+            max_concurrent=self.config.max_concurrent,
             **common_args
         )
 
@@ -343,7 +344,7 @@ class Plugin(object):
             consumer=request_consumer,
             validation_funcs=[self._validate_system, self._validate_running],
             plugin_name=self.unique_name,
-            max_workers=self.max_concurrent,
+            max_workers=self.config.max_concurrent,
         )
 
         return admin_processor, request_processor

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -8,6 +8,7 @@ from requests import ConnectionError as RequestsConnectionError
 
 from brewtils.config import load_config
 from brewtils.errors import (
+    _deprecate,
     ConflictError,
     PluginValidationError,
     ValidationError,
@@ -456,58 +457,71 @@ class Plugin(object):
     # These are provided for backward-compatibility
     @property
     def bg_host(self):
+        _deprecate("bg_host has moved into config (plugin.config.bg_host)")
         return self.config.bg_host
 
     @property
     def bg_port(self):
+        _deprecate("bg_port has moved into config (plugin.config.bg_port)")
         return self.config.bg_port
 
     @property
     def ssl_enabled(self):
+        _deprecate("ssl_enabled has moved into config (plugin.config.ssl_enabled)")
         return self.config.ssl_enabled
 
     @property
     def ca_cert(self):
+        _deprecate("ca_cert has moved into config (plugin.config.ca_cert)")
         return self.config.ca_cert
 
     @property
     def client_cert(self):
+        _deprecate("client_cert has moved into config (plugin.config.client_cert)")
         return self.config.client_cert
 
     @property
     def bg_url_prefix(self):
+        _deprecate("bg_url_prefix has moved into config (plugin.config.bg_url_prefix)")
         return self.config.bg_url_prefix
 
     @property
     def ca_verify(self):
+        _deprecate("ca_verify has moved into config (plugin.config.ca_verify)")
         return self.config.ca_verify
 
     @property
     def max_attempts(self):
+        _deprecate("max_attempts has moved into config (plugin.config.max_attempts)")
         return self.config.max_attempts
 
     @property
     def max_timeout(self):
+        _deprecate("max_timeout has moved into config (plugin.config.max_timeout)")
         return self.config.max_timeout
 
     @property
     def starting_timeout(self):
+        _deprecate(
+            "starting_timeout has moved into config (plugin.config.starting_timeout)"
+        )
         return self.config.starting_timeout
 
     @property
     def max_concurrent(self):
+        _deprecate(
+            "max_concurrent has moved into config (plugin.config.max_concurrent)"
+        )
         return self.config.max_concurrent
 
     @property
     def instance_name(self):
+        _deprecate("instance_name has moved into config (plugin.config.instance_name)")
         return self.config.instance_name
 
     @property
-    def metadata(self):
-        return self._system.metadata
-
-    @property
     def connection_parameters(self):
+        _deprecate("connection_parameters attribute was removed, please use 'config'")
         return {
             key: self.config[key]
             for key in (
@@ -529,22 +543,32 @@ class Plugin(object):
 
     @property
     def client(self):
+        _deprecate("client attribute has been renamed to _client")
         return self._client
 
     @property
     def system(self):
+        _deprecate("system attribute has been renamed to _system")
         return self._system
 
     @property
     def instance(self):
+        _deprecate("instance attribute has been renamed to _instance")
         return self._instance
 
     @property
+    def metadata(self):
+        _deprecate("metadata attribute has been renamed to _metadata")
+        return self._system.metadata
+
+    @property
     def bm_client(self):
+        _deprecate("bm_client attribute has been renamed to _ez_client")
         return self._ez_client
 
     @property
     def shutdown_event(self):
+        _deprecate("shutdown_event attribute has been renamed to _shutdown_event")
         return self._shutdown_event
 
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -162,13 +162,13 @@ class Plugin(object):
         # assume that logging has already been configured
         self._custom_logger = True
         if logger:
-            self.logger = logger
+            self._logger = logger
         else:
             if len(logging.root.handlers) == 0:
                 logging.config.dictConfig(default_config(level=self.config.log_level))
                 self._custom_logger = False
 
-            self.logger = logging.getLogger(__name__)
+            self._logger = logging.getLogger(__name__)
 
         global _HOST, _PORT
         _HOST = self.config.bg_host
@@ -177,7 +177,7 @@ class Plugin(object):
         self._client = client
         self._shutdown_event = threading.Event()
         self._system = self._setup_system(system, metadata, kwargs)
-        self._ez_client = EasyClient(logger=self.logger, **self.config)
+        self._ez_client = EasyClient(logger=self._logger, **self.config)
 
         # These will be created on startup
         self._instance = None
@@ -186,17 +186,17 @@ class Plugin(object):
 
     def run(self):
         self._startup()
-        self.logger.info("Plugin %s has started", self.unique_name)
+        self._logger.info("Plugin %s has started", self.unique_name)
 
         try:
             self._shutdown_event.wait()
         except KeyboardInterrupt:
-            self.logger.debug("Received KeyboardInterrupt - shutting down")
+            self._logger.debug("Received KeyboardInterrupt - shutting down")
         except Exception as ex:
-            self.logger.exception("Exception during wait, shutting down: %s", ex)
+            self._logger.exception("Exception during wait, shutting down: %s", ex)
 
         self._shutdown()
-        self.logger.info("Plugin %s has terminated", self.unique_name)
+        self._logger.info("Plugin %s has terminated", self.unique_name)
 
     @property
     def unique_name(self):
@@ -207,25 +207,25 @@ class Plugin(object):
         )
 
     def _startup(self):
-        self.logger.debug("About to start up plugin %s", self.unique_name)
+        self._logger.debug("About to start up plugin %s", self.unique_name)
 
         self._system = self._initialize_system()
         self._instance = self._initialize_instance()
         self._admin_processor, self._request_processor = self._initialize_processors()
 
-        self.logger.debug("Starting up processors")
+        self._logger.debug("Starting up processors")
         self._admin_processor.startup()
         self._request_processor.startup()
 
     def _shutdown(self):
-        self.logger.debug("About to shut down plugin %s", self.unique_name)
+        self._logger.debug("About to shut down plugin %s", self.unique_name)
         self._shutdown_event.set()
 
-        self.logger.debug("Shutting down processors")
+        self._logger.debug("Shutting down processors")
         self._request_processor.shutdown()
         self._admin_processor.shutdown()
 
-        self.logger.debug("Successfully shutdown plugin {0}".format(self.unique_name))
+        self._logger.debug("Successfully shutdown plugin {0}".format(self.unique_name))
 
     def _initialize_system(self):
         """Let Beergarden know about System-level info
@@ -572,6 +572,11 @@ class Plugin(object):
     def shutdown_event(self):
         _deprecate("shutdown_event attribute has been renamed to _shutdown_event")
         return self._shutdown_event
+
+    @property
+    def logger(self):
+        _deprecate("logger attribute has been renamed to _logger")
+        return self._logger
 
 
 # Alias old name

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -158,15 +158,17 @@ class Plugin(object):
         # TODO - can change to load_config(**kwargs) if yapconf supports CLI source
         self.config = load_config(cli_args=sys.argv[1:], **kwargs)
 
-        # If a logger is specified or the logging module already has additional
-        # handlers then we assume that logging has already been configured
-        if logger or len(logging.root.handlers) > 0:
-            self.logger = logger or logging.getLogger(__name__)
-            self._custom_logger = True
+        # If a logger is specified or the root logger already has handlers then we
+        # assume that logging has already been configured
+        self._custom_logger = True
+        if logger:
+            self.logger = logger
         else:
-            logging.config.dictConfig(default_config(level=self.config.log_level))
+            if len(logging.root.handlers) == 0:
+                logging.config.dictConfig(default_config(level=self.config.log_level))
+                self._custom_logger = False
+
             self.logger = logging.getLogger(__name__)
-            self._custom_logger = False
 
         global _HOST, _PORT
         _HOST = self.config.bg_host

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -530,11 +530,11 @@ class Plugin(object):
             for key in (
                 "bg_host",
                 "bg_port",
+                "bg_url_prefix",
                 "ssl_enabled",
                 "api_version",
                 "ca_cert",
                 "client_cert",
-                "url_prefix",
                 "ca_verify",
                 "username",
                 "password",

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -398,16 +398,16 @@ class Plugin(object):
     def _setup_system(self, system, metadata, plugin_kwargs):
         helper_keywords = {
             "name",
-            "description",
             "version",
+            "description",
             "icon_name",
             "display_name",
             "max_instances",
+            "metadata",
         }
 
         if system:
-            # TODO - should also raise if metadata is provided
-            if helper_keywords.intersection(plugin_kwargs.keys()):
+            if metadata or helper_keywords.intersection(plugin_kwargs.keys()):
                 raise ValidationError(
                     "Sorry, you can't provide a complete system definition as well as "
                     "system creation helper kwargs %s" % helper_keywords

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import logging.config
-import sys
 import threading
 
 from requests import ConnectionError as RequestsConnectionError
@@ -156,8 +155,7 @@ class Plugin(object):
 
     def __init__(self, client, system=None, logger=None, metadata=None, **kwargs):
         # Load config before setting up logging so level is configurable
-        # TODO - can change to load_config(**kwargs) if yapconf supports CLI source
-        self.config = load_config(cli_args=sys.argv[1:], **kwargs)
+        self.config = load_config(**kwargs)
 
         # If a logger is specified or the root logger already has handlers then we
         # assume that logging has already been configured

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -580,9 +580,20 @@ class Plugin(object):
         return self._logger
 
 
-# Alias old name
-PluginBase = Plugin
+# Alias old names
+class PluginBase(Plugin):
+    def __init__(self, *args, **kwargs):
+        _deprecate(
+            "Looks like you're creating a 'PluginBase'. Heads up - this name will be "
+            "removed in version 4.0, please use 'Plugin' instead. Thanks!"
+        )
+        super(PluginBase, self).__init__(*args, **kwargs)
 
 
 class RemotePlugin(Plugin):
-    pass
+    def __init__(self, *args, **kwargs):
+        _deprecate(
+            "Looks like you're creating a 'RemotePlugin'. Heads up - this name will be "
+            "removed in version 4.0, please use 'Plugin' instead. Thanks!"
+        )
+        super(RemotePlugin, self).__init__(*args, **kwargs)

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -15,7 +15,7 @@ from brewtils.errors import (
     RequestProcessingError,
     RestConnectionError,
 )
-from brewtils.log import DEFAULT_LOGGING_CONFIG
+from brewtils.log import default_config
 from brewtils.models import Instance, System
 from brewtils.request_handling import (
     HTTPRequestUpdater,
@@ -162,11 +162,11 @@ class Plugin(object):
 
         # If a logger is specified or the logging module already has additional
         # handlers then we assume that logging has already been configured
-        if logger or len(logging.getLogger(__name__).root.handlers) > 0:
+        if logger or len(logging.root.handlers) > 0:
             self.logger = logger or logging.getLogger(__name__)
             self._custom_logger = True
         else:
-            logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+            logging.config.dictConfig(default_config(level=self.config.log_level))
             self.logger = logging.getLogger(__name__)
             self._custom_logger = False
 

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
-SPECIFICATION = {
+_CONNECTION_SPEC = {
     "bg_host": {
         "type": "str",
-        "description": "The beergarden server FQDN",
+        "description": "Beergarden server FQDN",
         "required": True,
         "env_name": "HOST",
         "alt_env_names": ["WEB_HOST"],
     },
     "bg_port": {
         "type": "int",
-        "description": "The beergarden server port",
+        "description": "Beergarden server port",
         "default": 2337,
         "env_name": "PORT",
         "alt_env_names": ["WEB_PORT"],
@@ -28,18 +28,18 @@ SPECIFICATION = {
     },
     "client_cert": {
         "type": "str",
-        "description": "Client certificate to use with beergarden",
+        "description": "Client certificate to use with Beergarden",
         "required": False,
         "alt_env_names": ["SSL_CLIENT_CERT"],
     },
     "ssl_enabled": {
         "type": "bool",
-        "description": "Use SSL when communicating with beergarden",
+        "description": "Use SSL when communicating with Beergarden",
         "default": True,
     },
     "url_prefix": {
         "type": "str",
-        "description": "The beergarden server path",
+        "description": "Beergarden server path",
         "default": "/",
     },
     "api_version": {
@@ -67,11 +67,26 @@ SPECIFICATION = {
         "description": "Refresh token for authentication",
         "required": False,
     },
+    "max_attempts": {
+        "type": "int",
+        "description": "Number of times to attempt a request update",
+        "default": -1,
+    },
+    "max_timeout": {
+        "type": "int",
+        "description": "Maximum amount of time to wait between request update retries",
+        "default": 30,
+    },
+    "starting_timeout": {
+        "type": "int",
+        "description": "Initial amount of time to wait before request update retry",
+        "default": 5,
+    },
     "client_timeout": {
         "type": "float",
         "description": "Max time RestClient will wait for server response",
-        "long_description": "This setting controls how long the HTTP(s) client will wait "
-        "when opening a connection to Beergarden before aborting."
+        "long_description": "This setting controls how long the HTTP(s) client will "
+        "wait when opening a connection to Beergarden before aborting."
         "This prevents some strange Beergarden server state from causing "
         "plugins to hang indefinitely."
         "Set to -1 to disable (this is a bad idea in production code, see "
@@ -79,3 +94,79 @@ SPECIFICATION = {
         "default": -1,
     },
 }
+
+_SYSTEM_SPEC = {
+    "name": {"type": "str", "description": "The system name", "required": False},
+    "version": {"type": "str", "description": "The system version", "required": False},
+    "description": {
+        "type": "str",
+        "description": "The system description",
+        "required": False,
+    },
+    "max_instances": {
+        "type": "int",
+        "description": "The system max instances",
+        "default": 1,
+    },
+    "icon_name": {
+        "type": "str",
+        "description": "The system icon name",
+        "required": False,
+    },
+    "display_name": {
+        "type": "str",
+        "description": "The system display name",
+        "required": False,
+    },
+}
+
+_PLUGIN_SPEC = {
+    "instance_name": {
+        "type": "str",
+        "description": "The instance name",
+        "default": "default",
+    },
+    "log_level": {
+        "type": "str",
+        "description": "The log level to use",
+        "default": "INFO",
+    },
+    "max_concurrent": {
+        "type": "int",
+        "description": "Maximum number of requests to process concurrently",
+        "default": 5,
+    },
+    "worker_shutdown_timeout": {
+        "type": "int",
+        "description": "Time to wait during shutdown to finish processing requests",
+        "default": 5,
+    },
+}
+
+_MQ_SPEC = {
+    "type": "dict",
+    "items": {
+        "max_attempts": {
+            "type": "int",
+            "description": "Number of times to attempt reconnection to message queue"
+            "before giving up (default -1 aka never)",
+            "default": -1,
+        },
+        "max_timeout": {
+            "type": "int",
+            "description": "Maximum amount of time to wait between reconnect tries",
+            "default": 30,
+        },
+        "starting_timeout": {
+            "type": "int",
+            "description": "Initial amount of time to wait before reconnect try",
+            "default": 5,
+        },
+    },
+}
+
+SPECIFICATION = {"mq": _MQ_SPEC}
+
+SPECIFICATION.update(_SYSTEM_SPEC)
+SPECIFICATION.update(_PLUGIN_SPEC)
+SPECIFICATION.update(_CONNECTION_SPEC)

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -15,6 +15,13 @@ _CONNECTION_SPEC = {
         "env_name": "PORT",
         "alt_env_names": ["WEB_PORT"],
     },
+    "bg_url_prefix": {
+        "type": "str",
+        "description": "Beergarden server path",
+        "default": "/",
+        "env_name": "URL_PREFIX",
+        "cli_name": "url_prefix",
+    },
     "ca_cert": {
         "type": "str",
         "description": "CA certificate to use when verifying",
@@ -36,11 +43,6 @@ _CONNECTION_SPEC = {
         "type": "bool",
         "description": "Use SSL when communicating with Beergarden",
         "default": True,
-    },
-    "url_prefix": {
-        "type": "str",
-        "description": "Beergarden server path",
-        "default": "/",
     },
     "api_version": {
         "type": "int",

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,4 +75,4 @@ watchdog==0.9.0
 webencodings==0.5.1       # via bleach
 wheel==0.33.1
 wrapt==1.11.1
-yapconf==0.3.6
+yapconf==0.3.7

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "simplejson<4",
         "six<2",
         "wrapt<2",
-        "yapconf>=0.2.1",
+        "yapconf>=0.3.7",
     ],
     extras_require={
         ':python_version=="2.7"': ["futures", "funcsigs"],

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -154,5 +154,11 @@ class TestLoadConfig(object):
     def test_environment(self):
         os.environ["BG_HOST"] = "the_host"
 
-        config = load_config([])
+        config = load_config()
         assert config.bg_host == "the_host"
+
+    def test_ignore_environment(self, monkeypatch):
+        os.environ["BG_HOST"] = "the_host"
+
+        with pytest.raises(ValidationError):
+            load_config(environment=False)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -15,11 +15,11 @@ class TestGetConnectionInfo(object):
         return {
             "bg_host": "bg_host",
             "bg_port": 1234,
+            "bg_url_prefix": "/beer/",
             "ssl_enabled": False,
             "api_version": None,
             "ca_cert": "ca_cert",
             "client_cert": "client_cert",
-            "url_prefix": "/beer/",
             "ca_verify": True,
             "username": None,
             "password": None,
@@ -95,7 +95,7 @@ class TestGetConnectionInfo(object):
         os.environ["BG_URL_PREFIX"] = "/beer"
 
         generated_params = get_connection_info()
-        assert generated_params["url_prefix"] == params["url_prefix"]
+        assert generated_params["bg_url_prefix"] == params["bg_url_prefix"]
 
 
 class TestLoadConfig(object):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import argparse
 import copy
 import os
 import warnings
 
 import pytest
+from mock import Mock
 
 from brewtils.config import load_config, get_argument_parser, get_connection_info
 from brewtils.errors import ValidationError
@@ -105,11 +107,25 @@ class TestLoadConfig(object):
     def teardown_method(self):
         os.environ = self.safe_copy
 
-    def test_cli(self):
+    def test_cli_from_arg(self):
         cli_args = ["--bg-host", "the_host"]
 
-        config = load_config(cli_args)
+        config = load_config(cli_args=cli_args)
         assert config.bg_host == "the_host"
+
+    def test_cli_from_sys(self, monkeypatch):
+        cli_args = ["filename", "--bg-host", "the_host"]
+        monkeypatch.setattr(argparse, "_sys", Mock(argv=cli_args))
+
+        config = load_config()
+        assert config.bg_host == "the_host"
+
+    def test_ignore_cli(self, monkeypatch):
+        cli_args = ["filename", "--bg-host", "the_host"]
+        monkeypatch.setattr(argparse, "_sys", Mock(argv=cli_args))
+
+        with pytest.raises(ValidationError):
+            load_config(cli_args=False)
 
     def test_cli_custom_argument_parser_vars(self):
         parser = get_argument_parser()

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -77,10 +77,8 @@ def plugin(
     )
     plugin._instance = bg_instance
     plugin._ez_client = ez_client
-    plugin.request_updater = updater_mock
     plugin._admin_processor = admin_processor
     plugin._request_processor = request_processor
-    plugin.queue_connection_params = {}
 
     return plugin
 
@@ -109,12 +107,12 @@ class TestPluginInit(object):
 
     def test_defaults(self, plugin):
         assert plugin._logger == logging.getLogger("brewtils.plugin")
-        assert plugin.instance_name == "default"
-        assert plugin.bg_host == "localhost"
-        assert plugin.bg_port == 2337
-        assert plugin.bg_url_prefix == "/"
-        assert plugin.ssl_enabled is True
-        assert plugin.ca_verify is True
+        assert plugin.config.instance_name == "default"
+        assert plugin.config.bg_host == "localhost"
+        assert plugin.config.bg_port == 2337
+        assert plugin.config.bg_url_prefix == "/"
+        assert plugin.config.ssl_enabled is True
+        assert plugin.config.ca_verify is True
 
     def test_default_logger(self, monkeypatch, client):
         """Test that the default logging configuration is used.
@@ -148,12 +146,12 @@ class TestPluginInit(object):
             max_concurrent=1,
         )
 
-        assert plugin.bg_host == "host1"
-        assert plugin.bg_port == 2338
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
         assert plugin._logger == logger
+        assert plugin.config.bg_host == "host1"
+        assert plugin.config.bg_port == 2338
+        assert plugin.config.bg_url_prefix == "/beer/"
+        assert plugin.config.ssl_enabled is False
+        assert plugin.config.ca_verify is False
 
     def test_env(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -164,11 +162,11 @@ class TestPluginInit(object):
 
         plugin = Plugin(client, system=bg_system, max_concurrent=1)
 
-        assert plugin.bg_host == "remotehost"
-        assert plugin.bg_port == 7332
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
+        assert plugin.config.bg_host == "remotehost"
+        assert plugin.config.bg_port == 7332
+        assert plugin.config.bg_url_prefix == "/beer/"
+        assert plugin.config.ssl_enabled is False
+        assert plugin.config.ca_verify is False
 
     def test_conflicts(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -188,11 +186,11 @@ class TestPluginInit(object):
             max_concurrent=1,
         )
 
-        assert plugin.bg_host == "localhost"
-        assert plugin.bg_port == 2337
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is True
-        assert plugin.ca_verify is True
+        assert plugin.config.bg_host == "localhost"
+        assert plugin.config.bg_port == 2337
+        assert plugin.config.bg_url_prefix == "/beer/"
+        assert plugin.config.ssl_enabled is True
+        assert plugin.config.ca_verify is True
 
     def test_cli(self, client, bg_system):
         args = [
@@ -213,11 +211,11 @@ class TestPluginInit(object):
             **get_connection_info(cli_args=args)
         )
 
-        assert plugin.bg_host == "remotehost"
-        assert plugin.bg_port == 2338
-        assert plugin.bg_url_prefix == "/beer/"
-        assert plugin.ssl_enabled is False
-        assert plugin.ca_verify is False
+        assert plugin.config.bg_host == "remotehost"
+        assert plugin.config.bg_port == 2338
+        assert plugin.config.bg_url_prefix == "/beer/"
+        assert plugin.config.ssl_enabled is False
+        assert plugin.config.ca_verify is False
 
 
 class TestPluginRun(object):
@@ -406,9 +404,9 @@ class TestInitializeProcessors(object):
 
             plugin._initialize_processors()
             connection_info = create_mock.call_args_list[0][1]["connection_info"]
-            assert connection_info["ssl"]["ca_cert"] == plugin.ca_cert
-            assert connection_info["ssl"]["ca_verify"] == plugin.ca_verify
-            assert connection_info["ssl"]["client_cert"] == plugin.client_cert
+            assert connection_info["ssl"]["ca_cert"] == plugin.config.ca_cert
+            assert connection_info["ssl"]["ca_verify"] == plugin.config.ca_verify
+            assert connection_info["ssl"]["client_cert"] == plugin.config.client_cert
 
     def test_queue_names(self, plugin, bg_instance):
         request_queue = bg_instance.queue_info["request"]["name"]

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -108,7 +108,7 @@ class TestPluginInit(object):
         assert expected_unique == plugin.unique_name
 
     def test_defaults(self, plugin):
-        assert plugin.logger == logging.getLogger("brewtils.plugin")
+        assert plugin._logger == logging.getLogger("brewtils.plugin")
         assert plugin.instance_name == "default"
         assert plugin.bg_host == "localhost"
         assert plugin.bg_port == 2337
@@ -131,7 +131,7 @@ class TestPluginInit(object):
 
         plugin = Plugin(client, bg_host="localhost", name="test", version="1")
         dict_config.assert_called_once_with(default_config(level="INFO"))
-        assert logging.getLogger("brewtils.plugin") == plugin.logger
+        assert logging.getLogger("brewtils.plugin") == plugin._logger
 
     def test_kwargs(self, client, bg_system):
         logger = Mock()
@@ -153,7 +153,7 @@ class TestPluginInit(object):
         assert plugin.bg_url_prefix == "/beer/"
         assert plugin.ssl_enabled is False
         assert plugin.ca_verify is False
-        assert plugin.logger == logger
+        assert plugin._logger == logger
 
     def test_env(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -490,9 +490,9 @@ class TestSetupSystem(object):
             {"display_name": "foo"},
         ],
     )
-    def test_extra_params(self, plugin, client, bg_system, extra_args):
+    def test_extra_params(self, plugin, bg_system, extra_args):
         with pytest.raises(ValidationError, match="system creation helper"):
-            plugin._setup_system(client, bg_system, {}, extra_args)
+            plugin._setup_system(bg_system, {}, extra_args)
 
     @pytest.mark.parametrize(
         "attr,value", [("_bg_name", "name"), ("_bg_version", "1.1.1")]
@@ -500,23 +500,23 @@ class TestSetupSystem(object):
     def test_extra_decorator_params(self, plugin, client, bg_system, attr, value):
         setattr(client, attr, value)
         with pytest.raises(ValidationError, match="@system decorator"):
-            plugin._setup_system(client, bg_system, {}, {})
+            plugin._setup_system(bg_system, {}, {})
 
-    def test_no_instances(self, plugin, client):
+    def test_no_instances(self, plugin):
         system = System(name="name", version="1.0.0")
         with pytest.raises(ValidationError, match="explicit instance definition"):
-            plugin._setup_system(client, system, {}, {})
+            plugin._setup_system(system, {}, {})
 
-    def test_max_instances(self, plugin, client):
+    def test_max_instances(self, plugin):
         system = System(
             name="name",
             version="1.0.0",
             instances=[Instance(name="1"), Instance(name="2")],
         )
-        new_system = plugin._setup_system(client, system, {}, {})
+        new_system = plugin._setup_system(system, {}, {})
         assert new_system.max_instances == 2
 
-    def test_construct_system(self, plugin, client):
+    def test_construct_system(self, plugin):
         plugin.config.update(
             {
                 "name": "name",
@@ -527,7 +527,7 @@ class TestSetupSystem(object):
             }
         )
 
-        new_system = plugin._setup_system(client, None, {"foo": "bar"}, {})
+        new_system = plugin._setup_system(None, {"foo": "bar"}, {})
         self._validate_system(new_system)
 
     def test_construct_from_client(self, plugin, client):
@@ -535,7 +535,7 @@ class TestSetupSystem(object):
         client._bg_version = "1.0.0"
         client.__doc__ = "Description\nSome more stuff"
 
-        new_system = plugin._setup_system(client, None, {}, {})
+        new_system = plugin._setup_system(None, {}, {})
         assert new_system.name == "name"
         assert new_system.version == "1.0.0"
         assert new_system.description == "Description"

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -48,11 +48,6 @@ def client():
 
 
 @pytest.fixture
-def parser_mock():
-    return Mock()
-
-
-@pytest.fixture
 def updater_mock():
     return Mock()
 
@@ -71,7 +66,6 @@ def request_processor():
 def plugin(
     client,
     bm_client,
-    parser_mock,
     updater_mock,
     bg_system,
     bg_instance,
@@ -83,7 +77,6 @@ def plugin(
     )
     plugin.instance = bg_instance
     plugin.bm_client = bm_client
-    plugin.parser = parser_mock
     plugin.request_updater = updater_mock
     plugin.admin_processor = admin_processor
     plugin.request_processor = request_processor

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -16,7 +16,7 @@ from brewtils.errors import (
     RequestProcessingError,
     RestConnectionError,
 )
-from brewtils.log import DEFAULT_LOGGING_CONFIG
+from brewtils.log import default_config
 from brewtils.models import Instance, System, Command
 from brewtils.plugin import Plugin
 
@@ -131,14 +131,13 @@ class TestPluginInit(object):
         if there's no prior configuration we have to fake it a little.
 
         """
-        plugin_logger = logging.getLogger("brewtils.plugin")
         dict_config = Mock()
 
-        monkeypatch.setattr(plugin_logger, "root", Mock(handlers=[]))
+        monkeypatch.setattr(logging, "root", Mock(handlers=[]))
         monkeypatch.setattr(logging.config, "dictConfig", dict_config)
 
-        plugin = Plugin(client, bg_host="localhost", max_concurrent=1)
-        dict_config.assert_called_once_with(DEFAULT_LOGGING_CONFIG)
+        plugin = Plugin(client, bg_host="localhost", name="test", version="1")
+        dict_config.assert_called_once_with(default_config(level="INFO"))
         assert logging.getLogger("brewtils.plugin") == plugin.logger
 
     def test_kwargs(self, client, bg_system):

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -49,11 +49,6 @@ def client():
 
 
 @pytest.fixture
-def updater_mock():
-    return Mock()
-
-
-@pytest.fixture
 def admin_processor():
     return Mock()
 
@@ -65,17 +60,9 @@ def request_processor():
 
 @pytest.fixture
 def plugin(
-    client,
-    ez_client,
-    updater_mock,
-    bg_system,
-    bg_instance,
-    admin_processor,
-    request_processor,
+    client, ez_client, bg_system, bg_instance, admin_processor, request_processor
 ):
-    plugin = Plugin(
-        client, bg_host="localhost", system=bg_system, metadata={"foo": "bar"}
-    )
+    plugin = Plugin(client, bg_host="localhost", system=bg_system)
     plugin._instance = bg_instance
     plugin._ez_client = ez_client
     plugin._admin_processor = admin_processor


### PR DESCRIPTION
This PR simplifies and consolidates the `Plugin` class.

The main purpose here is to apply yapconf configuration loading to *all* of the various options that can be applied to a Plugin. Previously, there were basically three separate classes of Plugin parameters:

1. Parameters that could be loaded through yapconf. This was mostly the Beergarden connection parameters (`bg_host` and such). These allowed the use of the `Plugin(**get_connection_info(sys.argv[1:]))` initialization method, which allowed loading those values from the command line, the environment, or kwargs.
2. Parameters that could be passed directly to the Plugin but could also be specified as environment variables. The main one here is the `instance_name` (`BG_INSTANCE_NAME`). These are basically undocumented as they exist to support the way Bartender passes those things to Local Plugin processes.
3. Parameters that can only be passed as Plugin kwargs - pretty much everything else.

This PR adds entries to the specification for almost all Plugin parameters. The only ones not moved into the spec are not really representable as flat values (client, system, logger, metadata). These are the only kwargs specifically called out in the Plugin `__init__` signature (but everything is listed in the docstring). 

Also note that the first thing the Plugin does is load the configuration. The `load_config` function now uses both the command line and environment variables as sources by default.

```python
def __init__(self, client, system=None, logger=None, metadata=None, **kwargs):
    # Load config before setting up logging so level is configurable
    self.config = load_config(**kwargs)
```

The `load_config` function has undergone some small but significant changes:

- It takes advantage of yapconf's use of `load_known_args` and new CLI source to support a boolean value for `cli_args`. This frees the plugin developer from needing to understand how to use yapconf and argparse to parse the command line.
- It adds the `environment` kwarg to selectively disable using environment variables as a configuration source. Since Plugins now use this method by default there should be a way to disable this functionality if the plugin developer so desires.

#### Why?
Instead of having to do something like this to use the CLI and environment as a source for the `bg_host`:
```python
Plugin(client, **get_connection_info(cli_args=sys.argv[1:])).run()
```

Plugin developers can now do this and it'll be handled automatically:

```python
Plugin(client).run()
```

It's still possible to do things like this where options are manually specified:

```python
Plugin(client, bg_host="hostname").run()
```

And it's possible to completely disable all sources other than kwargs if you really want to:
```python
Plugin(client, cli_args=False, environment=False, bg_host="hostname", ...).run()
```