### PR TITLE
Can now pass just a logger name to a StoppableThread

### DIFF
--- a/brewtils/stoppable_thread.py
+++ b/brewtils/stoppable_thread.py
@@ -9,10 +9,20 @@ class StoppableThread(Thread):
     regularly for the stopped() condition."""
 
     def __init__(self, **kwargs):
-        self.logger = kwargs.pop("logger", logging.getLogger(__name__))
         self._stop_event = Event()
 
-        Thread.__init__(self, **kwargs)
+        if "logger" in kwargs:
+            self.logger = kwargs["logger"]
+        elif "logger_name" in kwargs:
+            self.logger = logging.getLogger(kwargs["logger_name"])
+        else:
+            self.logger = logging.getLogger(__name__)
+
+        filtered_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ("logger", "logger_name")
+        }
+
+        Thread.__init__(self, **filtered_kwargs)
 
     def stop(self):
         """Sets the stop event"""

--- a/test/stoppable_thread_test.py
+++ b/test/stoppable_thread_test.py
@@ -14,10 +14,14 @@ class TestStoppableThread(object):
     def test_init_stop_not_set(self, thread):
         assert thread._stop_event.isSet() is False
 
-    def test_init_logger_passed_in(self):
+    def test_init_logger(self):
         fake_logger = Mock()
         t = StoppableThread(logger=fake_logger)
         assert t.logger == fake_logger
+
+    def test_init_logger_name(self):
+        t = StoppableThread(logger_name="fake")
+        assert t.logger.name == "fake"
 
     def test_stop(self, thread):
         thread.stop()

--- a/test/stoppable_thread_test.py
+++ b/test/stoppable_thread_test.py
@@ -23,6 +23,11 @@ class TestStoppableThread(object):
         t = StoppableThread(logger_name="fake")
         assert t.logger.name == "fake"
 
+    def test_init_logger_logger_and_name(self):
+        fake_logger = Mock()
+        t = StoppableThread(logger=fake_logger, logger_name="fake")
+        assert t.logger == fake_logger
+
     def test_stop(self, thread):
         thread.stop()
         assert thread._stop_event.isSet() is True


### PR DESCRIPTION
Fixes beer-garden/beer-garden#874. Can now give a logger name to a `StoppableThread`.