### PR TITLE
Issue/777

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -45,7 +45,7 @@ def system(cls=None, bg_name=None, bg_version=None):
     For historical purposes - the functionality of the ``parse_client`` function was
     previously in this decorator.
 
-    This does creates some attributes on the class for back-compatability reasons (and
+    This does creates some attributes on the class for back-compatibility reasons (and
     to stop linters from complaining). But these are just placeholders until the actual
     values are determined when the Plugin client is set:
 
@@ -87,7 +87,7 @@ def command(
     icon_name=None,  # type: str
     hidden=False,  # type: bool
 ):
-    """Decorator that marks a function as a beer-garden command
+    """Decorator for specifying Command details
 
     For example:
 
@@ -166,9 +166,7 @@ def parameter(
     is_kwarg=None,  # type: bool
     model=None,  # type: Type
 ):
-    """Decorator that enables Parameter specifications for a beer-garden Command
-
-    This is intended to be used when more specification is desired for a Parameter.
+    """Decorator for specifying Parameter details
 
     For example::
 
@@ -265,7 +263,7 @@ def parameter(
 
 
 def parameters(*args, _partial=False):
-    """Specify multiple Parameter definitions at once
+    """Decorator for specifying multiple Parameter definitions at once
 
     This can be useful for commands which have a large number of complicated
     parameters but aren't good candidates for a Model.

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -302,6 +302,9 @@ def parameters(*args):
     params = args[0]
     _wrapped = args[1]
 
+    if not isinstance(_wrapped, MethodType):
+        raise PluginParamError("@parameters must be applied to a method")
+
     try:
         for param in params:
             parameter(_wrapped, **param)

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -445,70 +445,6 @@ def _method_docstring(method):
     return docstring.split("\n")[0] if docstring else None
 
 
-def _resolve_display_modifiers(
-    wrapped,  # type: MethodType
-    command_name,  # type: str
-    schema=None,  # type: Union[dict, str]
-    form=None,  # type: Union[dict, list, str]
-    template=None,  # type: str
-):
-    def _load_from_url(url):
-        response = requests.get(url)
-        if response.headers.get("content-type", "").lower() == "application/json":
-            return json.loads(response.text)
-        return response.text
-
-    def _load_from_path(path):
-        current_dir = os.path.dirname(inspect.getfile(wrapped))
-        file_path = os.path.abspath(os.path.join(current_dir, path))
-
-        with open(file_path, "r") as definition_file:
-            return definition_file.read()
-
-    resolved = {}
-
-    for key, value in {"schema": schema, "form": form, "template": template}.items():
-
-        if isinstance(value, six.string_types):
-            try:
-                if value.startswith("http"):
-                    resolved[key] = _load_from_url(value)
-
-                elif value.startswith("/") or value.startswith("."):
-                    loaded_value = _load_from_path(value)
-                    resolved[key] = (
-                        loaded_value if key == "template" else json.loads(loaded_value)
-                    )
-
-                elif key == "template":
-                    resolved[key] = value
-
-                else:
-                    raise PluginParamError(
-                        "%s specified for command '%s' was not a "
-                        "definition, file path, or URL" % (key, command_name)
-                    )
-            except Exception as ex:
-                raise PluginParamError(
-                    "Error reading %s definition from '%s' for command "
-                    "'%s': %s" % (key, value, command_name, ex)
-                )
-
-        elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):
-            resolved[key] = value
-
-        elif key == "form" and isinstance(value, list):
-            resolved[key] = {"type": "fieldset", "items": value}
-
-        else:
-            raise PluginParamError(
-                "%s specified for command '%s' was not a definition, "
-                "file path, or URL" % (key, command_name)
-            )
-
-    return resolved
-
-
 def _initialize_parameter(
     param=None,
     func=None,
@@ -650,6 +586,77 @@ def _generate_nested_params(parameter_list):
             raise PluginParamError("Unable to generate parameter from '%s'" % param)
 
     return initialized_params
+
+
+def _resolve_display_modifiers(
+    wrapped,  # type: MethodType
+    command_name,  # type: str
+    schema=None,  # type: Union[dict, str]
+    form=None,  # type: Union[dict, list, str]
+    template=None,  # type: str
+):
+    # type: (...) -> dict
+    """Parse display modifier parameter attributes
+
+    Returns:
+        Dictionary that fully describes a display specification
+    """
+
+    def _load_from_url(url):
+        response = requests.get(url)
+        if response.headers.get("content-type", "").lower() == "application/json":
+            return json.loads(response.text)
+        return response.text
+
+    def _load_from_path(path):
+        current_dir = os.path.dirname(inspect.getfile(wrapped))
+        file_path = os.path.abspath(os.path.join(current_dir, path))
+
+        with open(file_path, "r") as definition_file:
+            return definition_file.read()
+
+    resolved = {}
+
+    for key, value in {"schema": schema, "form": form, "template": template}.items():
+
+        if isinstance(value, six.string_types):
+            try:
+                if value.startswith("http"):
+                    resolved[key] = _load_from_url(value)
+
+                elif value.startswith("/") or value.startswith("."):
+                    loaded_value = _load_from_path(value)
+                    resolved[key] = (
+                        loaded_value if key == "template" else json.loads(loaded_value)
+                    )
+
+                elif key == "template":
+                    resolved[key] = value
+
+                else:
+                    raise PluginParamError(
+                        "%s specified for command '%s' was not a "
+                        "definition, file path, or URL" % (key, command_name)
+                    )
+            except Exception as ex:
+                raise PluginParamError(
+                    "Error reading %s definition from '%s' for command "
+                    "'%s': %s" % (key, value, command_name, ex)
+                )
+
+        elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):
+            resolved[key] = value
+
+        elif key == "form" and isinstance(value, list):
+            resolved[key] = {"type": "fieldset", "items": value}
+
+        else:
+            raise PluginParamError(
+                "%s specified for command '%s' was not a definition, "
+                "file path, or URL" % (key, command_name)
+            )
+
+    return resolved
 
 
 def _format_type(param_type):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -37,10 +37,9 @@ __all__ = [
 def system(cls=None, bg_name=None, bg_version=None):
     """Class decorator that marks a class as a beer-garden System
 
-    This doesn't really do anything anymore, and is now pretty much deprecated. This
-    should really be named "client," but after consideration it doesn't really need to
-    exist at all - the Client is whatever you tell the Plugin it is, no need for
-    a special decorator.
+    This should really be named "client," but that will be another PR. Also, as-is this
+    doesn't really need to exist at all - the Client is whatever you tell the Plugin it
+    is, no need for a special decorator.
 
     For historical purposes - the functionality of the ``parse_client`` function was
     previously in this decorator.
@@ -886,13 +885,20 @@ def _generate_nested_params(parameter_list):
     # type: (Iterable[Parameter, object]) -> List[Parameter]
     """Generate nested parameters from a list of Parameters or a Model object
 
-    This exists for backwards compatibility with the "old
+    This exists for backwards compatibility with the old way of specifying Models.
+    Previously, models were defined by creating a class with a ``parameters`` class
+    attribute. This required constructing each parameter manually, without using the
+    ``@parameter`` decorator.
 
-    This function will take a list of Parameters and will return a new list of "real"
-    Parameters.
+    This function takes either a list of Parameters or a class object with a
+    ``parameters`` attribute. It will return a list of initialized parameters. See the
+    ``_initialize_parameter`` function for information on what that entails.
 
-    The main thing this does is ensure the choices specification is correct for all
-    Parameters in the tree.
+    Args:
+        parameter_list: List of parameters or object with a ``parameters`` attritube
+
+    Returns:
+        List of initialized parameters
     """
     initialized_params = []
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -306,7 +306,11 @@ def parameters(*args, _partial=False):
     # This is the second invocation
     else:
         if len(args) != 2:
-            raise PluginParamError("@parameters takes a single argument")
+            raise PluginParamError(
+                "Incorrect number of arguments for parameters partial call. Did you "
+                "set _partial=True? If so, please don't do that. If not, please let "
+                "the Beergarden team know how you got here!"
+            )
 
     params = args[0]
     _wrapped = args[1]

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -40,7 +40,7 @@ __all__ = [
 _wrap_functions = False
 
 
-def get_commands(client):
+def parse_client(client):
     """Get a list of Beergarden Commands from a client object
 
     This will iterate over everything returned from dir, looking for metadata added

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -24,7 +24,7 @@ from brewtils.models import Command, Parameter, Choices
 if sys.version_info.major == 2:
     from funcsigs import signature, Parameter as InspectParameter  # noqa
 else:
-    from inspect import signature, Parameter as InspectParameter
+    from inspect import signature, Parameter as InspectParameter  # noqa
 
 __all__ = [
     "command",

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -653,6 +653,15 @@ def _generate_nested_params(parameter_list):
 
 
 def _format_type(param_type):
+    # type: (Any) -> str
+    """Parse Parameter type
+
+    Args:
+        param_type: Raw Parameter type, usually from a decorator
+
+    Returns:
+        Properly formatted string describing the parameter type
+    """
     if param_type == str:
         return "String"
     elif param_type == int:

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
 import requests
 import six
-import wrapt
 
 try:
     from lark import ParseError
@@ -23,7 +22,7 @@ from brewtils.errors import PluginParamError, _deprecate
 from brewtils.models import Command, Parameter, Choices
 
 if sys.version_info.major == 2:
-    from funcsigs import signature, Parameter as InspectParameter
+    from funcsigs import signature, Parameter as InspectParameter  # noqa
 else:
     from inspect import signature, Parameter as InspectParameter
 
@@ -33,13 +32,6 @@ __all__ = [
     "parameters",
     "system",
 ]
-
-# The wrapt module has a cool feature where you can disable wrapping a decorated function,
-# instead just using the original function. This is pretty much exactly what we want - we
-# aren't using decorators for their 'real' purpose of wrapping a function, we just want to add
-# some metadata to the function object. So we'll disable the wrapping normally, but we need to
-# test that enabling the wrapping would work.
-_wrap_functions = False
 
 
 def system(cls=None, bg_name=None, bg_version=None):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -7,7 +7,7 @@ import os
 import sys
 from io import open
 from types import MethodType
-from typing import List
+from typing import Any, Dict, Iterable, List, Type, Union
 
 import requests
 import six
@@ -220,24 +220,24 @@ def _initialize_command(method):
 
 
 def parameter(
-    _wrapped=None,
-    key=None,
-    type=None,
-    multi=None,
-    display_name=None,
-    optional=None,
-    default=None,
-    description=None,
-    choices=None,
-    parameters=None,
-    nullable=None,
-    maximum=None,
-    minimum=None,
-    regex=None,
-    form_input_type=None,
-    type_info=None,
-    is_kwarg=None,
-    model=None,
+    _wrapped=None,  # type: Union[MethodType, Type]
+    key=None,  # type: str
+    type=None,  # type: str
+    multi=None,  # type: bool
+    display_name=None,  # type: str
+    optional=None,  # type: bool
+    default=None,  # type: Any
+    description=None,  # type: str
+    choices=None,  # type: Union[Dict, Iterable, str]
+    parameters=None,  # type: List[Parameter]
+    nullable=None,  # type: bool
+    maximum=None,  # type: int
+    minimum=None,  # type: int
+    regex=None,  # type: str
+    form_input_type=None,  # type: str
+    type_info=None,  # type: dict
+    is_kwarg=None,  # type: bool
+    model=None,  # type: Type
 ):
     """Decorator that enables Parameter specifications for a beer-garden Command
 
@@ -258,8 +258,8 @@ def parameter(
     Args:
         _wrapped: The function to decorate. This is handled as a positional argument and
             shouldn't be explicitly set.
-        key: String specifying the parameter identifier. Must match an argument name of
-            the decorated function.
+        key: String specifying the parameter identifier. If the decorated object is a
+            method the key must match an argument name.
         type: String indicating the type to use for this parameter.
         multi: Boolean indicating if this parameter is a multi. See documentation for
             discussion of what this means.
@@ -270,19 +270,23 @@ def parameter(
         description: An additional string that will be displayed in the user interface.
         choices: List or dictionary specifying allowed values. See documentation for
             more information.
+        parameters: Any nested parameters. See also: the 'model' argument.
         nullable: Boolean indicating if this parameter is allowed to be null.
         maximum: Integer indicating the maximum value of the parameter.
         minimum: Integer indicating the minimum value of the parameter.
         regex: String describing a regular expression constraint on the parameter.
+        form_input_type: Specify the form input field type (e.g. textarea). Only used
+            for string fields.
+        type_info: Type-specific information. Mostly reserved for future use.
         is_kwarg: Boolean indicating if this parameter is meant to be part of the
-            decorated function's kwargs.
+            decorated function's kwargs. Only applies when the decorated object is a
+            method.
         model: Class to be used as a model for this parameter. Must be a Python type
             object, not an instance.
-        form_input_type: Only used for string fields. Changes the form input field
-            (e.g. textarea)
 
     Returns:
         The decorated function
+
     """
     if _wrapped is None:
         return functools.partial(

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -307,17 +307,16 @@ def parameters(*args):
     elif len(args) != 2:
         raise PluginParamError("@parameters takes a single argument")
 
+    params = args[0]
+    _wrapped = args[1]
+
     try:
-        for param in args[0]:
-            parameter(args[1], **param)
+        for param in params:
+            parameter(_wrapped, **param)
     except TypeError:
         raise PluginParamError("@parameters arg must be an iterable of dictionaries")
 
-    @wrapt.decorator(enabled=_wrap_functions)
-    def wrapper(_double_wrapped, _, _args, _kwargs):
-        return _double_wrapped(*_args, **_kwargs)
-
-    return wrapper(args[1])
+    return _wrapped
 
 
 def _parse_client(client):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -797,7 +797,7 @@ def _validate_kwargness(_wrapped, param):
     # Couldn't find the parameter. That's OK if this parameter is meant to be part of
     # the **kwargs AND the function has a **kwargs parameter.
     if sig_param is None:
-        if param.is_kwarg is False:
+        if not param.is_kwarg:
             raise PluginParamError(
                 "Parameter was not not marked as part of kwargs and wasn't found in "
                 "the method signature (should is_kwarg be True?)"

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -42,26 +42,6 @@ __all__ = [
 _wrap_functions = False
 
 
-def parse_client(client):
-    """Get a list of Beergarden Commands from a client object
-
-    This will iterate over everything returned from dir, looking for metadata added
-    by the decorators.
-
-    """
-    bg_commands = []
-
-    for attr in dir(client):
-        method = getattr(client, attr)
-
-        method_command = _parse_method(method)
-
-        if method_command:
-            bg_commands.append(method_command)
-
-    return bg_commands
-
-
 def system(cls=None, bg_name=None, bg_version=None):
     """Class decorator that marks a class as a beer-garden System
 
@@ -338,6 +318,26 @@ def parameters(*args):
         return _double_wrapped(*_args, **_kwargs)
 
     return wrapper(args[1])
+
+
+def _parse_client(client):
+    """Get a list of Beergarden Commands from a client object
+
+    This will iterate over everything returned from dir, looking for metadata added
+    by the decorators.
+
+    """
+    bg_commands = []
+
+    for attr in dir(client):
+        method = getattr(client, attr)
+
+        method_command = _parse_method(method)
+
+        if method_command:
+            bg_commands.append(method_command)
+
+    return bg_commands
 
 
 def _parse_method(method):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -131,7 +131,7 @@ def command(
             hidden=hidden,
         )
 
-    _wrapped._command = Command(
+    new_command = Command(
         description=description,
         parameters=parameters,
         command_type=command_type,
@@ -142,6 +142,12 @@ def command(
         icon_name=icon_name,
         hidden=hidden,
     )
+
+    # Python 2 compatibility
+    if hasattr(_wrapped, "__func__"):
+        _wrapped.__func__._command = new_command
+    else:
+        _wrapped._command = new_command
 
     return _wrapped
 
@@ -235,29 +241,33 @@ def parameter(
             model=model,
         )
 
-    _wrapped.parameters = getattr(_wrapped, "parameters", [])
-
-    _wrapped.parameters.append(
-        Parameter(
-            key=key,
-            type=type,
-            multi=multi,
-            display_name=display_name,
-            optional=optional,
-            default=default,
-            description=description,
-            choices=choices,
-            parameters=parameters,
-            nullable=nullable,
-            maximum=maximum,
-            minimum=minimum,
-            regex=regex,
-            form_input_type=form_input_type,
-            type_info=type_info,
-            is_kwarg=is_kwarg,
-            model=model,
-        )
+    new_parameter = Parameter(
+        key=key,
+        type=type,
+        multi=multi,
+        display_name=display_name,
+        optional=optional,
+        default=default,
+        description=description,
+        choices=choices,
+        parameters=parameters,
+        nullable=nullable,
+        maximum=maximum,
+        minimum=minimum,
+        regex=regex,
+        form_input_type=form_input_type,
+        type_info=type_info,
+        is_kwarg=is_kwarg,
+        model=model,
     )
+
+    # Python 2 compatibility
+    if hasattr(_wrapped, "__func__"):
+        _wrapped.__func__.parameters = getattr(_wrapped, "parameters", [])
+        _wrapped.__func__.parameters.append(new_parameter)
+    else:
+        _wrapped.parameters = getattr(_wrapped, "parameters", [])
+        _wrapped.parameters.append(new_parameter)
 
     return _wrapped
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -466,6 +466,7 @@ def _initialize_parameter(
     is_kwarg=None,
     model=None,
 ):
+    # type: (...) -> Parameter
     """Helper method to 'fix' Parameters
 
     This exists to move logic out of the @parameter decorator. Previously there was a
@@ -553,6 +554,7 @@ def _initialize_parameter(
 
 
 def _generate_nested_params(parameter_list):
+    # type: (Iterable[Parameter, object]) -> List[Parameter]
     """Generate nested parameters from a list of Parameters or a Model object
 
     This exists for backwards compatibility with the "old

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -34,7 +34,12 @@ __all__ = [
 ]
 
 
-def system(cls=None, bg_name=None, bg_version=None):
+def system(
+    cls=None,  # type: Type
+    bg_name=None,  # type: str
+    bg_version=None,  # type: str
+):
+    # type: (...) -> Type
     """Class decorator that marks a class as a beer-garden System
 
     This should really be named "client," but that will be another PR. Also, as-is this
@@ -63,7 +68,7 @@ def system(cls=None, bg_name=None, bg_version=None):
 
     """
     if cls is None:
-        return functools.partial(system, bg_name=bg_name, bg_version=bg_version)
+        return functools.partial(system, bg_name=bg_name, bg_version=bg_version)  # noqa
 
     # Assign these here so linters don't complain
     cls._bg_name = bg_name

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -262,7 +262,7 @@ def parameter(
     return _wrapped
 
 
-def parameters(*args, _partial=False):
+def parameters(*args, **kwargs):
     """Decorator for specifying multiple Parameter definitions at once
 
     This can be useful for commands which have a large number of complicated
@@ -288,13 +288,13 @@ def parameters(*args, _partial=False):
         *args (iterable): Positional arguments
             The first (and only) positional argument must be a list containing
             dictionaries that describe parameters.
-        _partial: Used for bookkeeping. Don't set this yourself!
+        **kwargs: Used for bookkeeping. Don't set any of these yourself!
 
     Returns:
         func: The decorated function
     """
     # This is the first invocation
-    if not _partial:
+    if not kwargs.get("_partial"):
         # Need the callable check to prevent applying the decorator with no parenthesis
         if len(args) == 1 and not callable(args[0]):
             return functools.partial(parameters, args[0], _partial=True)

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -308,24 +308,6 @@ def parameter(
     return _wrapped
 
 
-def fix_parameters(params, func=None):
-    """Initialize parameters"""
-
-    new_params = []
-
-    for param in params:
-
-        # If func is given these are top-level parameters, which get additional handling
-        if func:
-            func_default = _validate_kwargness(func, param)
-            if func_default and param.default is None:
-                param.default = func_default
-
-        new_params.append(_initialize_parameter(param=param))
-
-    return new_params
-
-
 def parameters(*args):
     """Specify multiple Parameter definitions at once
 
@@ -361,9 +343,6 @@ def parameters(*args):
     elif len(args) != 2:
         raise PluginParamError("@parameters takes a single argument")
 
-    # if not isinstance(args[1], types.FunctionType):
-    #     raise PluginParamError("@parameters must be applied to a function")
-
     try:
         for param in args[0]:
             parameter(args[1], **param)
@@ -375,30 +354,6 @@ def parameters(*args):
         return _double_wrapped(*_args, **_kwargs)
 
     return wrapper(args[1])
-
-
-# def _generate_command_from_function(func):
-#     """Generate a Command from a function
-#
-#     Will use the first line of the function's docstring as the description.
-#     """
-#     # Required for Python 2/3 compatibility
-#     if hasattr(func, "func_name"):
-#         command_name = func.func_name
-#     else:
-#         command_name = func.__name__
-#
-#     # Required for Python 2/3 compatibility
-#     if hasattr(func, "func_doc"):
-#         docstring = func.func_doc
-#     else:
-#         docstring = func.__doc__
-#
-#     return Command(
-#         name=command_name,
-#         description=docstring.split("\n")[0] if docstring else None,
-#         parameters=_generate_params_from_function(func),
-#     )
 
 
 def _function_name(func):
@@ -419,35 +374,6 @@ def _function_docstring(func):
         docstring = func.__doc__
 
     return docstring.split("\n")[0] if docstring else None
-
-
-# def _generate_params_from_function(func):
-#     """Generate Parameters from function arguments.
-#
-#     Will set the Parameter key, default value, and optional value.
-#     """
-#     parameters_to_return = []
-#
-#     code = six.get_function_code(func)
-#     function_arguments = list(code.co_varnames or [])[: code.co_argcount]
-#     function_defaults = list(six.get_function_defaults(func) or [])
-#
-#     while len(function_defaults) != len(function_arguments):
-#         function_defaults.insert(0, None)
-#
-#     for index, param_name in enumerate(function_arguments):
-#         # Skip Self or Class reference
-#         if index == 0 and isinstance(func, types.FunctionType):
-#             continue
-#
-#         default = function_defaults[index]
-#         optional = False if default is None else True
-#
-#         parameters_to_return.append(
-#             Parameter(key=param_name, default=default, optional=optional)
-#         )
-#
-#     return parameters_to_return
 
 
 def _resolve_display_modifiers(
@@ -843,36 +769,6 @@ def _validate_kwargness(_wrapped, param):
 
         if sig_param.default != InspectParameter.empty:
             return sig_param.default
-
-    # # If the command doesn't already have a parameter with this key then the
-    # # method doesn't have an explicit keyword argument with <key> as the name.
-    # # That's only OK if this parameter is meant to be part of the **kwargs.
-    # param = cmd.get_parameter_by_key(param.key)
-    # if param is None:
-    #     if param.is_kwarg:
-    #         param = Parameter(key=key, optional=False)
-    #         cmd.parameters.append(param)
-    #     else:
-    #         raise PluginParamError(
-    #             "Parameter '%s' was not an explicit keyword argument for "
-    #             "command '%s' and was not marked as part of kwargs (should "
-    #             "is_kwarg be True?)" % (key, cmd.name)
-    #         )
-    #
-    # # Next, fail if the param is_kwarg=True and the method doesn't have a **kwargs
-    # if is_kwarg:
-    #     kwarg_declared = False
-    #     for p in signature(_wrapped).parameters.values():
-    #         if p.kind == InspectParameter.VAR_KEYWORD:
-    #             kwarg_declared = True
-    #             break
-    #
-    #     if not kwarg_declared:
-    #         raise PluginParamError(
-    #             "Parameter '%s' of command '%s' was declared as a kwarg argument "
-    #             "(is_kwarg=True) but the command method does not declare a **kwargs "
-    #             "argument" % (key, cmd.name)
-    #         )
 
 
 # Alias the old names for compatibility

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -520,7 +520,7 @@ def _initialize_parameter(
     param.choices = _format_choices(param.choices)
 
     if func:
-        func_default = _validate_kwargness(func, param)
+        func_default = _validate_signature(func, param)
         if func_default and param.default is None:
             param.default = func_default
 
@@ -817,7 +817,7 @@ def _format_choices(choices):
     )
 
 
-def _validate_kwargness(_wrapped, param):
+def _validate_signature(_wrapped, param):
     # type: (MethodType, Parameter) -> Optional[Any]
     """Ensure that a Parameter lines up with the method signature, determine default
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -379,8 +379,12 @@ def _initialize_command(method):
     cmd.template = resolved_mod["template"]
 
     cmd.parameters += getattr(method, "parameters", [])
-    for arg in signature(method).parameters.values():
+    for index, arg in enumerate(signature(method).parameters.values()):
         if arg.name not in cmd.parameter_keys():
+            # Don't want to include special parameters
+            if index == 0 and arg.name in ("self", "cls"):
+                continue
+
             cmd.parameters.append(Parameter(key=arg.name, optional=False))
         else:
             # I'm not super happy about this. It makes sense - positional arguments are

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -321,6 +321,7 @@ def parameters(*args):
 
 
 def _parse_client(client):
+    # type: (object) -> List[Command]
     """Get a list of Beergarden Commands from a client object
 
     This will iterate over everything returned from dir, looking for metadata added

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -54,14 +54,9 @@ def parse_client(client):
     for attr in dir(client):
         method = getattr(client, attr)
 
-        if inspect.ismethod(method) and (
-            hasattr(method, "_command") or hasattr(method, "parameters")
-        ):
-            method_command = _initialize_command(method)
+        method_command = _parse_method(method)
 
-            for p in method_command.parameters:
-                _initialize_parameter(param=p, func=method)
-
+        if method_command:
             bg_commands.append(method_command)
 
     return bg_commands
@@ -343,6 +338,29 @@ def parameters(*args):
         return _double_wrapped(*_args, **_kwargs)
 
     return wrapper(args[1])
+
+
+def _parse_method(method):
+    """Parse a method object as a Beer-garden command target
+
+    If the method looks like a valid command target (based on the presence of certain
+    attributes) then this method will initialize necessary metadata.
+
+    Args:
+        method: The method to parse
+
+    Returns:
+        The modified method
+    """
+    if (inspect.ismethod(method) or inspect.isfunction(method)) and (
+        hasattr(method, "_command") or hasattr(method, "parameters")
+    ):
+        method_command = _initialize_command(method)
+
+        for p in method_command.parameters:
+            _initialize_parameter(param=p, func=method)
+
+        return method_command
 
 
 def _initialize_command(method):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -212,9 +212,10 @@ def parameter(
     maximum=None,
     minimum=None,
     regex=None,
+    form_input_type=None,
+    type_info=None,
     is_kwarg=None,
     model=None,
-    form_input_type=None,
 ):
     """Decorator that enables Parameter specifications for a beer-garden Command
 
@@ -278,6 +279,7 @@ def parameter(
             minimum=minimum,
             regex=regex,
             form_input_type=form_input_type,
+            type_info=type_info,
             is_kwarg=is_kwarg,
             model=model,
         )
@@ -300,6 +302,7 @@ def parameter(
             minimum=minimum,
             regex=regex,
             form_input_type=form_input_type,
+            type_info=type_info,
             is_kwarg=is_kwarg,
             model=model,
         )
@@ -584,12 +587,13 @@ def _initialize_parameter(
     default=None,
     description=None,
     choices=None,
+    parameters=None,
     nullable=None,
     maximum=None,
     minimum=None,
     regex=None,
     form_input_type=None,
-    parameters=None,
+    type_info=None,
     is_kwarg=None,
     model=None,
 ):
@@ -620,20 +624,20 @@ def _initialize_parameter(
     """
     param = param or Parameter(
         key=key,
+        type=type,
         multi=multi,
         display_name=display_name,
-        # optional=False if optional is None else optional,  # TODO CHEKC THIS
         optional=optional,
         default=default,
         description=description,
+        choices=choices,
+        parameters=parameters,
         nullable=nullable,
         maximum=maximum,
         minimum=minimum,
         regex=regex,
         form_input_type=form_input_type,
-        type=type,
-        choices=choices,
-        parameters=parameters,
+        type_info=type_info,
         is_kwarg=is_kwarg,
         model=model,
     )

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -114,9 +114,9 @@ def command(
     parameters=None,  # type: List[Parameter]
     command_type="ACTION",  # type: str
     output_type="STRING",  # type: str
-    schema=None,
-    form=None,
-    template=None,
+    schema=None,  # type: Union[dict, str]
+    form=None,  # type: Union[dict, list, str]
+    template=None,  # type: str
     icon_name=None,  # type: str
     hidden=False,  # type: bool
 ):
@@ -428,7 +428,11 @@ def _method_docstring(method):
 
 
 def _resolve_display_modifiers(
-    wrapped, command_name, schema=None, form=None, template=None
+    wrapped,  # type: MethodType
+    command_name,  # type: str
+    schema=None,  # type: Union[dict, str]
+    form=None,  # type: Union[dict, list, str]
+    template=None,  # type: str
 ):
     def _load_from_url(url):
         response = requests.get(url)

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -7,7 +7,7 @@ import os
 import sys
 from io import open
 from types import MethodType
-from typing import Any, Dict, Iterable, List, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
 import requests
 import six
@@ -674,6 +674,16 @@ def _format_type(param_type):
 
 
 def _format_choices(choices):
+    # type: (Union[dict, str, Iterable]) -> Optional[Choices]
+    """Parse choices definition
+
+    Args:
+        choices: Raw choices definition, usually from a decorator
+
+    Returns:
+        Choices: Dictionary that fully describes a choices specification
+    """
+
     def determine_display(display_value):
         if isinstance(display_value, six.string_types):
             return "typeahead"

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -358,8 +358,8 @@ def _initialize_command(method):
     """
     cmd = getattr(method, "_command", Command())
 
-    cmd.name = _function_name(method)
-    cmd.description = cmd.description or _function_docstring(method)
+    cmd.name = _method_name(method)
+    cmd.description = cmd.description or _method_docstring(method)
 
     resolved_mod = _resolve_display_modifiers(
         method, cmd.name, schema=cmd.schema, form=cmd.form, template=cmd.template
@@ -385,22 +385,44 @@ def _initialize_command(method):
     return cmd
 
 
-def _function_name(func):
-    # Required for Python 2/3 compatibility
-    if hasattr(func, "func_name"):
-        command_name = func.func_name
+def _method_name(method):
+    # type: (MethodType) -> str
+    """Get the name of a method
+
+    This is needed for Python 2 / 3 compatibility
+
+    Args:
+        method: Method to inspect
+
+    Returns:
+        Method name
+
+    """
+    if hasattr(method, "func_name"):
+        command_name = method.func_name
     else:
-        command_name = func.__name__
+        command_name = method.__name__
 
     return command_name
 
 
-def _function_docstring(func):
-    # Required for Python 2/3 compatibility
-    if hasattr(func, "func_doc"):
-        docstring = func.func_doc
+def _method_docstring(method):
+    # type: (MethodType) -> str
+    """Parse out the first line of the docstring from a method
+
+    This is needed for Python 2 / 3 compatibility
+
+    Args:
+        method: Method to inspect
+
+    Returns:
+        First line of docstring
+
+    """
+    if hasattr(method, "func_doc"):
+        docstring = method.func_doc
     else:
-        docstring = func.__doc__
+        docstring = method.__doc__
 
     return docstring.split("\n")[0] if docstring else None
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -68,7 +68,18 @@ def parse_client(client):
 def system(cls=None, bg_name=None, bg_version=None):
     """Class decorator that marks a class as a beer-garden System
 
-    Creates some properties on the class:
+    This doesn't really do anything anymore, and is now pretty much deprecated. This
+    should really be named "client," but after consideration it doesn't really need to
+    exist at all - the Client is whatever you tell the Plugin it is, no need for
+    a special decorator.
+
+    For historical purposes - the functionality of the ``parse_client`` function was
+    previously in this decorator.
+
+    This does creates some attributes on the class for back-compatability reasons (and
+    to stop linters from complaining). But these are just placeholders until the actual
+    values are determined when the Plugin client is set:
+
       * ``_bg_name``: an optional system name
       * ``_bg_version``: an optional system version
       * ``_bg_commands``: holds all registered commands
@@ -86,10 +97,10 @@ def system(cls=None, bg_name=None, bg_version=None):
     if cls is None:
         return functools.partial(system, bg_name=bg_name, bg_version=bg_version)
 
+    # Assign these here so linters don't complain
     cls._bg_name = bg_name
     cls._bg_version = bg_version
-
-    # Assign this here so linters don't complain
+    cls._bg_commands = []
     cls._current_request = None
 
     return cls

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -264,7 +264,7 @@ def parameter(
     return _wrapped
 
 
-def parameters(*args):
+def parameters(*args, _partial=False):
     """Specify multiple Parameter definitions at once
 
     This can be useful for commands which have a large number of complicated
@@ -290,14 +290,23 @@ def parameters(*args):
         *args (iterable): Positional arguments
             The first (and only) positional argument must be a list containing
             dictionaries that describe parameters.
+        _partial: Used for bookkeeping. Don't set this yourself!
 
     Returns:
         func: The decorated function
     """
-    if len(args) == 1:
-        return functools.partial(parameters, args[0])
-    elif len(args) != 2:
+    # This is the first invocation
+    if not _partial:
+        # Need the callable check to prevent applying the decorator with no parenthesis
+        if len(args) == 1 and not callable(args[0]):
+            return functools.partial(parameters, args[0], _partial=True)
+
         raise PluginParamError("@parameters takes a single argument")
+
+    # This is the second invocation
+    else:
+        if len(args) != 2:
+            raise PluginParamError("@parameters takes a single argument")
 
     params = args[0]
     _wrapped = args[1]

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -818,18 +818,32 @@ def _format_choices(choices):
 
 
 def _validate_kwargness(_wrapped, param):
-    """Try to ensure that a Parameter lines up with the method signature
+    # type: (MethodType, Parameter) -> Optional[Any]
+    """Ensure that a Parameter lines up with the method signature, determine default
+
+    This will raise a PluginParamError if there are any validation issues.
+
+    It will also return the "default" according to the method signature. For example,
+    the following would return "foo" for Parameter param:
+
+    .. code-block:: python
+
+        def my_command(self, param="foo"):
+            ...
 
     It's expected that this will only be called for Parameters where this makes sense
     (aka top-level Parameters). It doesn't make sense to call this for model Parameters,
     so you shouldn't do that.
 
     Args:
-        _wrapped:
-        param:
+        _wrapped: The underlying target method object
+        param: The Parameter definitions
 
     Returns:
+        The default value according to the method signature, if any
 
+    Raises:
+        PluginParamError: There was a validation problem
     """
     sig_param = None  # The actual inspect.Parameter from the signature
     has_kwargs = False  # Does the func have **kwargs?

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -7,7 +7,7 @@ import os
 import sys
 from io import open
 from types import MethodType
-from typing import Any, Dict, Iterable, List, Optional, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union
 
 import requests
 import six
@@ -76,7 +76,7 @@ def system(cls=None, bg_name=None, bg_version=None):
 
 
 def command(
-    _wrapped=None,  # type: MethodType
+    _wrapped=None,  # type: Union[Callable, MethodType]
     description=None,  # type: str
     parameters=None,  # type: List[Parameter]
     command_type="ACTION",  # type: str
@@ -147,7 +147,7 @@ def command(
 
 
 def parameter(
-    _wrapped=None,  # type: Union[MethodType, Type]
+    _wrapped=None,  # type: Union[Callable, MethodType, Type]
     key=None,  # type: str
     type=None,  # type: str
     multi=None,  # type: bool
@@ -302,8 +302,8 @@ def parameters(*args):
     params = args[0]
     _wrapped = args[1]
 
-    if not isinstance(_wrapped, MethodType):
-        raise PluginParamError("@parameters must be applied to a method")
+    if not callable(_wrapped):
+        raise PluginParamError("@parameters must be applied to a callable")
 
     try:
         for param in params:

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -287,6 +287,8 @@ class Parameter(BaseModel):
         regex=None,
         form_input_type=None,
         type_info=None,
+        is_kwarg=None,
+        model=None,
     ):
         self.key = key
         self.type = type
@@ -303,6 +305,12 @@ class Parameter(BaseModel):
         self.regex = regex
         self.form_input_type = form_input_type
         self.type_info = type_info or {}
+
+        # These are special - they aren't part of the Parameter "API" (they aren't in
+        # the serialization schema) but we still need them on this model for consistency
+        # when creating Clients - https://github.com/beer-garden/beer-garden/issues/777
+        self.is_kwarg = is_kwarg
+        self.model = model
 
     def __str__(self):
         return self.key

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -14,7 +14,7 @@ from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
 from brewtils.config import load_config
-from brewtils.decorators import get_commands
+from brewtils.decorators import parse_client
 from brewtils.errors import (
     ConflictError,
     DiscardMessageException,
@@ -264,7 +264,7 @@ class Plugin(object):
             self._system.description = new_client.__doc__.split("\n")[0]
 
         # Now roll up / interpret all metadata to get the Commands
-        self._system.commands = get_commands(new_client)
+        self._system.commands = parse_client(new_client)
 
         try:
             # Put some attributes on the Client class

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -266,17 +266,27 @@ class Plugin(object):
         # Now roll up / interpret all metadata to get the Commands
         self._system.commands = get_commands(new_client)
 
-        # Make the current request available to the client methods
-        client_clazz = type(new_client)
-        client_clazz.current_request = property(
-            lambda _: request_context.current_request
-        )
+        try:
+            # Put some attributes on the Client class
+            client_clazz = type(new_client)
+            client_clazz.current_request = property(
+                lambda _: request_context.current_request
+            )
 
-        # Add for back-compatibility
-        client_clazz._bg_name = self._system.name
-        client_clazz._bg_version = self._system.version
-        client_clazz._bg_commands = self._system.commands
-        client_clazz._current_request = client_clazz.current_request
+            # Add for back-compatibility
+            client_clazz._bg_name = self._system.name
+            client_clazz._bg_version = self._system.version
+            client_clazz._bg_commands = self._system.commands
+            client_clazz._current_request = client_clazz.current_request
+        except TypeError:
+            if sys.version_info.major != 2:
+                raise
+
+            self._logger.warning(
+                "Unable to assign attributes to Client class - current_request will "
+                "not be available. If you're using an old-style class declaration "
+                "it's recommended to switch to new-style if possible."
+            )
 
         self._client = new_client
 

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -14,7 +14,7 @@ from requests import ConnectionError as RequestsConnectionError
 
 import brewtils
 from brewtils.config import load_config
-from brewtils.decorators import parse_client
+from brewtils.decorators import _parse_client
 from brewtils.errors import (
     ConflictError,
     DiscardMessageException,
@@ -264,7 +264,7 @@ class Plugin(object):
             self._system.description = new_client.__doc__.split("\n")[0]
 
         # Now roll up / interpret all metadata to get the Commands
-        self._system.commands = parse_client(new_client)
+        self._system.commands = _parse_client(new_client)
 
         try:
             # Put some attributes on the Client class

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -285,7 +285,7 @@ class TestParseMethod(object):
         assert _parse_method(cmd_kwargs) is not None
 
     def test_parameters(self, cmd):
-        cmd = parameters(cmd, [{"key": "foo"}])
+        cmd = parameters([{"key": "foo"}], cmd)
         assert _parse_method(cmd) is not None
 
     def test_cmd_parameter(self, cmd):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -50,6 +50,19 @@ def param_definition():
     }
 
 
+@pytest.fixture
+def param():
+    return Parameter(
+        key="foo",
+        type="String",
+        description="Mutant",
+        default="Charles",
+        display_name="Professor X",
+        optional=True,
+        multi=True,
+    )
+
+
 @pytest.fixture(params=[True, False])
 def wrap_functions(request):
     brewtils.decorators._wrap_functions = request.param
@@ -81,6 +94,25 @@ class TestSystem(object):
 
 
 class TestParameter(object):
+    """Test parameter decorator
+
+    This doesn't really do anything except create uninitialized Parameter objects and
+    throw them in the method's parameters list.
+
+    Because the created Parameters are uninitialized it's too annoying to use the
+    normal bg_parameter fixture since nested parameters, choices, etc. won't match. So
+    use the basic fixture instead. Don't worry, we'll test the other one later!
+
+    """
+    def test_basic(self, param_definition, param):
+        wrapped = parameter(cmd, **param_definition)
+
+        assert hasattr(wrapped, "parameters")
+        assert len(wrapped.parameters) == 1
+        assert_parameter_equal(wrapped.parameters[0], param)
+
+
+class TestParameterLegacy(object):
     @pytest.fixture
     def param_1(self):
         return Parameter(

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -35,11 +35,12 @@ def sys():
 
 @pytest.fixture
 def cmd():
-    def _cmd(_, foo):
-        """Docstring"""
-        return foo
+    class Bar(object):
+        def _cmd(self, foo):
+            """Docstring"""
+            return foo
 
-    return _cmd
+    return Bar._cmd
 
 
 @pytest.fixture

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -104,6 +104,7 @@ class TestParameter(object):
     use the basic fixture instead. Don't worry, we'll test the other one later!
 
     """
+
     def test_basic(self, param_definition, param):
         wrapped = parameter(cmd, **param_definition)
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -112,13 +112,6 @@ def param():
     )
 
 
-@pytest.fixture(params=[True, False])
-def wrap_functions(request):
-    brewtils.decorators._wrap_functions = request.param
-    yield
-    brewtils.decorators._wrap_functions = False
-
-
 class TestOverall(object):
     """Test end-to-end functionality"""
 
@@ -265,7 +258,7 @@ class TestParameter(object):
         assert len(wrapped.parameters) == 1
         assert_parameter_equal(wrapped.parameters[0], param)
 
-    def test_wrapper(self, cmd, param_definition, wrap_functions):
+    def test_wrapper(self, cmd, param_definition):
         test_mock = Mock()
         wrapped = parameter(cmd, **param_definition)
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -14,7 +14,7 @@ from brewtils.decorators import (
 )
 from brewtils.errors import PluginParamError
 from brewtils.models import Parameter
-from brewtils.test.comparable import assert_parameter_equal
+from brewtils.test.comparable import assert_command_equal, assert_parameter_equal
 
 
 @pytest.fixture
@@ -71,13 +71,13 @@ def wrap_functions(request):
 
 
 class TestSystem(object):
-    def test_system_basic(self, sys):
+    def test_basic(self, sys):
         assert hasattr(sys, "_bg_name")
         assert hasattr(sys, "_bg_version")
         assert hasattr(sys, "_bg_commands")
         assert hasattr(sys, "_current_request")
 
-    def test_system_with_args(self):
+    def test_with_args(self):
         @system(bg_name="sys", bg_version="1.0.0")
         class SystemClass(object):
             @command
@@ -91,6 +91,21 @@ class TestSystem(object):
 
         assert SystemClass._bg_name == "sys"
         assert SystemClass._bg_version == "1.0.0"
+
+
+class TestCommand(object):
+    def test_basic(self, command_dict, bg_command):
+        # Removing things that need to be initialized
+        bg_command.name = None
+        bg_command.parameters = []
+        del command_dict["name"]
+        del command_dict["parameters"]
+
+        @command(**command_dict)
+        def foo():
+            pass
+
+        assert_command_equal(foo._command, bg_command)
 
 
 class TestParameter(object):
@@ -615,7 +630,7 @@ class TestParameters(object):
         assert func(self, test_mock) == test_mock
 
 
-class TestCommand(object):
+class TestCommandLegacy(object):
     @pytest.fixture
     def func_mock(self):
         code_mock = Mock(

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -900,11 +900,11 @@ class TestFormatChoices(object):
 class TestValidateSignature(object):
     class TestSuccess(object):
         def test_not_kwarg_no_default(self, cmd):
-            assert _validate_signature(cmd, Parameter(key="foo")) is None
+            assert _validate_signature(Parameter(key="foo"), cmd) is None
 
         def test_kwarg_no_default(self, cmd_kwargs):
             assert (
-                _validate_signature(cmd_kwargs, Parameter(key="foo", is_kwarg=True))
+                _validate_signature(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
                 is None
             )
 
@@ -913,20 +913,20 @@ class TestValidateSignature(object):
                 def c(self, foo="bar"):
                     pass
 
-            assert _validate_signature(Tester.c, Parameter(key="foo")) == "bar"  # noqa
+            assert _validate_signature(Parameter(key="foo"), Tester.c) == "bar"  # noqa
 
     class TestFailure(object):
         def test_mismatch_is_kwarg_true(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_signature(cmd, Parameter(key="foo", is_kwarg=True))
+                _validate_signature(Parameter(key="foo", is_kwarg=True), cmd)
 
         def test_mismatch_is_kwarg_false(self, cmd_kwargs):
             with pytest.raises(PluginParamError):
-                _validate_signature(cmd_kwargs, Parameter(key="foo", is_kwarg=False))
+                _validate_signature(Parameter(key="foo", is_kwarg=False), cmd_kwargs)
 
         def test_no_kwargs_in_signature(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_signature(cmd, Parameter(key="extra", is_kwarg=True))
+                _validate_signature(Parameter(key="extra", is_kwarg=True), cmd)
 
         # This is not valid syntax in Python < 3.8, so punting on this (it does work
         # for me right now :)
@@ -936,7 +936,7 @@ class TestValidateSignature(object):
         #             pass
         #
         #     with pytest.raises(PluginParamError):
-        #         _validate_signature(Tester.c, Parameter(key="foo"))  # noqa
+        #         _validate_signature(Parameter(key="foo"), Tester.c)  # noqa
 
 
 class TestGenerateNestedParameters(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -8,6 +8,8 @@ import brewtils.decorators
 from brewtils.decorators import (
     _format_choices,
     _format_type,
+    _method_name,
+    _method_docstring,
     _resolve_display_modifiers,
     command,
     command_registrar,
@@ -618,6 +620,16 @@ class TestDecoratorCombinations(object):
         assert_parameter_equal(
             _cmd._command.parameters[0], Parameter(**param_definition)
         )
+
+
+class TestMethodName(object):
+    def test_name(self, cmd):
+        assert _method_name(cmd) == "_cmd"
+
+
+class TestMethodDocstring(object):
+    def test_docstring(self, cmd):
+        assert _method_docstring(cmd) == "Docstring"
 
 
 class TestResolveModifiers(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -12,7 +12,7 @@ from brewtils.decorators import (
     _method_docstring,
     _method_name,
     _resolve_display_modifiers,
-    _validate_kwargness,
+    _validate_signature,
     command,
     command_registrar,
     parameter,
@@ -929,11 +929,11 @@ class TestFormatChoices(object):
 class TestValidateKwargness(object):
     class TestSuccess(object):
         def test_not_kwarg_no_default(self, cmd):
-            assert _validate_kwargness(cmd, Parameter(key="foo")) is None
+            assert _validate_signature(cmd, Parameter(key="foo")) is None
 
         def test_kwarg_no_default(self, cmd_kwargs):
             assert (
-                _validate_kwargness(cmd_kwargs, Parameter(key="foo", is_kwarg=True))
+                _validate_signature(cmd_kwargs, Parameter(key="foo", is_kwarg=True))
                 is None
             )
 
@@ -942,20 +942,20 @@ class TestValidateKwargness(object):
                 def c(self, foo="bar"):
                     pass
 
-            assert _validate_kwargness(Tester.c, Parameter(key="foo")) == "bar"  # noqa
+            assert _validate_signature(Tester.c, Parameter(key="foo")) == "bar"  # noqa
 
     class TestFailure(object):
         def test_mismatch_is_kwarg_true(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_kwargness(cmd, Parameter(key="foo", is_kwarg=True))
+                _validate_signature(cmd, Parameter(key="foo", is_kwarg=True))
 
         def test_mismatch_is_kwarg_false(self, cmd_kwargs):
             with pytest.raises(PluginParamError):
-                _validate_kwargness(cmd_kwargs, Parameter(key="foo", is_kwarg=False))
+                _validate_signature(cmd_kwargs, Parameter(key="foo", is_kwarg=False))
 
         def test_no_kwargs_in_signature(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_kwargness(cmd, Parameter(key="extra", is_kwarg=True))
+                _validate_signature(cmd, Parameter(key="extra", is_kwarg=True))
 
         # This is not valid syntax in Python < 3.8, so punting on this (it does work
         # for me right now :)
@@ -965,7 +965,7 @@ class TestValidateKwargness(object):
         #             pass
         #
         #     with pytest.raises(PluginParamError):
-        #         _validate_kwargness(Tester.c, Parameter(key="foo"))  # noqa
+        #         _validate_signature(Tester.c, Parameter(key="foo"))  # noqa
 
 
 class TestDeprecations(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -8,8 +8,11 @@ import brewtils.decorators
 from brewtils.decorators import (
     _resolve_display_modifiers,
     command,
+    command_registrar,
     parameter,
     parameters,
+    plugin_param,
+    register,
     system,
 )
 from brewtils.errors import PluginParamError
@@ -876,25 +879,20 @@ class TestDeprecations(object):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
 
-                from brewtils.decorators import command_registrar  # noqa F401
-
                 @command_registrar
                 class SystemClass(object):
                     @command
                     def foo(self):
                         pass
 
-                assert len(SystemClass._bg_commands) == 1
-                assert SystemClass._bg_commands[0].name == "foo"
-
                 assert issubclass(w[0].category, DeprecationWarning)
                 assert "command_registrar" in str(w[0].message)
+
+                assert SystemClass._bg_commands == []
 
         def test_arguments(self):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-
-                from brewtils.decorators import command_registrar  # noqa F401
 
                 @command_registrar(bg_name="sys", bg_version="1.0.0")
                 class SystemClass(object):
@@ -904,39 +902,35 @@ class TestDeprecations(object):
 
                 assert SystemClass._bg_name == "sys"
                 assert SystemClass._bg_version == "1.0.0"
-                assert len(SystemClass._bg_commands) == 1
-                assert SystemClass._bg_commands[0].name == "foo"
 
                 assert issubclass(w[0].category, DeprecationWarning)
                 assert "command_registrar" in str(w[0].message)
 
     def test_register(self, cmd):
+
+        # Just for sanity
+        assert not hasattr(cmd, "_command")
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            from brewtils.decorators import register  # noqa F401
-
-            assert not hasattr(cmd, "_command")
             register(cmd)
-
-            assert hasattr(cmd, "_command")
-            assert cmd._command.name == "_cmd"
-            assert cmd._command.description == "Docstring"
-            assert len(cmd._command.parameters) == 1
 
             assert issubclass(w[0].category, DeprecationWarning)
             assert "register" in str(w[0].message)
+
+            assert hasattr(cmd, "_command")
 
     def test_plugin_param(self, cmd, param_definition):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            from brewtils.decorators import plugin_param  # noqa F401
-
-            wrapped = plugin_param(cmd, **param_definition)
-            param = wrapped._command.get_parameter_by_key("foo")
-
-            assert_parameter_equal(param, Parameter(**param_definition))
+            plugin_param(cmd, **param_definition)
 
             assert issubclass(w[0].category, DeprecationWarning)
             assert "plugin_param" in str(w[0].message)
+
+            assert hasattr(cmd, "parameters")
+            assert len(cmd.parameters) == 1
+
+            assert_parameter_equal(cmd.parameters[0], Parameter(**param_definition))

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -59,20 +59,25 @@ def wrap_functions(request):
 
 class TestSystem(object):
     def test_system_basic(self, sys):
-        assert len(sys._bg_commands) == 1
-        assert sys._bg_commands[0].name == "foo"
+        assert hasattr(sys, "_bg_name")
+        assert hasattr(sys, "_bg_version")
+        assert hasattr(sys, "_bg_commands")
+        assert hasattr(sys, "_current_request")
 
-    def test_system(self):
+    def test_system_with_args(self):
         @system(bg_name="sys", bg_version="1.0.0")
         class SystemClass(object):
             @command
             def foo(self):
                 pass
 
+        assert hasattr(SystemClass, "_bg_name")
+        assert hasattr(SystemClass, "_bg_version")
+        assert hasattr(SystemClass, "_bg_commands")
+        assert hasattr(SystemClass, "_current_request")
+
         assert SystemClass._bg_name == "sys"
         assert SystemClass._bg_version == "1.0.0"
-        assert len(SystemClass._bg_commands) == 1
-        assert SystemClass._bg_commands[0].name == "foo"
 
 
 class TestParameter(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -12,6 +12,7 @@ from brewtils.decorators import (
     _initialize_parameter,
     _method_docstring,
     _method_name,
+    _parse_method,
     _resolve_display_modifiers,
     _validate_signature,
     command,
@@ -189,6 +190,39 @@ class TestParameter(object):
         wrapped = parameter(cmd, **param_definition)
 
         assert wrapped(self, test_mock) == test_mock
+
+
+class TestParseMethod(object):
+    """Test the various ways of marking a method as a Command"""
+
+    def test_non_command(self, cmd):
+        assert _parse_method(cmd) is None
+
+    def test_only_command(self, cmd):
+        cmd = command(cmd)
+        assert _parse_method(cmd) is not None
+
+    def test_one_parameter(self, cmd):
+        cmd = parameter(cmd, key="foo")
+        assert _parse_method(cmd) is not None
+
+    def test_multiple_parameter(self, cmd_kwargs):
+        cmd_kwargs = parameter(cmd_kwargs, key="foo", is_kwarg=True)
+        cmd_kwargs = parameter(cmd_kwargs, key="bar", is_kwarg=True)
+        assert _parse_method(cmd_kwargs) is not None
+
+    def test_parameters(self, cmd):
+        cmd = parameters(cmd, [{"key": "foo"}])
+        assert _parse_method(cmd) is not None
+
+    def test_cmd_parameter(self, cmd):
+        cmd = command(cmd)
+        cmd = parameter(cmd, key="foo")
+        assert _parse_method(cmd) is not None
+
+    def test_no_key(self, cmd):
+        with pytest.raises(PluginParamError):
+            _parse_method(parameter(cmd))
 
 
 class TestInitializeParameter(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -29,17 +29,6 @@ from brewtils.test.comparable import assert_command_equal, assert_parameter_equa
 
 
 @pytest.fixture
-def sys():
-    @system
-    class SystemClass(object):
-        @command
-        def foo(self):
-            pass
-
-    return SystemClass
-
-
-@pytest.fixture
 def cmd():
     class Bar(object):
         def _cmd(self, foo):
@@ -129,11 +118,17 @@ def wrap_functions(request):
 
 
 class TestSystem(object):
-    def test_basic(self, sys):
-        assert hasattr(sys, "_bg_name")
-        assert hasattr(sys, "_bg_version")
-        assert hasattr(sys, "_bg_commands")
-        assert hasattr(sys, "_current_request")
+    def test_basic(self):
+        @system
+        class SystemClass(object):
+            @command
+            def foo(self):
+                pass
+
+        assert hasattr(SystemClass, "_bg_name")
+        assert hasattr(SystemClass, "_bg_version")
+        assert hasattr(SystemClass, "_bg_commands")
+        assert hasattr(SystemClass, "_current_request")
 
     def test_with_args(self):
         @system(bg_name="sys", bg_version="1.0.0")

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -596,6 +596,10 @@ class TestInitializeParameter(object):
         p = Parameter(key="foo", default=default)
         assert _initialize_parameter(p).default == default
 
+    def test_file_defaults(self):
+        """File parameter defaults should be cleared for safety"""
+        assert _initialize_parameter(Parameter(key="f", type="Base64")).default is None
+
     @pytest.mark.parametrize(
         "default,expected",
         [(None, {"key1": 1, "key2": "100"}), ({"key1", 123}, {"key1", 123})],

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -124,11 +124,13 @@ class TestOverall(object):
 
         param_x = cmds[0].get_parameter_by_key("x")
         assert param_x.key == "x"
+        assert param_x.type == "Any"
         assert param_x.default is None
         assert param_x.optional is False
 
         param_y = cmds[0].get_parameter_by_key("y")
         assert param_y.key == "y"
+        assert param_y.type == "Any"
         assert param_y.default == "some_default"
         assert param_y.optional is True
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -538,8 +538,8 @@ class TestParameters(object):
         "args",
         [
             [],  # no args
-            [[{"key": "a"}], 2],  # too many args
-            [[{"key": "a"}], 2, 3],  # way too many args
+            [[{"key": "foo"}], 2],  # too many args
+            [[{"key": "foo"}], 2, 3],  # way too many args
         ],
     )
     def test_bad_arg_count(self, args):
@@ -547,23 +547,26 @@ class TestParameters(object):
         with pytest.raises(PluginParamError, match=r"single argument"):
 
             @parameters(*args)
-            def func(_, first):
-                return first
+            def func(foo):
+                return foo
 
     def test_no_parens(self):
         """Again, need an argument"""
         with pytest.raises(PluginParamError, match=r"single argument"):
 
             @parameters
-            def func(_, first):
-                return first
+            def func(foo):
+                return foo
 
     @pytest.mark.parametrize(
         "args",
         [
             ["string"],  # bad type
             [lambda x: x],  # decorator might be applied to wrong thing
-            [[{"key": "a"}], lambda x: x],  # decorator might be applied to wrong thing
+            [
+                [{"key": "foo"}],
+                lambda x: x,
+            ],  # decorator might be applied to wrong thing
         ],
     )
     def test_bad_args(self, args):
@@ -571,8 +574,8 @@ class TestParameters(object):
         with pytest.raises(PluginParamError):
 
             @parameters(*args)
-            def func(_, first):
-                return first
+            def func(foo):
+                return foo
 
     def test_bad_application(self):
         """I don't even know how you would do this. Something like:
@@ -587,6 +590,14 @@ class TestParameters(object):
         with pytest.raises(PluginParamError, match=r"callable"):
             partial = parameters([{"key": "foo"}])
             partial("not a callable")
+
+    def test_bad_partial_call(self, param_definition):
+        """Again, I don't even know how you would do this if you follow directions."""
+        with pytest.raises(PluginParamError, match=r"partial call"):
+
+            @parameters([param_definition], _partial=True)
+            def func(foo):
+                return foo
 
 
 class TestInitializeCommand(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -12,6 +12,7 @@ from brewtils.decorators import (
     _method_docstring,
     _method_name,
     _resolve_display_modifiers,
+    _validate_kwargness,
     command,
     command_registrar,
     parameter,
@@ -42,6 +43,16 @@ def cmd():
         def _cmd(self, foo):
             """Docstring"""
             return foo
+
+    return Bar._cmd
+
+
+@pytest.fixture
+def cmd_kwargs():
+    class Bar(object):
+        def _cmd(self, **kwargs):
+            """Docstring"""
+            pass
 
     return Bar._cmd
 
@@ -242,21 +253,6 @@ class TestParameterLegacy(object):
     def test_defaults(self, cmd, default):
         wrapped = parameter(cmd, key="foo", default=default)
         assert wrapped._command.get_parameter_by_key("foo").default == default
-
-    def test_is_kwarg(self, param_definition):
-        @parameter(is_kwarg=True, **param_definition)
-        def cmd(_, **kwargs):
-            return kwargs
-
-        param = cmd._command.get_parameter_by_key("foo")
-        assert_parameter_equal(param, Parameter(**param_definition))
-
-    def test_is_kwarg_missing(self, param_definition):
-        with pytest.raises(PluginParamError, match=param_definition["key"] + ".*cmd"):
-
-            @parameter(is_kwarg=True, **param_definition)
-            def cmd(_):
-                return None
 
     @pytest.mark.parametrize(
         "default,expected",
@@ -928,6 +924,48 @@ class TestFormatChoices(object):
     def test_choices_error(self, cmd, choices):
         with pytest.raises(PluginParamError):
             _format_choices(choices)
+
+
+class TestValidateKwargness(object):
+    class TestSuccess(object):
+        def test_not_kwarg_no_default(self, cmd):
+            assert _validate_kwargness(cmd, Parameter(key="foo")) is None
+
+        def test_kwarg_no_default(self, cmd_kwargs):
+            assert (
+                _validate_kwargness(cmd_kwargs, Parameter(key="foo", is_kwarg=True))
+                is None
+            )
+
+        def test_default(self):
+            class Tester(object):
+                def c(self, foo="bar"):
+                    pass
+
+            assert _validate_kwargness(Tester.c, Parameter(key="foo")) == "bar"  # noqa
+
+    class TestFailure(object):
+        def test_mismatch_is_kwarg_true(self, cmd):
+            with pytest.raises(PluginParamError):
+                _validate_kwargness(cmd, Parameter(key="foo", is_kwarg=True))
+
+        def test_mismatch_is_kwarg_false(self, cmd_kwargs):
+            with pytest.raises(PluginParamError):
+                _validate_kwargness(cmd_kwargs, Parameter(key="foo", is_kwarg=False))
+
+        def test_no_kwargs_in_signature(self, cmd):
+            with pytest.raises(PluginParamError):
+                _validate_kwargness(cmd, Parameter(key="extra", is_kwarg=True))
+
+        # This is not valid syntax in Python < 3.8, so punting on this (it does work
+        # for me right now :)
+        # def test_positional_only(self):
+        #     class Tester(object):
+        #         def c(self, foo, /):
+        #             pass
+        #
+        #     with pytest.raises(PluginParamError):
+        #         _validate_kwargness(Tester.c, Parameter(key="foo"))  # noqa
 
 
 class TestDeprecations(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -6,6 +6,7 @@ from mock import Mock, patch
 
 import brewtils.decorators
 from brewtils.decorators import (
+    _format_choices,
     _resolve_display_modifiers,
     command,
     command_registrar,
@@ -443,122 +444,6 @@ class TestParameterLegacy(object):
             assert key3_param.description == "key3"
             assert len(key3_param.parameters) == 0
 
-    @pytest.mark.parametrize(
-        "choices,expected",
-        [
-            (
-                ["1", "2", "3"],
-                {
-                    "type": "static",
-                    "value": ["1", "2", "3"],
-                    "display": "select",
-                    "strict": True,
-                },
-            ),
-            (
-                list(range(100)),
-                {
-                    "type": "static",
-                    "value": list(range(100)),
-                    "display": "typeahead",
-                    "strict": True,
-                },
-            ),
-            (
-                range(100),
-                {
-                    "type": "static",
-                    "value": list(range(100)),
-                    "display": "typeahead",
-                    "strict": True,
-                },
-            ),
-            (
-                {"value": [1, 2, 3]},
-                {
-                    "type": "static",
-                    "value": [1, 2, 3],
-                    "display": "select",
-                    "strict": True,
-                },
-            ),
-            (
-                {"value": {"a": [1, 2], "b": [3, 4]}, "key_reference": "${y}"},
-                {
-                    "type": "static",
-                    "value": {"a": [1, 2], "b": [3, 4]},
-                    "display": "select",
-                    "strict": True,
-                    "details": {"key_reference": "y"},
-                },
-            ),
-            (
-                "http://myhost:1234",
-                {
-                    "type": "url",
-                    "value": "http://myhost:1234",
-                    "display": "typeahead",
-                    "strict": True,
-                    "details": {"address": "http://myhost:1234", "args": []},
-                },
-            ),
-            (
-                "my_command",
-                {
-                    "type": "command",
-                    "value": "my_command",
-                    "display": "typeahead",
-                    "strict": True,
-                    "details": {"name": "my_command", "args": []},
-                },
-            ),
-            (
-                {"type": "command", "value": {"command": "my_command"}},
-                {
-                    "type": "command",
-                    "value": {"command": "my_command"},
-                    "display": "select",
-                    "strict": True,
-                    "details": {"name": "my_command", "args": []},
-                },
-            ),
-        ],
-    )
-    def test_choices(self, cmd, choices, expected):
-        wrapped = parameter(cmd, key="foo", choices=choices)
-        param = wrapped._command.get_parameter_by_key("foo")
-
-        assert param.choices.type == expected["type"]
-        assert param.choices.value == expected["value"]
-        assert param.choices.display == expected["display"]
-        assert param.choices.strict == expected["strict"]
-        assert param.choices.details == expected.get("details", {})
-
-    @pytest.mark.parametrize(
-        "choices",
-        [
-            # No value
-            {"type": "static", "display": "select"},
-            # Invalid type
-            {"type": "Invalid Type", "value": [1, 2, 3], "display": "select"},
-            # Invalid display
-            {"type": "static", "value": [1, 2, 3], "display": "Invalid display"},
-            # Command value invalid type
-            {"type": "command", "value": [1, 2, 3]},
-            # Static value invalid type
-            {"type": "static", "value": "This should not be a string"},
-            # No key reference
-            {"type": "static", "value": {"a": [1, 2, 3]}},
-            # Parse error
-            {"type": "command", "value": "bad_def(x="},
-            # Just wrong
-            1,
-        ],
-    )
-    def test_choices_error(self, cmd, choices):
-        with pytest.raises(PluginParamError):
-            parameter(cmd, key="foo", choices=choices)
-
 
 class TestParameters(object):
     def test_parameters_wrapper(self, cmd, param_definition, wrap_functions):
@@ -871,6 +756,123 @@ class TestResolveModifiers(object):
 
         with pytest.raises(PluginParamError):
             _resolve_display_modifiers(Mock(), Mock(), **args)
+
+
+class TestFormatChoices(object):
+    @pytest.mark.parametrize(
+        "choices,expected",
+        [
+            (
+                ["1", "2", "3"],
+                {
+                    "type": "static",
+                    "value": ["1", "2", "3"],
+                    "display": "select",
+                    "strict": True,
+                },
+            ),
+            (
+                list(range(100)),
+                {
+                    "type": "static",
+                    "value": list(range(100)),
+                    "display": "typeahead",
+                    "strict": True,
+                },
+            ),
+            (
+                range(100),
+                {
+                    "type": "static",
+                    "value": list(range(100)),
+                    "display": "typeahead",
+                    "strict": True,
+                },
+            ),
+            (
+                {"value": [1, 2, 3]},
+                {
+                    "type": "static",
+                    "value": [1, 2, 3],
+                    "display": "select",
+                    "strict": True,
+                },
+            ),
+            (
+                {"value": {"a": [1, 2], "b": [3, 4]}, "key_reference": "${y}"},
+                {
+                    "type": "static",
+                    "value": {"a": [1, 2], "b": [3, 4]},
+                    "display": "select",
+                    "strict": True,
+                    "details": {"key_reference": "y"},
+                },
+            ),
+            (
+                "http://myhost:1234",
+                {
+                    "type": "url",
+                    "value": "http://myhost:1234",
+                    "display": "typeahead",
+                    "strict": True,
+                    "details": {"address": "http://myhost:1234", "args": []},
+                },
+            ),
+            (
+                "my_command",
+                {
+                    "type": "command",
+                    "value": "my_command",
+                    "display": "typeahead",
+                    "strict": True,
+                    "details": {"name": "my_command", "args": []},
+                },
+            ),
+            (
+                {"type": "command", "value": {"command": "my_command"}},
+                {
+                    "type": "command",
+                    "value": {"command": "my_command"},
+                    "display": "select",
+                    "strict": True,
+                    "details": {"name": "my_command", "args": []},
+                },
+            ),
+        ],
+    )
+    def test_choices(self, cmd, choices, expected):
+        generated = _format_choices(choices)
+
+        assert generated.type == expected["type"]
+        assert generated.value == expected["value"]
+        assert generated.display == expected["display"]
+        assert generated.strict == expected["strict"]
+        assert generated.details == expected.get("details", {})
+
+    @pytest.mark.parametrize(
+        "choices",
+        [
+            # No value
+            {"type": "static", "display": "select"},
+            # Invalid type
+            {"type": "Invalid Type", "value": [1, 2, 3], "display": "select"},
+            # Invalid display
+            {"type": "static", "value": [1, 2, 3], "display": "Invalid display"},
+            # Command value invalid type
+            {"type": "command", "value": [1, 2, 3]},
+            # Static value invalid type
+            {"type": "static", "value": "This should not be a string"},
+            # No key reference
+            {"type": "static", "value": {"a": [1, 2, 3]}},
+            # Parse error
+            {"type": "command", "value": "bad_def(x="},
+            # Just wrong
+            1,
+        ],
+    )
+    def test_choices_error(self, cmd, choices):
+        with pytest.raises(PluginParamError):
+            _format_choices(choices)
 
 
 class TestDeprecations(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -7,6 +7,7 @@ from mock import Mock, patch
 import brewtils.decorators
 from brewtils.decorators import (
     _format_choices,
+    _format_type,
     _resolve_display_modifiers,
     command,
     command_registrar,
@@ -176,30 +177,6 @@ class TestParameterLegacy(object):
     def test_wrong_key(self, cmd):
         with pytest.raises(PluginParamError):
             parameter(cmd, key="bar")
-
-    @pytest.mark.parametrize(
-        "t,expected",
-        [
-            (None, "Any"),
-            (str, "String"),
-            (int, "Integer"),
-            (float, "Float"),
-            (bool, "Boolean"),
-            (dict, "Dictionary"),
-            ("String", "String"),
-            ("Integer", "Integer"),
-            ("Float", "Float"),
-            ("Boolean", "Boolean"),
-            ("Dictionary", "Dictionary"),
-            ("DateTime", "DateTime"),
-            ("Any", "Any"),
-            ("file", "Bytes"),
-            ("string", "String"),
-        ],
-    )
-    def test_types(self, cmd, t, expected):
-        wrapped = parameter(cmd, key="foo", type=t)
-        assert expected == wrapped._command.get_parameter_by_key("foo").type
 
     def test_file_type_info(self, cmd):
         wrapped = parameter(cmd, key="foo", type="file")
@@ -756,6 +733,31 @@ class TestResolveModifiers(object):
 
         with pytest.raises(PluginParamError):
             _resolve_display_modifiers(Mock(), Mock(), **args)
+
+
+class TestFormatType(object):
+    @pytest.mark.parametrize(
+        "t,expected",
+        [
+            (None, "Any"),
+            (str, "String"),
+            (int, "Integer"),
+            (float, "Float"),
+            (bool, "Boolean"),
+            (dict, "Dictionary"),
+            ("String", "String"),
+            ("Integer", "Integer"),
+            ("Float", "Float"),
+            ("Boolean", "Boolean"),
+            ("Dictionary", "Dictionary"),
+            ("DateTime", "DateTime"),
+            ("Any", "Any"),
+            ("file", "Bytes"),
+            ("string", "String"),
+        ],
+    )
+    def test_types(self, cmd, t, expected):
+        assert _format_type(t) == expected
 
 
 class TestFormatChoices(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -963,21 +963,11 @@ class TestGenerateNestedParameters(object):
 
 class TestValidateSignature(object):
     class TestSuccess(object):
-        def test_not_kwarg_no_default(self, cmd):
-            assert _validate_signature(Parameter(key="foo"), cmd) is None
+        def test_positional(self, cmd):
+            _validate_signature(Parameter(key="foo"), cmd)
 
-        def test_kwarg_no_default(self, cmd_kwargs):
-            assert (
-                _validate_signature(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
-                is None
-            )
-
-        def test_default(self):
-            class Tester(object):
-                def c(self, foo="bar"):
-                    pass
-
-            assert _validate_signature(Parameter(key="foo"), Tester.c) == "bar"  # noqa
+        def test_kwarg(self, cmd_kwargs):
+            _validate_signature(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
 
     class TestFailure(object):
         def test_mismatch_is_kwarg_true(self, cmd):


### PR DESCRIPTION
This fixes beer-garden/beer-garden#777. It completely rewrites the `decorators` module to remove actual logic from the decorator functions.

As a consequence of this the "flow" has changed. At a high level it can be characterized by moving from a more eager-type evaluation to a lazier one.

### Original way
The original flow was for things to be evaluated / processed as soon as possible:
-  The `@command` decorator would immediately generate a `Command` from the method signature and resolving display parameters.
- Similarly, the `@parameter` decorator would immediately generate a `Command` from the method signature if one did not already exist. It would then start verifying the `Parameter` was correct, using the method signature as necessary.
- Finally, the `@system` decorator would inspect every attribute of the decorated class, looking for a `_command` property. All those commands are assumed to be "done," so no additional processing is needed.

### New way

Now, the *only* function of the `@command` and `@parameter` decorators is to put placeholder objects on the function object. There is *no* modification that occurs in the decorators.

Roughly, any logic that was previously in the decorators has moved to `_initialize_command` and `_initialize_parameter`. However, these are not invoked until the client object is assigned to the plugin. At that point both the Command and all Parameters are initialized.

This means that the `@system` decorator isn't really useful anymore. It's only purpose is to put placeholder attributes on the Client class to make linters happy.

### Other changes
- We're no longer doing the weird thing with using `wrapt` to double-wrap the original methods. We now just return the underlying method object.