### PR TITLE
No longer need to manually specify items in get_connection_info

### DIFF
--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -8,7 +8,7 @@ from yapconf.exceptions import YapconfItemNotFound
 
 from brewtils.errors import ValidationError
 from brewtils.rest import normalize_url_prefix
-from brewtils.specification import SPECIFICATION
+from brewtils.specification import SPECIFICATION, _CONNECTION_SPEC
 
 
 def get_argument_parser():
@@ -73,24 +73,7 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
     """
     config = load_config(cli_args=cli_args, argument_parser=argument_parser, **kwargs)
 
-    return {
-        key: config[key]
-        for key in (
-            "bg_host",
-            "bg_port",
-            "bg_url_prefix",
-            "ssl_enabled",
-            "api_version",
-            "ca_cert",
-            "client_cert",
-            "ca_verify",
-            "username",
-            "password",
-            "access_token",
-            "refresh_token",
-            "client_timeout",
-        )
-    }
+    return {key: config[key] for key in _CONNECTION_SPEC}
 
 
 def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs):


### PR DESCRIPTION
This is a small tweak to `get_connection_info` that was enabled by the spec reorganization.