### PR TITLE
Removed Systems from Command Model

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -109,7 +109,6 @@ class Command(BaseModel):
         self.form = form
         self.template = template
         self.icon_name = icon_name
-        self.system = system
         self.hidden = hidden
 
     def __str__(self):


### PR DESCRIPTION
Added Commands as a Embedded objected instead of a Reference, so this field is no longer required. 