### PR TITLE
Can connect

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -263,8 +263,8 @@ Finally, `get_system()` and `get_request()` methods that raise a `NotFoundError`
 
 
 ### `RestClient`
-- Keyword arguments for `get_version()` are now unused. Previously they would be passed as query parameters, which is not useful as query parameters are ignored for that endpoint.
-- Keyword arguments for `get_config()` are now also unused. Previously they would be passed to the underlying `requests.session` call, which allowed for things like an alternate timeout value. This was inconsistent with all other `RestClient` methods and has been removed. However, this behavior *is* supported on the new `can_connect()` method, so if you'd like to specify an alternate timeout for checking connectivity that's possible with `can_connect()`. Also, specifying a value for the `client_timeout` parameter when creating the `RestClient` will enable timeouts across all `RestClient` methods, which is recommended.
+- Keyword arguments for `get_version()` are now unused and passing them will result in a `DeprecationWarning`. Previously they would be passed as query parameters, which is not useful as query parameters are ignored for that endpoint.
+- Keyword arguments for `get_config()` are now also unused and passing them will result in a `DeprecationWarning`. Previously they would be passed to the underlying `requests.session` call, which allowed for things like an alternate timeout value. This was inconsistent with all other `RestClient` methods and has been removed. However, this behavior *is* supported on the new `can_connect()` method, so if you'd like to specify an alternate timeout for checking connectivity that's possible with `can_connect()`. Also, specifying a value for the `client_timeout` parameter when creating the `RestClient` will enable timeouts across all `RestClient` methods, which is recommended.
 - `can_connect()` is a new method that can be used to check connectivity to the Beer-garden server. Previously this method was only available on the `EasyClient`.
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -220,6 +220,9 @@ def main():
 #### Internal `_start` and `_stop` method return values
 The `_start` and `_stop` methods both previously returned a string literal that was not used. These methods now return `None`.
 
+#### Startup connection error
+The `Plugin.run()` method now raises a `brewtils.errors.RestConnectionError` if the initial connection to Beer-garden was unsuccessful. Previously a `requests.exceptions.ConnectionError` would be raised.
+
 
 ### `SystemClient`
 
@@ -257,6 +260,12 @@ The `EasyClient` had some API changes:
 Also, a new method `update_instance()` was added; `update_instance_status()` is now deprecated.
 
 Finally, `get_system()` and `get_request()` methods that raise a `NotFoundError` if the system or request isn't found were added. The existing `find_*` and `find_unique_*` methods are unchanged.
+
+
+### `RestClient`
+- Keyword arguments for `get_version()` are now unused. Previously they would be passed as query parameters, which is not useful as query parameters are ignored for that endpoint.
+- Keyword arguments for `get_config()` are now also unused. Previously they would be passed to the underlying `requests.session` call, which allowed for things like an alternate timeout value. This was inconsistent with all other `RestClient` methods and has been removed. However, this behavior *is* supported on the new `can_connect()` method, so if you'd like to specify an alternate timeout for checking connectivity that's possible with `can_connect()`. Also, specifying a value for the `client_timeout` parameter when creating the `RestClient` will enable timeouts across all `RestClient` methods, which is recommended.
+- `can_connect()` is a new method that can be used to check connectivity to the Beer-garden server. Previously this method was only available on the `EasyClient`.
 
 
 ### General Organization

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -267,7 +267,19 @@ class Plugin(object):
         )
 
     def _startup(self):
+        """Plugin startup procedure
+
+        This method actually starts the plugin. When it completes the plugin should be
+        considered in a "running" state - listening to the appropriate message queues,
+        connected to the Beer-garden server, and ready to process Requests.
+
+        This method should be the first time that a connection to the Beer-garden
+        server is *required*.
+        """
         self._logger.debug("About to start up plugin %s", self.unique_name)
+
+        if not self._ez_client.can_connect():
+            raise RestConnectionError("Cannot connect to the Beer-garden server")
 
         self._system = self._initialize_system()
         self._instance = self._initialize_instance()
@@ -284,6 +296,12 @@ class Plugin(object):
         self._request_processor.startup()
 
     def _shutdown(self):
+        """Plugin shutdown procedure
+
+        This method gracefully stops the plugin. When it completes the plugin should be
+        considered in a "stopped" state - the message processors shut down and all
+        connections closed.
+        """
         self._logger.debug("About to shut down plugin %s", self.unique_name)
         self._shutdown_event.set()
 

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -232,23 +232,35 @@ class RestClient(object):
         return True
 
     @enable_auth
-    def get_version(self, **_):
+    def get_version(self, **kwargs):
         # type: (**Any) -> Response
         """Perform a GET to the version URL
 
         Returns:
             Requests Response object
         """
+        if kwargs:
+            _deprecate(
+                "Keyword arguments for get_version are no longer used and will be "
+                "removed in a future release."
+            )
+
         return self.session.get(self.version_url)
 
     @enable_auth
-    def get_config(self, **_):
+    def get_config(self, **kwargs):
         # type: (**Any) -> Response
         """Perform a GET to the config URL
 
         Returns:
             Requests Response object
         """
+        if kwargs:
+            _deprecate(
+                "Keyword arguments for get_config are no longer used and will be "
+                "removed in a future release."
+            )
+
         return self.session.get(self.config_url)
 
     @enable_auth

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 import jwt
+import requests.exceptions
 import urllib3
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
@@ -202,6 +203,33 @@ class RestClient(object):
             positional["bg_port"] = args[1]
 
         return spec.load_config(*[kwargs, renamed, positional, brewtils.plugin.CONFIG])
+
+    def can_connect(self, **kwargs):
+        # type: (**Any) -> bool
+        """Determine if a connection to the Beer-garden server is possible
+
+        Args:
+            kwargs: Keyword arguments to pass to Requests session call
+
+        Returns:
+            A bool indicating if the connection attempt was successful. Will
+            return False only if a ConnectionError is raised during the attempt.
+            Any other exception will be re-raised.
+
+        Raises:
+            requests.exceptions.RequestException:
+                The connection attempt resulted in an exception that indicates
+                something other than a basic connection error. For example,
+                an error with certificate verification.
+        """
+        try:
+            self.session.get(self.config_url, **kwargs)
+        except requests.exceptions.ConnectionError as ex:
+            if type(ex) == requests.exceptions.ConnectionError:
+                return False
+            raise
+
+        return True
 
     @enable_auth
     def get_version(self, **kwargs):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -232,30 +232,24 @@ class RestClient(object):
         return True
 
     @enable_auth
-    def get_version(self, **kwargs):
+    def get_version(self, **_):
         # type: (**Any) -> Response
         """Perform a GET to the version URL
 
-        Args:
-            kwargs: Query parameters to be used in the GET request
-
         Returns:
             Requests Response object
         """
-        return self.session.get(self.version_url, params=kwargs)
+        return self.session.get(self.version_url)
 
     @enable_auth
-    def get_config(self, **kwargs):
+    def get_config(self, **_):
         # type: (**Any) -> Response
         """Perform a GET to the config URL
 
-        Args:
-            kwargs: Passed to underlying Requests method
-
         Returns:
             Requests Response object
         """
-        return self.session.get(self.config_url, **kwargs)
+        return self.session.get(self.config_url)
 
     @enable_auth
     def get_logging_config(self, **kwargs):

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import requests.exceptions
 import six
 import wrapt
 
@@ -175,14 +174,7 @@ class EasyClient(object):
                 an error with certificate verification.
 
         """
-        try:
-            self.client.get_config(**kwargs)
-        except requests.exceptions.ConnectionError as ex:
-            if type(ex) == requests.exceptions.ConnectionError:
-                return False
-            raise
-
-        return True
+        return self.client.can_connect(**kwargs)
 
     @wrap_response(default_exc=FetchError)
     def get_version(self, **kwargs):

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -153,9 +153,31 @@ class TestRestClient(object):
                 client.can_connect()
             session_mock.get.assert_called_with(client.config_url)
 
+    def test_get_version(self, client, session_mock):
+        client.get_version()
+        session_mock.get.assert_called_with(client.version_url)
+
+    def test_get_version_deprecation(self, client):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            client.get_version(timeout=5)
+
+            assert len(w) == 1
+            assert w[0].category == DeprecationWarning
+
     def test_get_config(self, client, session_mock):
         client.get_config()
         session_mock.get.assert_called_with(client.config_url)
+
+    def test_get_config_deprecation(self, client):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            client.get_config(timeout=5)
+
+            assert len(w) == 1
+            assert w[0].category == DeprecationWarning
 
     def test_get_system_1(self, client, session_mock):
         client.get_system("id")

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -113,7 +113,8 @@ class TestRestClient(object):
     @pytest.mark.parametrize(
         "method,params,verb,url",
         [
-            ("get_version", {"key": "value"}, "get", "version_url"),
+            ("get_version", {}, "get", "version_url"),
+            ("get_config", {}, "get", "config_url"),
             (
                 "get_logging_config",
                 {"system_name": "system_name"},
@@ -128,9 +129,13 @@ class TestRestClient(object):
         getattr(client, method)(**params)
 
         # Make sure the call is correct
-        getattr(session_mock, verb).assert_called_once_with(
-            getattr(client, url), params=params
-        )
+        session_method = getattr(session_mock, verb)
+        expected_url = getattr(client, url)
+
+        if params:
+            session_method.assert_called_once_with(expected_url, params=params)
+        else:
+            session_method.assert_called_once_with(expected_url)
 
     class TestConnect(object):
         def test_success(self, client, session_mock):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -3,26 +3,25 @@
 import warnings
 
 import pytest
-import requests.exceptions
 from mock import ANY, Mock
 
 import brewtils.rest.easy_client
 from brewtils.errors import (
-    FetchError,
-    ValidationError,
-    DeleteError,
-    RestConnectionError,
-    NotFoundError,
     ConflictError,
+    DeleteError,
+    FetchError,
+    NotFoundError,
+    RestConnectionError,
     RestError,
-    WaitExceededError,
     SaveError,
     TooLargeError,
+    ValidationError,
+    WaitExceededError,
 )
 from brewtils.rest.easy_client import (
+    EasyClient,
     get_easy_client,
     handle_response_failure,
-    EasyClient,
 )
 from brewtils.schema_parser import SchemaParser
 
@@ -85,23 +84,9 @@ class TestHandleResponseFailure(object):
             handle_response_failure(server_error)
 
 
-class TestConnect(object):
-    """Test the can_connect method
-
-    Actually test failure cases here as this method isn't decorated with @wrap_response
-    """
-
-    def test_success(self, client):
-        assert client.can_connect()
-
-    def test_fail(self, client, rest_client):
-        rest_client.get_config.side_effect = requests.exceptions.ConnectionError
-        assert not client.can_connect()
-
-    def test_error(self, client, rest_client):
-        rest_client.get_config.side_effect = requests.exceptions.SSLError
-        with pytest.raises(requests.exceptions.SSLError):
-            client.can_connect()
+def test_can_connect(client, rest_client, success):
+    rest_client.can_connect.return_value = True
+    assert client.can_connect() is True
 
 
 def test_get_version(client, rest_client, success):


### PR DESCRIPTION
This PR is part of #92. It does a couple of things:

- Fixes an inconsistency with how kwargs were handled for the `RestClient.get_config` method
- Moves the `can_connect` logic from the `EasyClient` down into the `RestClient`
- Adds an explicit connection check to the plugin startup procedure for a cleaner error message and stacktrace when the connection to the Beer-garden server can't be established