### PR TITLE
Using local Plugin Configs for System Client

### DIFF
--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -203,7 +203,7 @@ class SystemClient(object):
             )
             kwargs.setdefault("system_name", args[2])
 
-        system_kwargs = {
+        config_map = {
             "system_name": "name",
             "version_constraint": "version",
             "default_instance": "instance_name",
@@ -217,18 +217,20 @@ class SystemClient(object):
         # Now we need to figure out if any of the provided kwargs don't match
         # some sort of loop that checks the value of system kwargs against the CONFIG
         # If they are different, target_self = False and break
-        for key in system_kwargs.keys():
-            if kwargs.get(key) is None:
-                continue
-            if kwargs.get(key) != brewtils.plugin.CONFIG[system_kwargs[key]]:
+
+        for key, value in config_map.items():
+            if (
+                kwargs.get(key) is not None
+                and kwargs.get(key) != brewtils.plugin.CONFIG[value]
+            ):
                 target_self = False
                 break
 
         # Now assign self._system_name, etc based on the value of target_self
         if target_self:
-            self._system_name = brewtils.plugin.CONFIG.name or None
-            self._version_constraint = brewtils.plugin.CONFIG.version or None
-            self._default_instance = brewtils.plugin.CONFIG.instance_name or None
+            self._system_name = brewtils.plugin.CONFIG.name
+            self._version_constraint = brewtils.plugin.CONFIG.version
+            self._default_instance = brewtils.plugin.CONFIG.instance_name
             self._system_namespace = brewtils.plugin.CONFIG.namespace or ""
         else:
             self._system_name = kwargs.get("system_name")

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -203,7 +203,12 @@ class SystemClient(object):
             )
             kwargs.setdefault("system_name", args[2])
 
-        system_kwargs = "system_name", "version_constraint", "default_instance", "system_namespace"
+        system_kwargs = (
+            "system_name",
+            "version_constraint",
+            "default_instance",
+            "system_namespace",
+        )
         provided_system_kwargs = False
         for arg in system_kwargs:
             if kwargs.get(arg, None):
@@ -219,17 +224,15 @@ class SystemClient(object):
             )
         else:
             self._system_name = brewtils.plugin.CONFIG.name or None
-            self._version_constraint = brewtils.plugin.CONFIG.version or 'latest'
-            self._default_instance = brewtils.plugin.CONFIG.instance_name or 'default'
+            self._version_constraint = brewtils.plugin.CONFIG.version or "latest"
+            self._default_instance = brewtils.plugin.CONFIG.instance_name or "default"
             self._system_namespace = brewtils.plugin.CONFIG.namespace or ""
-
 
         self._always_update = kwargs.get("always_update", False)
         self._timeout = kwargs.get("timeout", None)
         self._max_delay = kwargs.get("max_delay", 30)
         self._blocking = kwargs.get("blocking", True)
         self._raise_on_error = kwargs.get("raise_on_error", False)
-
 
         # This is for Python 3.4 compatibility - max_workers MUST be non-None
         # in that version. This logic is what was added in Python 3.5

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -214,19 +214,49 @@ class SystemClient(object):
             if kwargs.get(arg, None):
                 provided_system_kwargs = True
                 break
+        map_local = False
 
-        if provided_system_kwargs:
+        if not provided_system_kwargs:
+            map_local = True
+        else:
+            if kwargs.get("system_namespace") == brewtils.plugin.CONFIG.namespace:
+                if (
+                    kwargs.get("system_name") is None
+                    and kwargs.get("version_constraint") is None
+                    and kwargs.get("default_instance") is None
+                ):
+                    map_local = True
+            elif kwargs.get("system_name") == brewtils.plugin.CONFIG.name:
+                if (
+                    kwargs.get("version_constraint") is None
+                    and kwargs.get("default_instance") is None
+                    and (
+                        kwargs.get("system_namespace")
+                        == brewtils.plugin.CONFIG.namespace
+                        or kwargs.get("system_namespace") is None
+                    )
+                ):
+                    map_local = True
+            elif kwargs.get("version_constraint") == brewtils.plugin.CONFIG.version:
+                if (
+                    kwargs.get("system_namespace") == brewtils.plugin.CONFIG.namespace
+                    and kwargs.get("system_name") == brewtils.plugin.CONFIG.name
+                    and kwargs.get("default_instance") is None
+                ):
+                    map_local = True
+
+        if map_local:
+            self._system_name = brewtils.plugin.CONFIG.name or None
+            self._version_constraint = brewtils.plugin.CONFIG.version or None
+            self._default_instance = brewtils.plugin.CONFIG.instance_name or None
+            self._system_namespace = brewtils.plugin.CONFIG.namespace or ""
+        else:
             self._system_name = kwargs.get("system_name")
             self._version_constraint = kwargs.get("version_constraint", "latest")
             self._default_instance = kwargs.get("default_instance", "default")
             self._system_namespace = kwargs.get(
                 "system_namespace", brewtils.plugin.CONFIG.namespace or ""
             )
-        else:
-            self._system_name = brewtils.plugin.CONFIG.name or None
-            self._version_constraint = brewtils.plugin.CONFIG.version or "latest"
-            self._default_instance = brewtils.plugin.CONFIG.instance_name or "default"
-            self._system_namespace = brewtils.plugin.CONFIG.namespace or ""
 
         self._always_update = kwargs.get("always_update", False)
         self._timeout = kwargs.get("timeout", None)

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -203,17 +203,33 @@ class SystemClient(object):
             )
             kwargs.setdefault("system_name", args[2])
 
-        self._system_name = kwargs.get("system_name")
-        self._version_constraint = kwargs.get("version_constraint", "latest")
-        self._default_instance = kwargs.get("default_instance", "default")
+        system_kwargs = "system_name", "version_constraint", "default_instance", "system_namespace"
+        provided_system_kwargs = False
+        for arg in system_kwargs:
+            if kwargs.get(arg, None):
+                provided_system_kwargs = True
+                break
+
+        if provided_system_kwargs:
+            self._system_name = kwargs.get("system_name")
+            self._version_constraint = kwargs.get("version_constraint", "latest")
+            self._default_instance = kwargs.get("default_instance", "default")
+            self._system_namespace = kwargs.get(
+                "system_namespace", brewtils.plugin.CONFIG.namespace or ""
+            )
+        else:
+            self._system_name = brewtils.plugin.CONFIG.name or None
+            self._version_constraint = brewtils.plugin.CONFIG.version or 'latest'
+            self._default_instance = brewtils.plugin.CONFIG.instance_name or 'default'
+            self._system_namespace = brewtils.plugin.CONFIG.namespace or ""
+
+
         self._always_update = kwargs.get("always_update", False)
         self._timeout = kwargs.get("timeout", None)
         self._max_delay = kwargs.get("max_delay", 30)
         self._blocking = kwargs.get("blocking", True)
         self._raise_on_error = kwargs.get("raise_on_error", False)
-        self._system_namespace = kwargs.get(
-            "system_namespace", brewtils.plugin.CONFIG.namespace or ""
-        )
+
 
         # This is for Python 3.4 compatibility - max_workers MUST be non-None
         # in that version. This logic is what was added in Python 3.5

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -222,15 +222,10 @@ class TestLoadBgSystem(object):
         assert client._version_constraint == "latest"
         assert client._default_instance == "default"
 
-<<<<<<< HEAD
-    def test_system_name_kwargs_matching(self):
-        """Behavior should be the same regardless of whether the system name comes from the global config or kwarg"""
-
-=======
     def test_system_name_kwarg_matching(self):
         """Behavior should be the same regardless of whether the system name comes
         from the global config or a kwarg"""
->>>>>>> ce328953e9ab7634cd2392e73831811c462395aa
+
         brewtils.plugin.CONFIG.name = "foo"
         brewtils.plugin.CONFIG.version = "1.0.0"
         brewtils.plugin.CONFIG.instance_name = "instance"

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -199,7 +199,11 @@ class TestLoadBgSystem(object):
         brewtils.plugin.CONFIG.version = "1.0.0"
         brewtils.plugin.CONFIG.instance_name = "foo"
 
-        client = SystemClient(system_name="not foo", version_constraint= "2.0.0", default_instance="not foo")
+        client = SystemClient(
+            system_name="not foo",
+            version_constraint="2.0.0",
+            default_instance="not foo",
+        )
 
         assert client._system_name != brewtils.plugin.CONFIG.name
         assert client._version_constraint != brewtils.plugin.CONFIG.version

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -179,6 +179,32 @@ class TestLoadBgSystem(object):
             name=system_1.name, namespace="foo"
         )
 
+    def test_no_system_kwargs(self):
+
+        brewtils.plugin.CONFIG.namespace = "foo"
+        brewtils.plugin.CONFIG.name = "foo"
+        brewtils.plugin.CONFIG.version = "1.0.0"
+        brewtils.plugin.CONFIG.instance_name = "foo"
+
+        client = SystemClient()
+
+        assert client._system_namespace == brewtils.plugin.CONFIG.namespace
+        assert client._system_name == brewtils.plugin.CONFIG.name
+        assert client._version_constraint == brewtils.plugin.CONFIG.version
+        assert client._default_instance == brewtils.plugin.CONFIG.instance_name
+
+    def test_all_system_kwargs(self):
+
+        brewtils.plugin.CONFIG.name = "foo"
+        brewtils.plugin.CONFIG.version = "1.0.0"
+        brewtils.plugin.CONFIG.instance_name = "foo"
+
+        client = SystemClient(system_name="not foo", version_constraint= "2.0.0", default_instance="not foo")
+
+        assert client._system_name != brewtils.plugin.CONFIG.name
+        assert client._version_constraint != brewtils.plugin.CONFIG.version
+        assert client._default_instance != brewtils.plugin.CONFIG.instance_name
+
 
 class TestCreateRequest(object):
     @pytest.mark.parametrize("context", [None, Mock(current_request=None)])

--- a/test/rest/system_client_test.py
+++ b/test/rest/system_client_test.py
@@ -209,6 +209,32 @@ class TestLoadBgSystem(object):
         assert client._version_constraint != brewtils.plugin.CONFIG.version
         assert client._default_instance != brewtils.plugin.CONFIG.instance_name
 
+    def test_different_system_name(self):
+        """Using a system name that's NOT the current running system"""
+
+        brewtils.plugin.CONFIG.name = "foo"
+        brewtils.plugin.CONFIG.version = "1.0.0"
+        brewtils.plugin.CONFIG.instance_name = "instance"
+
+        client = SystemClient(system_name="not foo")
+
+        assert client._system_name == "not foo"
+        assert client._version_constraint == "latest"
+        assert client._default_instance == "default"
+
+    def test_system_name_kwargs_matching(self):
+        """Behavior should be the same regardless of whether the system name comes from the global config or kwarg"""
+
+        brewtils.plugin.CONFIG.name = "foo"
+        brewtils.plugin.CONFIG.version = "1.0.0"
+        brewtils.plugin.CONFIG.instance_name = "instance"
+
+        client = SystemClient(system_name="foo")
+
+        assert client._system_name == "foo"
+        assert client._version_constraint == "1.0.0"
+        assert client._default_instance == "instance"
+
 
 class TestCreateRequest(object):
     @pytest.mark.parametrize("context", [None, Mock(current_request=None)])


### PR DESCRIPTION
The System Client can now reference itself. The System Client used to have to have manually passed in the name, the version, Instance, and the namespace. All of this information can be found in a plugins 'self' attributes. Developers can now call the System Client without parameters, and the System Client can grab it's attributes from a locally running Plugin to apply them.  

Fixes beer-garden/beer-garden#780