### PR TITLE
Issue/836

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -202,13 +202,15 @@ class RestClient(object):
         if len(args) > 0:
             _deprecate(
                 "Heads up - passing bg_host as a positional argument is deprecated "
-                "and will be removed in version 4.0"
+                "and will be removed in version 4.0",
+                stacklevel=kwargs.get("stacklevel", 3),
             )
             positional["bg_host"] = args[0]
         if len(args) > 1:
             _deprecate(
                 "Heads up - passing bg_port as a positional argument is deprecated "
-                "and will be removed in version 4.0"
+                "and will be removed in version 4.0",
+                stacklevel=kwargs.get("stacklevel", 3),
             )
             positional["bg_port"] = args[1]
 

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -159,8 +159,11 @@ class EasyClient(object):
         "chunk_size": 255 * 1024,
     }
 
-    def __init__(self, **kwargs):
-        self.client = RestClient(**kwargs)
+    def __init__(self, *args, **kwargs):
+        # This points DeprecationWarnings at the right line
+        kwargs.setdefault("stacklevel", 4)
+
+        self.client = RestClient(*args, **kwargs)
 
     def can_connect(self, **kwargs):
         """Determine if the Beergarden server is responding.

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -14,6 +14,7 @@ from brewtils.errors import (
     RequestProcessException,
     TimeoutExceededError,
     ValidationError,
+    _deprecate,
 )
 from brewtils.models import Request
 from brewtils.resolvers import UploadResolver, build_resolver_map
@@ -194,9 +195,12 @@ class SystemClient(object):
         self._system = None
         self._commands = None
 
-        # Need this for back-compatibility (see #836). The RestClient is going to yell
-        # about deprecation, so just worry about what SystemClient needs
+        # Need this for back-compatibility (see #836)
         if len(args) > 2:
+            _deprecate(
+                "Heads up - passing system_name as a positional argument is deprecated "
+                "and will be removed in version 4.0",
+            )
             kwargs.setdefault("system_name", args[2])
 
         self._system_name = kwargs.get("system_name")

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import warnings
 from concurrent.futures import wait
 
 import pytest
@@ -89,6 +90,16 @@ def sleep_patch(monkeypatch):
     mock = Mock(name="sleep mock")
     monkeypatch.setattr(brewtils.rest.system_client.time, "sleep", mock)
     return mock
+
+
+def test_old_positional_args():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        SystemClient("host", 80, "system")
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
 
 
 class TestLoadBgSystem(object):


### PR DESCRIPTION
Fixes beer-garden/beer-garden#836. Adds (and deprecates) support for positional arguments in `EasyClient` and `SystemClient`.