### PR TITLE
Serialization of Datetime fields works if already in correct form

### DIFF
--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -88,6 +88,10 @@ class DateTime(fields.DateTime):
 
     @staticmethod
     def to_epoch(dt, localtime=False):
+        # If already in epoch form just return it
+        if isinstance(dt, int):
+            return dt
+
         if localtime and dt.tzinfo is not None:
             localized = dt
         else:
@@ -101,6 +105,10 @@ class DateTime(fields.DateTime):
 
     @staticmethod
     def from_epoch(epoch):
+        # If already in datetime form just return it
+        if isinstance(epoch, datetime.datetime):
+            return epoch
+
         # utcfromtimestamp will correctly parse milliseconds in Python 3,
         # but in Python 2 we need to help it
         seconds, millis = divmod(epoch, 1000)

--- a/test/schema_test.py
+++ b/test/schema_test.py
@@ -39,13 +39,22 @@ class TestFields(object):
             (lazy_fixture("ts_dt"), True, lazy_fixture("ts_epoch")),
             (lazy_fixture("ts_dt_eastern"), False, lazy_fixture("ts_epoch_eastern")),
             (lazy_fixture("ts_dt_eastern"), True, lazy_fixture("ts_epoch")),
+            (lazy_fixture("ts_epoch"), False, lazy_fixture("ts_epoch")),
+            (lazy_fixture("ts_epoch"), True, lazy_fixture("ts_epoch")),
         ],
     )
     def test_to_epoch(self, dt, localtime, expected):
         assert DateTime.to_epoch(dt, localtime) == expected
 
-    def test_from_epoch(self, ts_epoch, ts_dt):
-        assert DateTime.from_epoch(ts_epoch) == ts_dt
+    @pytest.mark.parametrize(
+        "epoch,expected",
+        [
+            (lazy_fixture("ts_epoch"), lazy_fixture("ts_dt")),
+            (lazy_fixture("ts_dt"), lazy_fixture("ts_dt")),
+        ],
+    )
+    def test_from_epoch(self, epoch, expected):
+        assert DateTime.from_epoch(epoch) == expected
 
     def test_modelfield_serialize_invalid_type(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This is part of beer-garden/beer-garden#611

This allows Datetime fields to (de)serialize correctly if the data is already in the "correct" form. This helps with serializing a dict/box that may already have a Datetime field in epoch format.