### PR TITLE
Adding an update_instance method to EasyClient

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -249,6 +249,8 @@ The `EasyClient` had some API changes:
   - `get_queues()` default is now `FetchError`
   - `clear_queue()` and `clear_all_queues()` defaults are now `DeleteError`
 
+Also, a new method `update_instance()` was added; `update_instance_status()` is now deprecated.
+
 
 ### General Organization
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -288,7 +288,7 @@ class Plugin(object):
         self._admin_processor.shutdown()
 
         try:
-            self._ez_client.update_instance_status(self._instance.id, "STOPPED")
+            self._ez_client.update_instance(self._instance.id, new_status="STOPPED")
         except Exception:
             self._logger.warning(
                 "Unable to notify Beer-garden that this plugin is STOPPED, so this "
@@ -443,8 +443,8 @@ class Plugin(object):
 
     def _start(self):
         """Handle start Request by marking this plugin as running"""
-        self._instance = self._ez_client.update_instance_status(
-            self._instance.id, "RUNNING"
+        self._instance = self._ez_client.update_instance(
+            self._instance.id, new_status="RUNNING"
         )
 
     def _stop(self):

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -330,14 +330,14 @@ class TestShutdown(object):
         plugin._shutdown()
         assert plugin._request_processor.shutdown.called is True
         assert plugin._admin_processor.shutdown.called is True
-        ez_client.update_instance_status.assert_called_once_with(
-            bg_instance.id, "STOPPED"
+        ez_client.update_instance.assert_called_once_with(
+            bg_instance.id, new_status="STOPPED"
         )
 
     def test_update_error(self, caplog, plugin, ez_client, bg_instance):
         plugin.request_consumer = Mock()
         plugin.admin_consumer = Mock()
-        ez_client.update_instance_status.side_effect = RequestsConnectionError()
+        ez_client.update_instance.side_effect = RequestsConnectionError()
 
         with caplog.at_level(level=logging.WARNING):
             plugin._shutdown()
@@ -505,11 +505,11 @@ class TestInitializeProcessors(object):
 class TestAdminMethods(object):
     def test_start(self, plugin, ez_client, bg_instance):
         new_instance = Mock()
-        ez_client.update_instance_status.return_value = new_instance
+        ez_client.update_instance.return_value = new_instance
 
         plugin._start()
-        ez_client.update_instance_status.assert_called_once_with(
-            bg_instance.id, "RUNNING"
+        ez_client.update_instance.assert_called_once_with(
+            bg_instance.id, new_status="RUNNING"
         )
         assert plugin._instance == new_instance
 

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -243,11 +243,23 @@ class TestInstances(object):
         rest_client.patch_instance.assert_called_once_with("id", ANY)
         assert rest_client.patch_instance.called is True
 
+    def test_update(self, client, rest_client, success):
+        rest_client.patch_instance.return_value = success
+
+        client.update_instance("id", new_status="status", metadata={"meta": "update"})
+        rest_client.patch_instance.assert_called_once_with("id", ANY)
+
     def test_update_status(self, client, rest_client, success):
         rest_client.patch_instance.return_value = success
 
-        client.update_instance_status("id", "status")
-        rest_client.patch_instance.assert_called_once_with("id", ANY)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            client.update_instance_status("id", "status")
+            rest_client.patch_instance.assert_called_once_with("id", ANY)
+
+            assert len(w) == 1
+            assert w[0].category == DeprecationWarning
 
     def test_heartbeat(self, client, rest_client, success):
         rest_client.patch_instance.return_value = success


### PR DESCRIPTION
This PR adds an `update_instance` method the the `EasyClient` and deprecates the `update_instance_status` method.