### PR TITLE
Issue/381

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -169,6 +169,12 @@ class Plugin(object):
 
         # Set the global config so it can be used by SystemClients and such
         global CONFIG
+        if len(CONFIG):
+            print(
+                "Global CONFIG object is not empty! If multiple plugins are running in "
+                "this process please ensure any [System|Easy|Rest]Clients are passed "
+                "connection information as kwargs - auto-discovery may be incorrect."
+            )
         CONFIG = Box(self._config.to_dict(), default_box=True)
 
         # If a logger is specified or the root logger already has handlers then we

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -168,7 +168,7 @@ class Plugin(object):
 
         # Set the global config so it can be used by SystemClients and such
         global CONFIG
-        CONFIG = Box(self._config.to_dict(), default_box=True, frozen_box=True)
+        CONFIG = Box(self._config.to_dict(), default_box=True)
 
         # If a logger is specified or the root logger already has handlers then we
         # assume that logging has already been configured

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -30,7 +30,7 @@ from brewtils.rest.easy_client import EasyClient
 request_context = threading.local()
 
 # Global config, used to simplify BG client creation and sanity checks.
-CONFIG = None
+CONFIG = Box(default_box=True)
 
 
 class Plugin(object):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -9,9 +9,11 @@ import urllib3
 from requests import Session
 from requests.adapters import HTTPAdapter
 
-import brewtils.plugin
+import brewtils.plugin as plugin
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
+from brewtils.specification import _CONNECTION_SPEC
+from yapconf import YapconfSpec
 
 
 def enable_auth(method):
@@ -104,62 +106,37 @@ class RestClient(object):
     JSON_HEADERS = {"Content-type": "application/json", "Accept": "text/plain"}
 
     def __init__(self, *args, **kwargs):
-        self.bg_host = kwargs.get("bg_host") or kwargs.get("host")
-        if not self.bg_host:
-            if len(args) > 0:
-                self.bg_host = args[0]
-                _deprecate(
-                    "Heads up - passing bg_host as a positional argument is deprecated "
-                    "and will be removed in version 4.0"
-                )
-            else:
-                if brewtils.plugin.CONFIG and brewtils.plugin.CONFIG.bg_host:
-                    self.bg_host = brewtils.plugin.CONFIG.bg_host
-                else:
-                    raise ValueError('Missing keyword argument "bg_host"')
+        self._config = self._load_config(args, kwargs)
 
-        self.bg_port = kwargs.get("bg_port") or kwargs.get("port")
-        if not self.bg_port:
-            if len(args) > 1:
-                self.bg_port = args[1]
-                _deprecate(
-                    "Heads up - passing bg_port as a positional argument is deprecated "
-                    "and will be removed in version 4.0"
-                )
-            else:
-                if brewtils.plugin.CONFIG and brewtils.plugin.CONFIG.bg_port:
-                    self.bg_port = brewtils.plugin.CONFIG.bg_port
-                else:
-                    raise ValueError('Missing keyword argument "bg_port"')
-
-        self.bg_prefix = kwargs.get("bg_url_prefix") or kwargs.get("url_prefix")
-        self.username = kwargs.get("username")
-        self.password = kwargs.get("password")
-        self.access_token = kwargs.get("access_token")
-        self.refresh_token = kwargs.get("refresh_token")
+        self.bg_host = self._config.bg_host
+        self.bg_port = self._config.bg_port
+        self.bg_prefix = self._config.bg_url_prefix
+        self.username = self._config.username
+        self.password = self._config.password
+        self.access_token = self._config.access_token
+        self.refresh_token = self._config.refresh_token
 
         # Configure the session to use when making requests
         self.session = Session()
-        self.session.cert = kwargs.get("client_cert")
+        self.session.cert = self._config.client_cert
 
-        if not kwargs.get("ca_verify", True):
+        if not self._config.ca_verify:
             urllib3.disable_warnings()
             self.session.verify = False
-        elif kwargs.get("ca_cert"):
-            self.session.verify = kwargs.get("ca_cert")
+        elif self._config.ca_cert:
+            self.session.verify = self._config.ca_cert
 
-        timeout = kwargs.get("client_timeout")
-        if timeout == -1:
-            timeout = None
+        client_timeout = self._config.client_timeout
+        if client_timeout == -1:
+            client_timeout = None
 
         # Having two is kind of strange to me, but this is what Requests does
-        self.session.mount("https://", TimeoutAdapter(timeout=timeout))
-        self.session.mount("http://", TimeoutAdapter(timeout=timeout))
+        self.session.mount("https://", TimeoutAdapter(timeout=client_timeout))
+        self.session.mount("http://", TimeoutAdapter(timeout=client_timeout))
 
         # Configure the beer-garden URLs
-        scheme = "https" if kwargs.get("ssl_enabled") else "http"
         self.base_url = "%s://%s:%s%s" % (
-            scheme,
+            "https" if self._config.ssl_enabled else "http",
             self.bg_host,
             self.bg_port,
             normalize_url_prefix(self.bg_prefix),
@@ -167,7 +144,7 @@ class RestClient(object):
         self.version_url = self.base_url + "version"
         self.config_url = self.base_url + "config"
 
-        api_version = kwargs.get("api_version") or self.LATEST_VERSION
+        api_version = self._config.api_version or self.LATEST_VERSION
         if api_version == 1:
             self.system_url = self.base_url + "api/v1/systems/"
             self.instance_url = self.base_url + "api/v1/instances/"
@@ -182,6 +159,47 @@ class RestClient(object):
             self.event_url = self.base_url + "api/vbeta/events/"
         else:
             raise ValueError("Invalid Beer-garden API version: %s" % api_version)
+
+    @staticmethod
+    def _load_config(args, kwargs):
+        """Load a config based on the CONNECTION section of the Brewtils Specification
+
+        This will load a configuration with the following source precedence:
+
+        1. kwargs
+        2. kwargs with "old" names ("host", "port", "url_prefix")
+        3. host and port passed as positional arguments
+        4. the global configuration (brewtils.plugin.CONFIG)
+
+        Args:
+            args: DEPRECATED - host and port
+            kwargs: Standard connection arguments to be used
+
+        Returns:
+            The resolved configuration object
+        """
+        spec = YapconfSpec(_CONNECTION_SPEC)
+
+        renamed = {}
+        for key in ["host", "port", "url_prefix"]:
+            if kwargs.get(key):
+                renamed["bg_" + key] = kwargs.get(key)
+
+        positional = {}
+        if len(args) > 0:
+            _deprecate(
+                "Heads up - passing bg_host as a positional argument is deprecated "
+                "and will be removed in version 4.0"
+            )
+            positional["bg_host"] = args[0]
+        if len(args) > 1:
+            _deprecate(
+                "Heads up - passing bg_port as a positional argument is deprecated "
+                "and will be removed in version 4.0"
+            )
+            positional["bg_port"] = args[1]
+
+        return spec.load_config(*[kwargs, renamed, positional, plugin.CONFIG])
 
     @enable_auth
     def get_version(self, **kwargs):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -111,6 +111,7 @@ class RestClient(object):
         self.bg_host = self._config.bg_host
         self.bg_port = self._config.bg_port
         self.bg_prefix = self._config.bg_url_prefix
+        self.api_version = self._config.api_version
         self.username = self._config.username
         self.password = self._config.password
         self.access_token = self._config.access_token
@@ -144,8 +145,7 @@ class RestClient(object):
         self.version_url = self.base_url + "version"
         self.config_url = self.base_url + "config"
 
-        api_version = self._config.api_version or self.LATEST_VERSION
-        if api_version == 1:
+        if self.api_version == 1:
             self.system_url = self.base_url + "api/v1/systems/"
             self.instance_url = self.base_url + "api/v1/instances/"
             self.command_url = self.base_url + "api/v1/commands/"
@@ -158,7 +158,7 @@ class RestClient(object):
 
             self.event_url = self.base_url + "api/vbeta/events/"
         else:
-            raise ValueError("Invalid Beer-garden API version: %s" % api_version)
+            raise ValueError("Invalid Beer-garden API version: %s" % self.api_version)
 
     @staticmethod
     def _load_config(args, kwargs):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -9,7 +9,7 @@ import urllib3
 from requests import Session
 from requests.adapters import HTTPAdapter
 
-import brewtils.plugin as plugin
+import brewtils.plugin
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
@@ -199,7 +199,7 @@ class RestClient(object):
             )
             positional["bg_port"] = args[1]
 
-        return spec.load_config(*[kwargs, renamed, positional, plugin.CONFIG])
+        return spec.load_config(*[kwargs, renamed, positional, brewtils.plugin.CONFIG])
 
     @enable_auth
     def get_version(self, **kwargs):

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -376,9 +376,9 @@ class SystemClient(object):
         if parent is None:
             return None
 
-        if (
-            getattr(brewtils.plugin, "_HOST").upper() != self._bg_host.upper()
-            or getattr(brewtils.plugin, "_PORT") != self._bg_port
+        if brewtils.plugin.CONFIG and (
+            brewtils.plugin.CONFIG.bg_host.upper() != self._bg_host.upper()
+            or brewtils.plugin.CONFIG.bg_port != self._bg_port
         ):
             self._logger.warning(
                 "A parent request was found, but the destination beer-garden "

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -191,12 +191,7 @@ class SystemClient(object):
         max_concurrent = kwargs.get("max_concurrent", (cpu_count() or 1) * 5)
         self._thread_pool = ThreadPoolExecutor(max_workers=max_concurrent)
 
-        self._bg_host = kwargs.pop("bg_host", None) or kwargs.pop("host")
-        self._bg_port = kwargs.pop("bg_port", None) or kwargs.pop("port")
-
-        self._easy_client = EasyClient(
-            bg_host=self._bg_host, bg_port=self._bg_port, **kwargs
-        )
+        self._easy_client = EasyClient(**kwargs)
 
         self._loaded = False
         self._system = None
@@ -377,8 +372,9 @@ class SystemClient(object):
             return None
 
         if brewtils.plugin.CONFIG and (
-            brewtils.plugin.CONFIG.bg_host.upper() != self._bg_host.upper()
-            or brewtils.plugin.CONFIG.bg_port != self._bg_port
+            brewtils.plugin.CONFIG.bg_host.upper()
+            != self._easy_client.client.bg_host.upper()
+            or brewtils.plugin.CONFIG.bg_port != self._easy_client.client.bg_port
         ):
             self._logger.warning(
                 "A parent request was found, but the destination beer-garden "

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -47,7 +47,8 @@ _CONNECTION_SPEC = {
     "api_version": {
         "type": "int",
         "description": "Beergarden API version",
-        "required": False,
+        "default": 1,
+        "choices": [1],
     },
     "client_timeout": {
         "type": "float",

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -19,7 +19,7 @@ class TestGetConnectionInfo(object):
             "bg_port": 1234,
             "bg_url_prefix": "/beer/",
             "ssl_enabled": False,
-            "api_version": None,
+            "api_version": 1,
             "ca_cert": "ca_cert",
             "client_cert": "client_cert",
             "ca_verify": True,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+from box import Box
 
 import brewtils.test
 
@@ -28,4 +29,4 @@ def environ():
 def global_config():
     """Make sure that the global CONFIG is reset after every test"""
     yield
-    brewtils.plugin.CONFIG = None
+    brewtils.plugin.CONFIG = Box(default_box=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
+
+import pytest
 
 import brewtils.test
 
@@ -11,3 +14,18 @@ def pytest_configure():
 
 def pytest_unconfigure():
     delattr(brewtils.test, "_running_tests")
+
+
+@pytest.fixture(autouse=True)
+def environ():
+    """Make sure tests don't clobber the environment"""
+    safe_copy = os.environ.copy()
+    yield
+    os.environ = safe_copy
+
+
+@pytest.fixture(autouse=True)
+def global_config():
+    """Make sure that the global CONFIG is reset after every test"""
+    yield
+    brewtils.plugin.CONFIG = None

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -70,6 +70,14 @@ class TestInit(object):
         with pytest.raises(ValidationError):
             Plugin(client)
 
+    def test_existing_config(self, capsys, bg_system):
+        brewtils.plugin.CONFIG.foo = "bar"
+
+        Plugin(bg_host="localhost", system=bg_system)
+        out = capsys.readouterr().out
+
+        assert "CONFIG" in out
+
     @pytest.mark.parametrize(
         "instance_name,expected_unique",
         [(None, "system[default]-1.0.0"), ("unique", "system[unique]-1.0.0")],

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -23,13 +23,6 @@ from brewtils.models import Instance, System, Command
 from brewtils.plugin import Plugin, PluginBase, RemotePlugin
 
 
-@pytest.fixture(autouse=True)
-def environ():
-    safe_copy = os.environ.copy()
-    yield
-    os.environ = safe_copy
-
-
 @pytest.fixture
 def ez_client(bg_system, bg_instance):
     return Mock(

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -89,12 +89,12 @@ class TestInit(object):
 
     def test_defaults(self, plugin):
         assert plugin._logger == logging.getLogger("brewtils.plugin")
-        assert plugin.config.instance_name == "default"
-        assert plugin.config.bg_host == "localhost"
-        assert plugin.config.bg_port == 2337
-        assert plugin.config.bg_url_prefix == "/"
-        assert plugin.config.ssl_enabled is True
-        assert plugin.config.ca_verify is True
+        assert plugin._config.instance_name == "default"
+        assert plugin._config.bg_host == "localhost"
+        assert plugin._config.bg_port == 2337
+        assert plugin._config.bg_url_prefix == "/"
+        assert plugin._config.ssl_enabled is True
+        assert plugin._config.ca_verify is True
 
     def test_default_logger(self, monkeypatch, client):
         """Test that the default logging configuration is used.
@@ -129,11 +129,11 @@ class TestInit(object):
         )
 
         assert plugin._logger == logger
-        assert plugin.config.bg_host == "host1"
-        assert plugin.config.bg_port == 2338
-        assert plugin.config.bg_url_prefix == "/beer/"
-        assert plugin.config.ssl_enabled is False
-        assert plugin.config.ca_verify is False
+        assert plugin._config.bg_host == "host1"
+        assert plugin._config.bg_port == 2338
+        assert plugin._config.bg_url_prefix == "/beer/"
+        assert plugin._config.ssl_enabled is False
+        assert plugin._config.ca_verify is False
 
     def test_env(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -144,11 +144,11 @@ class TestInit(object):
 
         plugin = Plugin(client, system=bg_system, max_concurrent=1)
 
-        assert plugin.config.bg_host == "remotehost"
-        assert plugin.config.bg_port == 7332
-        assert plugin.config.bg_url_prefix == "/beer/"
-        assert plugin.config.ssl_enabled is False
-        assert plugin.config.ca_verify is False
+        assert plugin._config.bg_host == "remotehost"
+        assert plugin._config.bg_port == 7332
+        assert plugin._config.bg_url_prefix == "/beer/"
+        assert plugin._config.ssl_enabled is False
+        assert plugin._config.ca_verify is False
 
     def test_conflicts(self, client, bg_system):
         os.environ["BG_HOST"] = "remotehost"
@@ -168,11 +168,11 @@ class TestInit(object):
             max_concurrent=1,
         )
 
-        assert plugin.config.bg_host == "localhost"
-        assert plugin.config.bg_port == 2337
-        assert plugin.config.bg_url_prefix == "/beer/"
-        assert plugin.config.ssl_enabled is True
-        assert plugin.config.ca_verify is True
+        assert plugin._config.bg_host == "localhost"
+        assert plugin._config.bg_port == 2337
+        assert plugin._config.bg_url_prefix == "/beer/"
+        assert plugin._config.ssl_enabled is True
+        assert plugin._config.ca_verify is True
 
     def test_cli(self, client, bg_system):
         args = [
@@ -193,11 +193,11 @@ class TestInit(object):
             **get_connection_info(cli_args=args)
         )
 
-        assert plugin.config.bg_host == "remotehost"
-        assert plugin.config.bg_port == 2338
-        assert plugin.config.bg_url_prefix == "/beer/"
-        assert plugin.config.ssl_enabled is False
-        assert plugin.config.ca_verify is False
+        assert plugin._config.bg_host == "remotehost"
+        assert plugin._config.bg_port == 2338
+        assert plugin._config.bg_url_prefix == "/beer/"
+        assert plugin._config.ssl_enabled is False
+        assert plugin._config.ca_verify is False
 
 
 class TestRun(object):
@@ -401,7 +401,7 @@ class TestInitializeSystem(object):
         ez_client.find_unique_system.return_value = existing_system
 
         new_name = "foo_instance"
-        plugin.config.instance_name = new_name
+        plugin._config.instance_name = new_name
 
         plugin._initialize_system()
         assert ez_client.create_system.called is False
@@ -446,15 +446,15 @@ class TestInitializeProcessors(object):
             create_mock = Mock()
             monkeypatch.setattr(brewtils.plugin.RequestConsumer, "create", create_mock)
 
-            plugin.config.ca_cert = Mock()
-            plugin.config.ca_verify = Mock()
-            plugin.config.client_cert = Mock()
+            plugin._config.ca_cert = Mock()
+            plugin._config.ca_verify = Mock()
+            plugin._config.client_cert = Mock()
 
             plugin._initialize_processors()
             connection_info = create_mock.call_args_list[0][1]["connection_info"]
-            assert connection_info["ssl"]["ca_cert"] == plugin.config.ca_cert
-            assert connection_info["ssl"]["ca_verify"] == plugin.config.ca_verify
-            assert connection_info["ssl"]["client_cert"] == plugin.config.client_cert
+            assert connection_info["ssl"]["ca_cert"] == plugin._config.ca_cert
+            assert connection_info["ssl"]["ca_verify"] == plugin._config.ca_verify
+            assert connection_info["ssl"]["client_cert"] == plugin._config.client_cert
 
     def test_queue_names(self, plugin, bg_instance):
         request_queue = bg_instance.queue_info["request"]["name"]
@@ -543,7 +543,7 @@ class TestSetupSystem(object):
         assert new_system.max_instances == 2
 
     def test_construct_system(self, plugin):
-        plugin.config.update(
+        plugin._config.update(
             {
                 "name": "name",
                 "version": "1.0.0",
@@ -578,7 +578,7 @@ class TestSetupSystem(object):
 
     @pytest.mark.parametrize("kwargs", [{"name": "foo"}, {"version": "foo"}])
     def test_missing_params(self, plugin, kwargs):
-        plugin.config.update(kwargs)
+        plugin._config.update(kwargs)
         with pytest.raises(ValidationError):
             plugin._setup_system(None, {}, kwargs)
 

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -4,7 +4,6 @@ import json
 import warnings
 
 import pytest
-from box import Box
 from mock import Mock, MagicMock, ANY
 
 import brewtils.rest
@@ -65,9 +64,8 @@ class TestRestClient(object):
             RestClient(**kwargs)
 
     def test_args_from_config(self, monkeypatch):
-        monkeypatch.setattr(
-            brewtils.plugin, "CONFIG", Box(bg_host="localhost", bg_port=3000)
-        )
+        brewtils.plugin.CONFIG.bg_host = "localhost"
+        brewtils.plugin.CONFIG.bg_port = 3000
 
         client = RestClient()
         assert client.bg_host == "localhost"

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -61,13 +61,18 @@ class TestRestClient(object):
         with pytest.raises(ValueError):
             RestClient(**kwargs)
 
+    def test_args_from_config(self, monkeypatch):
+        monkeypatch.setattr(
+            brewtils.plugin, "CONFIG", Mock(bg_host="localhost", bg_port=3000)
+        )
+
+        client = RestClient()
+        assert client.bg_host == "localhost"
+        assert client.bg_port == 3000
+
     def test_non_versioned_uris(self, client, url_prefix):
         assert client.version_url == "http://host:80" + url_prefix + "version"
         assert client.config_url == "http://host:80" + url_prefix + "config"
-
-    @pytest.fixture(params=["system_url"])
-    def urls(self, client):
-        return client.param
 
     @pytest.mark.parametrize(
         "url,expected",

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -3,7 +3,6 @@ import logging
 from concurrent.futures import wait
 
 import pytest
-from box import Box
 from mock import call, Mock, PropertyMock
 from pytest_lazyfixture import lazy_fixture
 
@@ -170,9 +169,8 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(
-            brewtils.plugin, "CONFIG", Box(bg_host="localhost", bg_port=3000)
-        )
+        brewtils.plugin.CONFIG.bg_host = "localhost"
+        brewtils.plugin.CONFIG.bg_port = 3000
 
         client.command_1()
 
@@ -187,9 +185,8 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(
-            brewtils.plugin, "CONFIG", Box(bg_host="OTHER_HOST", bg_port=3000)
-        )
+        brewtils.plugin.CONFIG.bg_host = "OTHER_HOST"
+        brewtils.plugin.CONFIG.bg_port = 3000
 
         client.command_1()
 

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -3,6 +3,7 @@ import logging
 from concurrent.futures import wait
 
 import pytest
+from box import Box
 from mock import call, Mock, PropertyMock
 from pytest_lazyfixture import lazy_fixture
 
@@ -179,8 +180,9 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(brewtils.plugin, "_HOST", "localhost")
-        monkeypatch.setattr(brewtils.plugin, "_PORT", 3000)
+        monkeypatch.setattr(
+            brewtils.plugin, "CONFIG", Box(bg_host="localhost", bg_port=3000)
+        )
 
         client.command_1()
 
@@ -195,8 +197,9 @@ class TestCreateRequest(object):
         monkeypatch.setattr(
             brewtils.plugin, "request_context", Mock(current_request=parent_request)
         )
-        monkeypatch.setattr(brewtils.plugin, "_HOST", "OTHER_HOST")
-        monkeypatch.setattr(brewtils.plugin, "_PORT", 3000)
+        monkeypatch.setattr(
+            brewtils.plugin, "CONFIG", Box(bg_host="OTHER_HOST", bg_port=3000)
+        )
 
         client.command_1()
 

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -69,6 +69,8 @@ def easy_client(system_1):
     mock = Mock(name="easy_client")
     mock.find_unique_system.return_value = system_1
     mock.find_systems.return_value = [system_1]
+    mock.client.bg_host = "localhost"
+    mock.client.bg_port = 3000
     return mock
 
 
@@ -89,18 +91,6 @@ def easy_client_patch(monkeypatch, easy_client):
     monkeypatch.setattr(
         brewtils.rest.system_client, "EasyClient", Mock(return_value=easy_client)
     )
-
-
-class TestCreate(object):
-    def test_alternate_kwargs(self):
-        client = SystemClient(host="localhost", port=3000, system_name="system")
-        assert client._bg_host == "localhost"
-        assert client._bg_port == 3000
-
-    @pytest.mark.parametrize("kwargs", [{"host": "localhost"}, {"port": 3000}])
-    def test_missing_kwargs(self, kwargs):
-        with pytest.raises(Exception):
-            SystemClient(**kwargs)
 
 
 class TestLoadBgSystem(object):


### PR DESCRIPTION
This fixes beer-garden/beer-garden#381.

Changes in this PR:
- Instead of saving off the host and port globally when the Plugin is created, save off the entire config (frozen to prevent accidental modification).
- A `RestClient` will now attempt to grab host and port information from that global config if it exists. Host and port info passed as args will take precedence.
- The `SystemClient` will no longer store host and port info. It only uses this as a sanity check to ensure child requests are not being created on a different Beergarden. Instead, it will reach down into its underlying `RestClient` to make that check. This prevents us from needing to duplicate the host / port precedence logic in the `SystemClient`.