### PR TITLE
Adding client_key spec item

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -122,7 +122,12 @@ class RestClient(object):
 
         # Configure the session to use when making requests
         self.session = Session()
-        self.session.cert = self._config.client_cert
+
+        # This is what Requests is expecting
+        if self._config.client_key:
+            self.session.cert = (self._config.client_cert, self._config.client_key)
+        else:
+            self.session.cert = self._config.client_cert
 
         if not self._config.ca_verify:
             urllib3.disable_warnings()

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -49,6 +49,11 @@ _CONNECTION_SPEC = {
         "required": False,
         "alt_env_names": ["SSL_CLIENT_CERT"],
     },
+    "client_key": {
+        "type": "str",
+        "description": "Client key to use with Beergarden",
+        "required": False,
+    },
     "ssl_enabled": {
         "type": "bool",
         "description": "Use SSL when communicating with Beergarden",

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -27,6 +27,7 @@ def params():
         "api_version": 1,
         "ca_cert": "ca_cert",
         "client_cert": "client_cert",
+        "client_key": "client_key",
         "ca_verify": True,
         "username": None,
         "password": None,
@@ -46,6 +47,7 @@ class TestGetConnectionInfo(object):
         os.environ["BG_SSL_ENABLED"] = "False"
         os.environ["BG_CA_CERT"] = "ca_cert"
         os.environ["BG_CLIENT_CERT"] = "client_cert"
+        os.environ["BG_CLIENT_KEY"] = "client_key"
         os.environ["BG_URL_PREFIX"] = "/beer/"
         os.environ["BG_CA_VERIFY"] = "True"
 


### PR DESCRIPTION
Fixes beer-garden/beer-garden#785.

~In draft until I can set up a tls Beergarden and test for real.~

Tested using the tls docker-compose setup with  `BG_ENTRY_HTTP_SSL_CLIENT_CERT_VERIFY: "REQUIRED"`. Remote plugin was unable to register (raising a `requests.exceptions.SSLError`) using these CLI args:

```
--no-ca-verify
```

Changing the CLI args to these results in successful registration:

```
--ca-cert beer-garden/docker/docker-compose/data/certs/ca_certificate.pem
--client-cert beer-garden/docker/docker-compose/data/certs/client_certificate.pem
--client-key beer-garden/docker/docker-compose/data/certs/client_key.pem
```

Doing things this way is kind of weird and prevents the UI from working since the requests coming from the UI container don't have a client cert. So I had to point the plugin directly at the exposed beer-garden port instead of going through the UI. This isn't a big deal since nginx should really be doing TLS termination anyway - I wouldn't run things this way for real, but it was enough to prove this PR is doing what it's supposed to.