### PR TITLE
Plugin invoke method slightly more robust for None parameters

### DIFF
--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -531,7 +531,8 @@ class Plugin(object):
         # trying to call a function on self. In both cases the function object
         # is bound... think it has something to do with our decorators
         args = [self] if target is self else []
-        return getattr(target, request.command)(*args, **request.parameters)
+        kwargs = request.parameters or {}
+        return getattr(target, request.command)(*args, **kwargs)
 
     def _update_request(self, request, headers):
         """Sends a Request update to beer-garden

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -683,6 +683,14 @@ class TestInvokeCommand(object):
         plugin._invoke_command(client, request)
         client.command.assert_called_once_with(**request.parameters)
 
+    def test_invoke_request_none_parameters(self, plugin, client):
+        request = Request(
+            system="test_system", system_version="1.0.0", command="command"
+        )
+
+        plugin._invoke_command(client, request)
+        client.command.assert_called_once_with()
+
     @pytest.mark.parametrize(
         "command", ["foo", "_commands"]  # Missing attribute  # Non-callable attribute
     )


### PR DESCRIPTION
This fixes beer-garden/beer-garden#351 *in the v2 branch*. This is needed to provide compatibility between v3 beer-garden and a plugin using v2 brewtils.