### PR TITLE
Adding comparison lambda so tests don't break

### DIFF
--- a/brewtils/test/comparable.py
+++ b/brewtils/test/comparable.py
@@ -119,8 +119,9 @@ def _assert_equal(obj1, obj2, expected_type=None, deep_fields=None):
             nested2 = getattr(obj2, key)
 
             if isinstance(nested1, list) and isinstance(nested2, list):
-                l1 = sorted(getattr(obj1, key))
-                l2 = sorted(getattr(obj2, key))
+                l1 = sorted(getattr(obj1, key), key=lambda x: str(x))
+                l2 = sorted(getattr(obj2, key), key=lambda x: str(x))
+
                 _assert(
                     len(l1) == len(l2), "Length of list field %s was different" % key
                 )

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -181,6 +181,23 @@ def bg_command(command_dict, bg_parameter, system_id):
 
 
 @pytest.fixture
+def command_dict_2(command_dict):
+    """A second command represented as a dictionary."""
+    dict_copy = copy.deepcopy(command_dict)
+    dict_copy["name"] = "speak2"
+    return dict_copy
+
+
+@pytest.fixture
+def bg_command_2(command_dict_2, bg_parameter, system_id):
+    """Use the bg_command fixture instead."""
+    dict_copy = copy.deepcopy(command_dict_2)
+    dict_copy["parameters"] = [bg_parameter]
+    dict_copy["system"] = System(id=system_id)
+    return Command(**dict_copy)
+
+
+@pytest.fixture
 def instance_dict(ts_epoch):
     """An instance represented as a dictionary."""
     return {
@@ -217,7 +234,7 @@ def bg_instance(instance_dict, ts_dt):
 
 
 @pytest.fixture
-def system_dict(instance_dict, command_dict, system_id):
+def system_dict(instance_dict, command_dict, command_dict_2, system_id):
     """A system represented as a dictionary."""
     return {
         "name": "system",
@@ -226,7 +243,7 @@ def system_dict(instance_dict, command_dict, system_id):
         "id": system_id,
         "max_instances": 1,
         "instances": [instance_dict],
-        "commands": [command_dict],
+        "commands": [command_dict, command_dict_2],
         "icon_name": "fa-beer",
         "display_name": "non-offensive",
         "metadata": {"some": "stuff"},
@@ -236,11 +253,11 @@ def system_dict(instance_dict, command_dict, system_id):
 
 
 @pytest.fixture
-def bg_system(system_dict, bg_instance, bg_command):
+def bg_system(system_dict, bg_instance, bg_command, bg_command_2):
     """A system as a model."""
     dict_copy = copy.deepcopy(system_dict)
     dict_copy["instances"] = [bg_instance]
-    dict_copy["commands"] = [bg_command]
+    dict_copy["commands"] = [bg_command, bg_command_2]
     return System(**dict_copy)
 
 


### PR DESCRIPTION
This PR makes the testing comparison functions more robust.

The comparison functions attempt to sort "deep" field lists before comparing them item-by-item, but the models don't define an `__lt__` method, so they are unsortable.

This hasn't been a problem because the suite of fixtures does not have any nested lists with multiple items. For example, the system fixture only has one command. So this shortcoming was never exposed.

This PR adds an additional command fixture and uses a basic string-based comparison function when sorting.

I purposely didn't implement any magic method comparison methods in the model definitions - I don't think comparing models in that way is something we should even implicitly endorse. So hiding this in the `test` package is preferable since it doesn't commit to anything.
