### PR TITLE
System model methods

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -606,7 +606,7 @@ class System(BaseModel):
         Returns:
             bool: True if an instance with the given name exists, False otherwise
         """
-        return True if self.get_instance(name) else False
+        return name in self.instance_names
 
     def get_instance_by_name(self, name, raise_missing=False):
         """Get an instance that currently exists in the system

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import pytz
 import six
+from brewtils.errors import ModelError, _deprecate
 
 __all__ = [
     "BaseModel",
@@ -607,19 +608,58 @@ class System(BaseModel):
         """
         return True if self.get_instance(name) else False
 
-    def get_instance(self, name):
+    def get_instance_by_name(self, name, raise_missing=False):
         """Get an instance that currently exists in the system
 
         Args:
             name (str): The instance name
+            raise_missing (bool): If True, raise an exception if an Instance with the
+            given name is not found. If False, will return None in that case.
 
         Returns:
             Instance: The instance if it exists, None otherwise
+
+        Raises:
+            ModelError: Instance was not found and raise_missing=True
         """
         for instance in self.instances:
             if instance.name == name:
                 return instance
+
+        if raise_missing:
+            raise ModelError("Instance not found")
+
         return None
+
+    def get_instance_by_id(self, id, raise_missing=False):
+        """Get an instance that currently exists in the system
+
+        Args:
+            id (str): The instance id
+            raise_missing (bool): If True, raise an exception if an Instance with the
+            given id is not found. If False, will return None in that case.
+
+        Returns:
+            Instance: The instance if it exists, None otherwise
+
+        Raises:
+            ModelError: Instance was not found and raise_missing=True
+        """
+        for instance in self.instances:
+            if instance.id == id:
+                return instance
+
+        if raise_missing:
+            raise ModelError("Instance not found")
+
+        return None
+
+    def get_instance(self, name):
+        """DEPRECATED: Please use get_instance_by_name instead"""
+        _deprecate(
+            "Heads up! This method is deprecated, please use get_instance_by_name"
+        )
+        return self.get_instance_by_name(name)
 
     def get_command_by_name(self, command_name):
         """Retrieve a particular command from the system

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -448,7 +448,7 @@ class Plugin(object):
             )
 
         return self._ez_client.initialize_instance(
-            self._system.get_instance(self._config.instance_name).id,
+            self._system.get_instance_by_name(self._config.instance_name).id,
             runner_id=self._config.runner_id,
         )
 


### PR DESCRIPTION
This PR changes some of the methods on the System model:

- Adds `get_instance_by_id`
- Functionality of `get_instance` is moved to `get_instance_by_name`
- `get_instance` is deprecated and delegates to `get_instance_by_name`

It also cleans up the System model tests a bit.