### PR TITLE
Tweaking plugin logging initialization steps

### DIFF
--- a/brewtils/config.py
+++ b/brewtils/config.py
@@ -76,7 +76,9 @@ def get_connection_info(cli_args=None, argument_parser=None, **kwargs):
     return {key: config[key] for key in _CONNECTION_SPEC}
 
 
-def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs):
+def load_config(
+    cli_args=True, environment=True, argument_parser=None, bootstrap=False, **kwargs
+):
     """Load configuration using Yapconf
 
     Configuration will be loaded from these sources, with earlier sources having
@@ -154,7 +156,7 @@ def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs)
         sources.append("ENVIRONMENT")
 
     try:
-        config = spec.load_config(*sources)
+        config = spec.load_config(*sources, bootstrap=bootstrap)
     except YapconfItemNotFound as ex:
         if ex.item.name == "bg_host":
             raise ValidationError(
@@ -167,6 +169,7 @@ def load_config(cli_args=True, environment=True, argument_parser=None, **kwargs)
         raise
 
     # Make sure the url_prefix is normal
-    config.bg_url_prefix = normalize_url_prefix(config.bg_url_prefix)
+    if "bg_url_prefix" in config:
+        config.bg_url_prefix = normalize_url_prefix(config.bg_url_prefix)
 
     return config

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -164,40 +164,50 @@ class Plugin(object):
     """
 
     def __init__(self, client=None, system=None, logger=None, **kwargs):
-        # Load config before setting up logging so the log level is configurable
-        self._config = load_config(**kwargs)
+        # These will be created on startup
+        self._instance = None
+        self._admin_processor = None
+        self._request_processor = None
 
-        # Set the global config so it can be used by SystemClients and such
-        global CONFIG
-        if len(CONFIG):
-            print(
-                "Global CONFIG object is not empty! If multiple plugins are running in "
-                "this process please ensure any [System|Easy|Rest]Clients are passed "
-                "connection information as kwargs - auto-discovery may be incorrect."
-            )
-        CONFIG = Box(self._config.to_dict(), default_box=True)
+        self._client = client
+        self._shutdown_event = threading.Event()
 
-        # If a logger is specified or the root logger already has handlers then we
-        # assume that logging has already been configured
+        # First thing to do is set a basic logging config, if necessary. If a logger is
+        # specified or the root logger already has handlers then we assume that
+        # configuration is already done and we don't modify it.
         self._custom_logger = True
         if logger:
             self._logger = logger
         else:
             if len(logging.root.handlers) == 0:
-                logging.config.dictConfig(default_config(level=self._config.log_level))
                 self._custom_logger = False
+
+                # log_level is the only bootstrap config item
+                boot_config = load_config(bootstrap=True, **kwargs)
+                logging.config.dictConfig(default_config(level=boot_config.log_level))
 
             self._logger = logging.getLogger(__name__)
 
-        self._client = client
-        self._shutdown_event = threading.Event()
+        # Now that some logging configuration is set we can load the real config
+        self._config = load_config(**kwargs)
+
+        # If global config has already been set that's a warning
+        global CONFIG
+        if len(CONFIG):
+            self._logger.warning(
+                "Global CONFIG object is not empty! If multiple plugins are running in "
+                "this process please ensure any [System|Easy|Rest]Clients are passed "
+                "connection information as kwargs as auto-discovery may be incorrect."
+            )
+        CONFIG = Box(self._config.to_dict(), default_box=True)
+
+        # Now that the config is loaded we can set _system and _ez_client
         self._system = self._setup_system(system, kwargs)
         self._ez_client = EasyClient(logger=self._logger, **self._config)
 
-        # These will be created on startup
-        self._instance = None
-        self._admin_processor = None
-        self._request_processor = None
+        # And with _system and _ez_client we can ask for the real logging config
+        # (unless _custom_logger is True, in which case this does nothing)
+        self._initialize_logging()
 
     def run(self):
         if not self._client:
@@ -246,7 +256,6 @@ class Plugin(object):
         )
 
     def _startup(self):
-        self._initialize_logging()
         self._logger.debug("About to start up plugin %s", self.unique_name)
 
         self._system = self._initialize_system()

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -207,7 +207,8 @@ class Plugin(object):
 
         # And with _system and _ez_client we can ask for the real logging config
         # (unless _custom_logger is True, in which case this does nothing)
-        self._initialize_logging()
+        # TODO - Enable this once plugin logging is in a better state
+        # self._initialize_logging()
 
     def run(self):
         if not self._client:

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -135,6 +135,7 @@ _PLUGIN_SPEC = {
         "type": "str",
         "description": "The log level to use",
         "default": "INFO",
+        "bootstrap": True,
     },
     "max_concurrent": {
         "type": "int",

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -5,7 +5,7 @@ import os
 import warnings
 
 import pytest
-from mock import MagicMock, Mock, ANY, call
+from mock import MagicMock, Mock, ANY
 from requests import ConnectionError as RequestsConnectionError
 
 import brewtils.plugin
@@ -138,12 +138,15 @@ class TestInit(object):
         )
         assert logging.getLogger("brewtils.plugin") == plugin._logger
 
+        # TODO - Enable this once plugin logging is in a better state
         # Config will happen twice - once with the bootstrap level default config and
         # once as part of the call to _initialize_logging
-        assert dict_config.call_count == 2
-        dict_config.assert_has_calls(
-            [call(default_config(level="WARNING")), call(convert_logging)]
-        )
+        # assert dict_config.call_count == 2
+        # dict_config.assert_has_calls(
+        #     [call(default_config(level="WARNING")), call(convert_logging)]
+        # )
+        assert dict_config.call_count == 1
+        dict_config.assert_called_once_with(default_config(level="WARNING"))
 
     def test_kwargs(self, client, bg_system):
         logger = Mock()


### PR DESCRIPTION
This PR helps with the logging / config loading chicken and egg issue.

We'd like logging configuration to be the first thing to happen so that any issues that occur are reported properly. However, we need to load the configuration in order to determine the correct log level to use.

This PR marks `log_level` as a bootstrap item. If logging configuration is necessary (there isn't a logger passed to the plugin and there aren't any handlers on the root logger) then it will load only the bootstrap items (i.e. the log level), configure logging, and then continue with Plugin __init__ (load the rest of the config, etc.)

This PR also disables automatically asking Beer-garden for the plugin logging configuration. I'd like to get to the point where that makes sense, but that's not something that currently happens in v2 and there is more work needed to get that into a good place. So I'm taking that out for now.