### PR TITLE
Plugin now asks Beer-garden for logging config during startup

### DIFF
--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -284,6 +284,27 @@ class TestShutdown(object):
         assert len(caplog.records) == 1
 
 
+class TestInitializeLogging(object):
+    @pytest.fixture(autouse=True)
+    def config_mock(self, monkeypatch):
+        dict_config = Mock()
+        monkeypatch.setattr(logging.config, "dictConfig", dict_config)
+        return dict_config
+
+    def test_normal(self, plugin, ez_client, config_mock, bg_logging_config):
+        plugin._custom_logger = False
+        ez_client.get_logging_config.return_value = bg_logging_config
+
+        plugin._initialize_logging()
+        assert config_mock.called is True
+
+    def test_custom_logger(self, plugin, ez_client, config_mock):
+        plugin._custom_logger = True
+
+        plugin._initialize_logging()
+        assert config_mock.called is False
+
+
 class TestInitializeSystem(object):
     def test_new_system(self, plugin, ez_client, bg_system, bg_instance):
         ez_client.find_unique_system.return_value = None


### PR DESCRIPTION
This PR adds a step for logging initialization to the Plugin startup process.

This is intended to make the integrated logging configuration opt-out, rather than opt-in. Previously, in order to use the plugin logging configuration feature plugin developers needed to 1. know it exists and 2. explicitly call it.

Because the logging configuration was handled outside of the plugin connection information needs to be determined and saved:

```python
def main():
    connection_params = get_connection_info(sys.argv[1:])

    brewtils.log.configure_logging(system_name="foo", **connection_params)

    plugin = Plugin(MyComplicatedClient(), name="foo", **connection_params)
```

Now, this is what's required for the same behavior. Also, it's now possible to omit hardcoding the `name` kwarg and use yapconf to determine the system name:

```python
def main():
    plugin = Plugin(MyComplicatedClient(), name="foo")
```

Finally, this also ties in with 4712ee7 to become really useful (at least, I think so :smile:). These  changes taken together mean that logging configuration can be done before client creation (which is when it's most necessary) without any extra calls (since you need a plugin instance anyway).

```python
def main():
    # Don't pass in a client yet. BUT after this call, logging will be configured
    plugin = Plugin(name="foo")

    # Now logging is configured before I try to create my client!
    client = MyComplicatedClient()

    # I just need to set the client before run()
    plugin.client = client
    plugin.run()
````