### PR TITLE
Issue/787

### DIFF
--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -24,6 +24,13 @@ from brewtils.plugin import Plugin, PluginBase, RemotePlugin
 
 
 @pytest.fixture(autouse=True)
+def stub_dangerous(monkeypatch):
+    """Stub out stuff that could interfere with pytest"""
+    monkeypatch.setattr(brewtils.plugin.Plugin, "_set_signal_handlers", Mock())
+    monkeypatch.setattr(brewtils.plugin.Plugin, "_set_exception_hook", Mock())
+
+
+@pytest.fixture(autouse=True)
 def ez_client(monkeypatch, bg_system, bg_instance, bg_logging_config):
     _ez_client = Mock(
         name="ez_client",


### PR DESCRIPTION
This adds a hook to "correctly" (aka, using the supplied logging config) log any uncaught exceptions. Fixes beer-garden/beer-garden#787.

I've also explicitly mocked out functions that mangle system-wide attributes during testing. I'm normally *very* against not testing things in brewtils, but I'm honestly not sure how we'd go about unit testing these things.