### PR TITLE
Adding metadata to spec, tightening plugin method signatures

### DIFF
--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import json
 import warnings
 from argparse import ArgumentParser
 
@@ -7,8 +7,8 @@ from yapconf import YapconfSpec
 from yapconf.exceptions import YapconfItemNotFound
 
 from brewtils.errors import ValidationError
-from brewtils.specification import SPECIFICATION
 from brewtils.rest import normalize_url_prefix
+from brewtils.specification import SPECIFICATION
 
 
 def get_argument_parser():
@@ -147,6 +147,12 @@ def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs)
                 stacklevel=2,
             )
             kwargs["bg_port"] = kwargs.pop("port")
+
+        # Metadata is a little weird because yapconf doesn't support raw dicts, so we
+        # need to make it a json string in that case
+        metadata = kwargs.get("metadata")
+        if isinstance(metadata, dict):
+            kwargs["metadata"] = json.dumps(metadata)
 
         sources.append(("kwargs", kwargs))
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 import logging.config
 import threading
@@ -163,7 +164,7 @@ class Plugin(object):
             attempts. Will double on subsequent attempts until reaching mq_max_timeout.
     """
 
-    def __init__(self, client=None, system=None, logger=None, metadata=None, **kwargs):
+    def __init__(self, client=None, system=None, logger=None, **kwargs):
         # Load config before setting up logging so the log level is configurable
         self.config = load_config(**kwargs)
 
@@ -185,7 +186,7 @@ class Plugin(object):
 
         self._client = client
         self._shutdown_event = threading.Event()
-        self._system = self._setup_system(system, metadata, kwargs)
+        self._system = self._setup_system(system, kwargs)
         self._ez_client = EasyClient(logger=self._logger, **self.config)
 
         # These will be created on startup
@@ -443,7 +444,7 @@ class Plugin(object):
                 "Unable to process message - currently shutting down"
             )
 
-    def _setup_system(self, system, metadata, plugin_kwargs):
+    def _setup_system(self, system, plugin_kwargs):
         helper_keywords = {
             "name",
             "version",
@@ -455,7 +456,7 @@ class Plugin(object):
         }
 
         if system:
-            if metadata or helper_keywords.intersection(plugin_kwargs.keys()):
+            if helper_keywords.intersection(plugin_kwargs.keys()):
                 raise ValidationError(
                     "Sorry, you can't provide a complete system definition as well as "
                     "system creation helper kwargs %s" % helper_keywords
@@ -483,7 +484,7 @@ class Plugin(object):
                 name=name,
                 description=description,
                 version=version,
-                metadata=metadata,
+                metadata=json.loads(self.config.metadata),
                 commands=getattr(self._client, "_bg_commands", []),
                 instances=[Instance(name=self.config.instance_name)],
                 max_instances=self.config.max_instances,

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
 
+
+def _is_json_dict(s):
+    import json
+
+    try:
+        return isinstance(json.loads(s), dict)
+    except json.decoder.JSONDecodeError:
+        return False
+
+
 _CONNECTION_SPEC = {
     "bg_host": {
         "type": "str",
@@ -104,6 +114,13 @@ _SYSTEM_SPEC = {
         "type": "str",
         "description": "The system display name",
         "required": False,
+    },
+    "metadata": {
+        "type": "str",
+        "description": "The system metadata, in JSON string form."
+        'Something like \'{"foo": "bar"}\'',
+        "default": "{}",
+        "validator": _is_json_dict,
     },
 }
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -101,12 +101,6 @@ class TestGetConnectionInfo(object):
 
 
 class TestLoadConfig(object):
-    def setup_method(self):
-        self.safe_copy = os.environ.copy()
-
-    def teardown_method(self):
-        os.environ = self.safe_copy
-
     def test_cli_from_arg(self):
         cli_args = ["--bg-host", "the_host"]
 
@@ -163,15 +157,24 @@ class TestLoadConfig(object):
         with pytest.raises(ValidationError):
             load_config(environment=False)
 
-    def test_metadata_kwarg(self):
-        os.environ["BG_HOST"] = "the_host"
+    class TestMetadata(object):
+        @pytest.fixture(autouse=True)
+        def host_env(self):
+            """Just always set this so load_config doesn't fail"""
+            os.environ["BG_HOST"] = "the_host"
 
-        config = load_config(metadata={"foo": "bar"})
-        assert config.metadata == '{"foo": "bar"}'
+        def test_kwarg_dict(self):
+            assert load_config(metadata={"foo": "bar"}).metadata == '{"foo": "bar"}'
 
-    def test_metadata_env(self):
-        os.environ["BG_HOST"] = "the_host"
-        os.environ["BG_METADATA"] = '{"foo": "bar"}'
+        def test_kwarg_str(self):
+            assert load_config(metadata='{"foo": "bar"}').metadata == '{"foo": "bar"}'
 
-        config = load_config()
-        assert config.metadata == '{"foo": "bar"}'
+        def test_env(self):
+            os.environ["BG_METADATA"] = '{"foo": "bar"}'
+
+            assert load_config().metadata == '{"foo": "bar"}'
+
+        def test_cli(self):
+            cli_args = ["--metadata", '{"foo": "bar"}']
+
+            assert load_config(cli_args=cli_args).metadata == '{"foo": "bar"}'

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -162,3 +162,16 @@ class TestLoadConfig(object):
 
         with pytest.raises(ValidationError):
             load_config(environment=False)
+
+    def test_metadata_kwarg(self):
+        os.environ["BG_HOST"] = "the_host"
+
+        config = load_config(metadata={"foo": "bar"})
+        assert config.metadata == '{"foo": "bar"}'
+
+    def test_metadata_env(self):
+        os.environ["BG_HOST"] = "the_host"
+        os.environ["BG_METADATA"] = '{"foo": "bar"}'
+
+        config = load_config()
+        assert config.metadata == '{"foo": "bar"}'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
+
+import pytest
 
 import brewtils.test
 
@@ -11,3 +14,11 @@ def pytest_configure():
 
 def pytest_unconfigure():
     delattr(brewtils.test, "_running_tests")
+
+
+@pytest.fixture(autouse=True)
+def environ():
+    """Make sure tests don't clobber the environment"""
+    safe_copy = os.environ.copy()
+    yield
+    os.environ = safe_copy

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -528,17 +528,17 @@ class TestSetupSystem(object):
             {"icon_name": "foo"},
             {"display_name": "foo"},
             {"max_instances": 1},
-            {"metadata": {"foo": "bar"}},
+            {"metadata": '{"foo": "bar"}'},
         ],
     )
     def test_extra_params(self, plugin, bg_system, extra_args):
         with pytest.raises(ValidationError, match="system creation helper"):
-            plugin._setup_system(bg_system, {}, extra_args)
+            plugin._setup_system(bg_system, extra_args)
 
     def test_no_instances(self, plugin):
         system = System(name="name", version="1.0.0")
         with pytest.raises(ValidationError, match="explicit instance definition"):
-            plugin._setup_system(system, {}, {})
+            plugin._setup_system(system, {})
 
     def test_max_instances(self, plugin):
         system = System(
@@ -546,7 +546,7 @@ class TestSetupSystem(object):
             version="1.0.0",
             instances=[Instance(name="1"), Instance(name="2")],
         )
-        new_system = plugin._setup_system(system, {}, {})
+        new_system = plugin._setup_system(system, {})
         assert new_system.max_instances == 2
 
     def test_construct_system(self, plugin):
@@ -557,10 +557,11 @@ class TestSetupSystem(object):
                 "description": "desc",
                 "icon_name": "icon",
                 "display_name": "display_name",
+                "metadata": '{"foo": "bar"}',
             }
         )
 
-        new_system = plugin._setup_system(None, {"foo": "bar"}, {})
+        new_system = plugin._setup_system(None, {})
         self._validate_system(new_system)
 
     def test_construct_from_client(self, plugin, client):
@@ -569,7 +570,7 @@ class TestSetupSystem(object):
         client._bg_version = "1.0.0"
         client.__doc__ = "Description\nSome more stuff"
 
-        new_system = plugin._setup_system(None, {}, {})
+        new_system = plugin._setup_system(None, {})
         assert new_system.name == "name"
         assert new_system.version == "1.0.0"
         assert new_system.description == "Description"
@@ -579,7 +580,7 @@ class TestSetupSystem(object):
         client._bg_name = "system"
         client._bg_version = "1.0.0"
 
-        new_system = plugin._setup_system(bg_system, {}, {})
+        new_system = plugin._setup_system(bg_system, {})
         assert new_system.name == "system"
         assert new_system.version == "1.0.0"
 
@@ -587,7 +588,7 @@ class TestSetupSystem(object):
     def test_missing_params(self, plugin, kwargs):
         plugin.config.update(kwargs)
         with pytest.raises(ValidationError):
-            plugin._setup_system(None, {}, kwargs)
+            plugin._setup_system(None, kwargs)
 
     @pytest.mark.parametrize(
         "attr,value", [("_bg_name", "name"), ("_bg_version", "1.1.1")]
@@ -595,7 +596,7 @@ class TestSetupSystem(object):
     def test_decorator_mismatch(self, plugin, client, bg_system, attr, value):
         setattr(client, attr, value)
         with pytest.raises(ValidationError, match="doesn't match"):
-            plugin._setup_system(bg_system, {}, {})
+            plugin._setup_system(bg_system, {})
 
     @staticmethod
     def _validate_system(new_system):


### PR DESCRIPTION
This PR adds the last piece of being able to completely construct a `System` definition using yapconf.

Basically, instead of `metadata` being a special thing you could *only* specify by hardcoding it into your Plugin

```python
Plugin(client, system_name="foo", metadata={"foo": "bar"})
```

You can put it in the environment or CLI and we'll pick it up, just like all the other System kwargs. But you can still pass it as a dict (or a string, if you want) to the Plugin like before.