### PR TITLE
Adding runner_id to spec, instance initialization

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -379,6 +379,7 @@ class Plugin(object):
         return self._ez_client.update_system(existing_system.id, **update_kwargs)
 
     def _initialize_instance(self):
+        """Let Beer-garden know this instance is ready to process Requests"""
         # Sanity check to make sure an instance with this name was registered
         if not self._system.has_instance(self._config.instance_name):
             raise PluginValidationError(
@@ -387,7 +388,8 @@ class Plugin(object):
             )
 
         return self._ez_client.initialize_instance(
-            self._system.get_instance(self._config.instance_name).id
+            self._system.get_instance(self._config.instance_name).id,
+            runner_id=self._config.runner_id,
         )
 
     def _initialize_processors(self):

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -333,18 +333,22 @@ class EasyClient(object):
     @wrap_response(
         parse_method="parse_instance", parse_many=False, default_exc=SaveError
     )
-    def initialize_instance(self, instance_id):
+    def initialize_instance(self, instance_id, runner_id=None):
         """Start an Instance
 
         Args:
             instance_id (str): The Instance ID
+            runner_id (str): The PluginRunner ID, if any
 
         Returns:
             Instance: The updated Instance
 
         """
         return self.client.patch_instance(
-            instance_id, SchemaParser.serialize_patch(PatchOperation("initialize"))
+            instance_id,
+            SchemaParser.serialize_patch(
+                PatchOperation(operation="initialize", value={"runner_id": runner_id})
+            ),
         )
 
     @wrap_response(

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -136,6 +136,11 @@ _PLUGIN_SPEC = {
         "description": "The instance name",
         "default": "default",
     },
+    "runner_id": {
+        "type": "str",
+        "description": "The PluginRunner ID, if applicable",
+        "required": False,
+    },
     "log_level": {
         "type": "str",
         "description": "The log level to use",

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -455,9 +455,18 @@ class TestInitializeSystem(object):
 
 
 class TestInitializeInstance(object):
-    def test_success(self, plugin, ez_client, bg_instance):
+    def test_remote(self, plugin, ez_client, bg_instance):
         plugin._initialize_instance()
-        ez_client.initialize_instance.assert_called_once_with(bg_instance.id)
+        ez_client.initialize_instance.assert_called_once_with(
+            bg_instance.id, runner_id=None
+        )
+
+    def test_local(self, plugin, ez_client, bg_instance):
+        plugin._config.runner_id = "ABC"
+        plugin._initialize_instance()
+        ez_client.initialize_instance.assert_called_once_with(
+            bg_instance.id, runner_id="ABC"
+        )
 
     def test_unregistered_instance(self, plugin, ez_client, bg_system):
         bg_system.has_instance = Mock(return_value=False)


### PR DESCRIPTION
This PR adds a `runner_id` field to the plugin spec to enble linking a plugin to a local plugin runner.