### PR TITLE
Allow tagging to existing PyPi releases for docker deployments

### DIFF
--- a/.github/workflows/tag-actions.yml
+++ b/.github/workflows/tag-actions.yml
@@ -36,6 +36,8 @@ jobs:
           pip install setuptools wheel twine
 
       - name: Build and publish
+        # If the package already exists, we can continue on with releasing the Docker Images
+        continue-on-error: true
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -72,8 +74,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Build Images
+        run: make publish-docker VERSION=${GITHUB_REF#refs/tags/}
+
       - name: Run Dep Docs
         run: make docs-deps
 
-      - name: Build Images
-        run: make publish-docker VERSION=${GITHUB_REF#refs/tags/}
+      - name: Build Doc Images
+        run: make publish-docker-docs VERSION=${GITHUB_REF#refs/tags/}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,13 @@ Date: 1/11/21
 
 Bug Fixes
 ^^^^^^^^^
-- Fixed Plugin Logging hook to ensure logs are written when Plugin shuts down unexptendetly (Issue #787 / PR #276)
+- Fixed Plugin Logging hook to ensure logs are written when Plugin shuts down unexpectedly (Issue #787 / PR #276)
 - Properly handle empty command list (PR #277)
 
 New Features
 ^^^^^^^^^^^^
 - Adding check for PyPi before building Docker Images in Github Actions (PR #275)
-- Addes ReScan Method the Easy Client (Issue #815 / PR #278)
+- Adds ReScan Method the Easy Client (Issue #815 / PR #278)
 - Deprecation warnings for annotations `command_registrar`, `register`, and `plugin_param` (Issue #825 / PR #280)
 - Removes requirement for Namespace when submitting Request through the Easy Client (Issue #827 / PR #281)
 

--- a/Makefile
+++ b/Makefile
@@ -111,16 +111,19 @@ coverage-view: coverage ## view coverage report in a browser
 docker-login: ## log in to the docker registry
 	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin
 
-docker-build: docs ## build the docker images
+docker-build-docs: docs
+	docker build -t $(DOCKER_NAME):docs-$(VERSION) -f docs/Dockerfile docs/
+	docker tag $(DOCKER_NAME):docs-$(VERSION) $(DOCKER_NAME):docs
+
+docker-build:
 	docker build -t $(DOCKER_NAME):python3-$(VERSION) --build-arg VERSION=$(VERSION) -f docker/python3/Dockerfile .
 	docker build -t $(DOCKER_NAME):python3-onbuild-$(VERSION)  --build-arg VERSION=$(VERSION) -f docker/python3/onbuild/Dockerfile .
 	docker build -t $(DOCKER_NAME):python2-$(VERSION) --build-arg VERSION=$(VERSION) -f docker/python2/Dockerfile .
 	docker build -t $(DOCKER_NAME):python2-onbuild-$(VERSION) --build-arg VERSION=$(VERSION) -f docker/python2/onbuild/Dockerfile .
-	docker build -t $(DOCKER_NAME):docs-$(VERSION) -f docs/Dockerfile docs/
 	docker tag $(DOCKER_NAME):python3-$(VERSION) $(DOCKER_NAME):latest
 	docker tag $(DOCKER_NAME):python3-$(VERSION) $(DOCKER_NAME):python3
 	docker tag $(DOCKER_NAME):python2-$(VERSION) $(DOCKER_NAME):python2
-	docker tag $(DOCKER_NAME):docs-$(VERSION) $(DOCKER_NAME):docs
+
 
 # Documentation
 docs-deps: ## install dependencies for documentation
@@ -160,8 +163,10 @@ publish-docker: docker-build ## push the docker images
 	docker push $(DOCKER_NAME):python3-onbuild-$(VERSION)
 	docker push $(DOCKER_NAME):python2-$(VERSION)
 	docker push $(DOCKER_NAME):python2-onbuild-$(VERSION)
-	docker push $(DOCKER_NAME):docs-$(VERSION)
 	docker push $(DOCKER_NAME):latest
 	docker push $(DOCKER_NAME):python3
 	docker push $(DOCKER_NAME):python2
+
+publish-docker-docs: docker-build-docs ## push the docker images
+	docker push $(DOCKER_NAME):docs-$(VERSION)
 	docker push $(DOCKER_NAME):docs


### PR DESCRIPTION
If we have to rebuild docker images or any other downstream action, this will allow the PyPi upload to fail and continue on in the process. If the PyPi Check job fails, then it won't proceed, so this is a safe approach.