### PR TITLE
Can now manually specify a parent request when using the SystemClient

### DIFF
--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -402,8 +402,7 @@ class SystemClient(object):
         comment = kwargs.pop("_comment", None)
         output_type = kwargs.pop("_output_type", None)
         metadata = kwargs.pop("_metadata", {})
-
-        parent = self._get_parent_for_request()
+        parent = kwargs.pop("_parent", self._get_parent_for_request())
 
         if system_display:
             metadata["system_display_name"] = system_display

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -205,6 +205,25 @@ class TestCreateRequest(object):
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING
 
+    def test_create_request_manual_parent_no_context(
+        self, client, easy_client, mock_success, bg_request
+    ):
+        easy_client.create_request.return_value = mock_success
+
+        client.command_1(_parent=bg_request)
+        assert easy_client.create_request.call_args[0][0].parent == bg_request
+
+    def test_create_request_manual_parent_context(
+        self, monkeypatch, client, easy_client, mock_success, bg_request
+    ):
+        easy_client.create_request.return_value = mock_success
+        monkeypatch.setattr(
+            brewtils.plugin, "request_context", Mock(current_request=Mock(id="1")),
+        )
+
+        client.command_1(_parent=bg_request)
+        assert easy_client.create_request.call_args[0][0].parent == bg_request
+
     @pytest.mark.parametrize(
         "kwargs",
         [


### PR DESCRIPTION
This fixes beer-garden/beer-garden#336.

Originally from #154.