### PR TITLE
Removing status state checking from Request model

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -5,8 +5,6 @@ from enum import Enum
 import pytz
 import six
 
-from brewtils.errors import RequestStatusTransitionError
-
 __all__ = [
     "BaseModel",
     "System",
@@ -505,6 +503,10 @@ class Request(RequestTemplate):
     def status(self):
         return self._status
 
+    @status.setter
+    def status(self, value):
+        self._status = value
+
     @property
     def is_ephemeral(self):
         return self.command_type and self.command_type.upper() == "EPHEMERAL"
@@ -512,28 +514,6 @@ class Request(RequestTemplate):
     @property
     def is_json(self):
         return self.output_type and self.output_type.upper() == "JSON"
-
-    @status.setter
-    def status(self, value):
-        if self._status in self.COMPLETED_STATUSES:
-            raise RequestStatusTransitionError(
-                "Status for a request cannot be updated once it has been "
-                "completed. Current status: {0} Requested status: {1}".format(
-                    self.status, value
-                )
-            )
-
-        elif self._status == "IN_PROGRESS" and value not in self.COMPLETED_STATUSES + (
-            "IN_PROGRESS",
-        ):
-            raise RequestStatusTransitionError(
-                "A request cannot go from IN_PROGRESS to a non-completed "
-                "status. Completed statuses are {0}. You requested: {1}".format(
-                    self.COMPLETED_STATUSES, value
-                )
-            )
-
-        self._status = value
 
 
 class System(BaseModel):

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -4,24 +4,23 @@ import pytz
 from mock import Mock, PropertyMock
 from pytest_lazyfixture import lazy_fixture
 
-from brewtils.errors import RequestStatusTransitionError
 from brewtils.models import (
+    Choices,
     Command,
+    CronTrigger,
+    Event,
     Instance,
+    IntervalTrigger,
+    LoggingConfig,
     Parameter,
     PatchOperation,
-    Request,
-    System,
-    Choices,
-    LoggingConfig,
-    Event,
-    Queue,
     Principal,
-    Role,
-    RequestTemplate,
-    CronTrigger,
-    IntervalTrigger,
+    Queue,
+    Request,
     RequestFile,
+    RequestTemplate,
+    Role,
+    System,
 )
 
 
@@ -317,20 +316,9 @@ class TestRequest(object):
         assert "name" in repr(request1)
         assert "CREATED" in repr(request1)
 
-    def test_set_valid_status(self):
-        request = Request(status="CREATED")
-        request.status = "RECEIVED"
-        request.status = "IN_PROGRESS"
-        request.status = "SUCCESS"
-
-    @pytest.mark.parametrize(
-        "start,end",
-        [("SUCCESS", "IN_PROGRESS"), ("SUCCESS", "ERROR"), ("IN_PROGRESS", "CREATED")],
-    )
-    def test_invalid_status_transitions(self, start, end):
-        request = Request(status=start)
-        with pytest.raises(RequestStatusTransitionError):
-            request.status = end
+    def test_set_status(self, request1):
+        request1.status = "RECEIVED"
+        assert request1._status == "RECEIVED"
 
     def test_is_ephemeral(self, request1):
         assert not request1.is_ephemeral


### PR DESCRIPTION
This PR removes the last piece of changes to models raising exceptions - modifying a Request status. The logic of ensuring that an illegal state transition does not occur has been moved into the Beer-garden database layer.

This is part of #92.