### PR TITLE
Issue/827

### DIFF
--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -464,11 +464,15 @@ class SystemClient(object):
             parameters=kwargs,
         )
 
-        file_params = self._commands[command].parameter_keys_by_type("Base64")
-        resolver = UploadResolver(request, file_params, self._resolvers)
-        request.parameters = resolver.resolve_parameters()
+        request.parameters = self._resolve_parameters(command, request)
 
         return request
+
+    def _resolve_parameters(self, command, request):
+        file_params = self._commands[command].parameter_keys_by_type("Base64")
+        resolver = UploadResolver(request, file_params, self._resolvers)
+
+        return resolver.resolve_parameters()
 
     @staticmethod
     def _determine_latest(systems):

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -441,10 +441,9 @@ class SystemClient(object):
         if system_display:
             metadata["system_display_name"] = system_display
 
+        # Don't check namespace - https://github.com/beer-garden/beer-garden/issues/827
         if command is None:
             raise ValidationError("Unable to send a request with no command")
-        if system_namespace is None:
-            raise ValidationError("Unable to send a request with no system namespace")
         if system_name is None:
             raise ValidationError("Unable to send a request with no system name")
         if system_version is None:

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -249,7 +249,9 @@ class TestCreateRequest(object):
             "_instance_name",
         ],
     )
-    def test_missing_field(self, client, remove_kwarg):
+    def test_missing_field(self, monkeypatch, client, remove_kwarg):
+        monkeypatch.setattr(client, "_resolve_parameters", Mock())
+
         kwargs = {
             "_command": "",
             "_system_name": "",

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -244,7 +244,6 @@ class TestCreateRequest(object):
         "remove_kwarg",
         [
             "_command",
-            "_system_namespace",
             "_system_name",
             "_system_version",
             "_instance_name",
@@ -253,7 +252,6 @@ class TestCreateRequest(object):
     def test_missing_field(self, client, remove_kwarg):
         kwargs = {
             "_command": "",
-            "_system_namespace": "",
             "_system_name": "",
             "_system_version": "",
             "_instance_name": "",


### PR DESCRIPTION
Fixes beer-garden/beer-garden#827. Removes the SystemClient check against creating a request without a namespace since that's a legal thing to do, especially when talking to a v2 garden.