### PR TITLE
Issue/925

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -923,6 +923,10 @@ def _generate_nested_params(parameter_list):
             )
             initialized_params += _generate_nested_params(param.parameters)
 
+        # This is a dict of Parameter kwargs
+        elif isinstance(param, dict):
+            initialized_params.append(_initialize_parameter(**param))
+
         # No clue!
         else:
             raise PluginParamError("Unable to generate parameter from '%s'" % param)

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -783,8 +783,8 @@ def _format_choices(choices):
 
         return "static"
 
-    if not choices:
-        return None
+    if choices is None or isinstance(choices, Choices):
+        return choices
 
     if isinstance(choices, dict):
         if not choices.get("value"):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -1195,11 +1195,11 @@ class TestDeprecations(object):
 
             assert hasattr(cmd, "_command")
 
-    def test_plugin_param(self, cmd, basic_param):
+    def test_plugin_param(self, cmd, parameter_dict):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            plugin_param(cmd, **basic_param)
+            plugin_param(cmd, **parameter_dict)
 
             assert issubclass(w[0].category, DeprecationWarning)
             assert "plugin_param" in str(w[0].message)
@@ -1207,4 +1207,7 @@ class TestDeprecations(object):
             assert hasattr(cmd, "parameters")
             assert len(cmd.parameters) == 1
 
-            assert_parameter_equal(cmd.parameters[0], Parameter(**basic_param))
+            assert_parameter_equal(
+                _initialize_parameter(cmd.parameters[0]),
+                _initialize_parameter(**parameter_dict),
+            )

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -1101,6 +1101,13 @@ class TestGenerateNestedParameters(object):
             assert issubclass(w[0].category, DeprecationWarning)
             assert "model class objects" in str(w[0].message)
 
+    def test_dict(self, init_mock, basic_param):
+        res = _generate_nested_params([basic_param])
+
+        assert len(res) == 1
+        assert res[0] == init_mock.return_value
+        init_mock.assert_called_once_with(**basic_param)
+
     def test_unknown_type(self):
         with pytest.raises(PluginParamError):
             _generate_nested_params(["This isn't a parameter!"])  # noqa

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -756,10 +756,12 @@ class TestInitializeParameter(object):
             "storage": "gridfs"
         }
 
-    def test_values(self, cmd, basic_param):
-        """This seems like a weird test"""
-        p = _initialize_parameter(**basic_param)
-        assert_parameter_equal(p, Parameter(**basic_param))
+    def test_reinitialize(self, parameter_dict):
+        """Parameter objects can be initialized twice, so make sure that works"""
+        p1 = _initialize_parameter(**parameter_dict)
+        p2 = _initialize_parameter(p1)
+
+        assert_parameter_equal(p1, p2)
 
     @pytest.mark.parametrize(
         "default", [None, 1, "bar", [], ["bar"], {}, {"bar"}, {"foo": "bar"}]


### PR DESCRIPTION
This fixes beer-garden/beer-garden#925, an issue where re-initializing a Parameter object would fail.

This also adds the ability to specify nested parameters as dictionaries. So all of these are now acceptable (the last one is the change this PR adds):

```python
Parameter(key="foo", parameters=[Parameter(key="nested")])
Parameter(key="foo", parameters=[ModelObject])  # The old way, assumes ModelObject.parameters exists
Parameter(key="foo", parameters=[{"key": "nested"}])
```