### PR TITLE
Changing system decorator name to client

### DIFF
--- a/brewtils/__init__.py
+++ b/brewtils/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from brewtils.__version__ import __version__
 from brewtils.config import get_argument_parser, get_connection_info, load_config
-from brewtils.decorators import command, parameter, system
+from brewtils.decorators import client, command, parameter, system
 from brewtils.log import configure_logging
 from brewtils.plugin import Plugin, RemotePlugin  # noqa F401
 from brewtils.rest import normalize_url_prefix
@@ -10,6 +10,7 @@ from brewtils.rest.system_client import SystemClient
 
 __all__ = [
     "__version__",
+    "client",
     "command",
     "parameter",
     "system",

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -69,7 +69,7 @@ def client(
 
     """
     if cls is None:
-        return functools.partial(system, bg_name=bg_name, bg_version=bg_version)  # noqa
+        return functools.partial(client, bg_name=bg_name, bg_version=bg_version)  # noqa
 
     # Assign these here so linters don't complain
     cls._bg_name = bg_name

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -27,6 +27,7 @@ else:
     from inspect import signature, Parameter as InspectParameter  # noqa
 
 __all__ = [
+    "client",
     "command",
     "parameter",
     "parameters",
@@ -34,24 +35,24 @@ __all__ = [
 ]
 
 
-def system(
+def client(
     cls=None,  # type: Type
     bg_name=None,  # type: str
     bg_version=None,  # type: str
 ):
     # type: (...) -> Type
-    """Class decorator that marks a class as a beer-garden System
+    """Class decorator that marks a class as a beer-garden Client
 
-    This should really be named "client," but that will be another PR. Also, as-is this
-    doesn't really need to exist at all - the Client is whatever you tell the Plugin it
-    is, no need for a special decorator.
+    Using this decorator is no longer strictly necessary. It was previously required in
+    order to mark a class as being a Beer-garden Client, and contained most of the logic
+    that currently resides in the ``parse_client`` function. However, that's no longer
+    the case and this currently exists mainly for back-compatibility reasons.
 
-    For historical purposes - the functionality of the ``parse_client`` function was
-    previously in this decorator.
+    Applying this decorator to a client class does have the nice effect of preventing
+    linters from complaining if any special attributes are used. So that's something.
 
-    This does creates some attributes on the class for back-compatibility reasons (and
-    to stop linters from complaining). But these are just placeholders until the actual
-    values are determined when the Plugin client is set:
+    Those special attributes are below. Note that these are just placeholders until the
+    actual values are populated when the client instance is assigned to a Plugin:
 
       * ``_bg_name``: an optional system name
       * ``_bg_version``: an optional system version
@@ -991,6 +992,10 @@ def _validate_signature(param, method):
 
 
 # Alias the old names for compatibility
+# This isn't deprecated, see https://github.com/beer-garden/beer-garden/issues/927
+system = client
+
+
 def command_registrar(*args, **kwargs):
     _deprecate(
         "Looks like you're using the '@command_registrar' decorator. Heads up - this "

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -19,6 +19,7 @@ from brewtils.decorators import (
     _resolve_display_modifiers,
     _sig_info,
     _validate_signature,
+    client,
     command,
     command_registrar,
     parameter,
@@ -170,33 +171,33 @@ class TestOverall(object):
             assert_parameter_equal(c.parameters[0], Parameter(**param_definition))
 
 
-class TestSystem(object):
+class TestClient(object):
     def test_basic(self):
-        @system
-        class SystemClass(object):
+        @client
+        class ClientClass(object):
             @command
             def foo(self):
                 pass
 
-        assert hasattr(SystemClass, "_bg_name")
-        assert hasattr(SystemClass, "_bg_version")
-        assert hasattr(SystemClass, "_bg_commands")
-        assert hasattr(SystemClass, "_current_request")
+        assert hasattr(ClientClass, "_bg_name")
+        assert hasattr(ClientClass, "_bg_version")
+        assert hasattr(ClientClass, "_bg_commands")
+        assert hasattr(ClientClass, "_current_request")
 
     def test_with_args(self):
-        @system(bg_name="sys", bg_version="1.0.0")
-        class SystemClass(object):
+        @client(bg_name="sys", bg_version="1.0.0")
+        class ClientClass(object):
             @command
             def foo(self):
                 pass
 
-        assert hasattr(SystemClass, "_bg_name")
-        assert hasattr(SystemClass, "_bg_version")
-        assert hasattr(SystemClass, "_bg_commands")
-        assert hasattr(SystemClass, "_current_request")
+        assert hasattr(ClientClass, "_bg_name")
+        assert hasattr(ClientClass, "_bg_version")
+        assert hasattr(ClientClass, "_bg_commands")
+        assert hasattr(ClientClass, "_current_request")
 
-        assert SystemClass._bg_name == "sys"
-        assert SystemClass._bg_version == "1.0.0"
+        assert ClientClass._bg_name == "sys"
+        assert ClientClass._bg_version == "1.0.0"
 
 
 class TestCommand(object):
@@ -1139,6 +1140,20 @@ class TestValidateSignature(object):
 
 
 class TestDeprecations(object):
+    def test_system_decorator(self):
+        """This isn't really deprecated, but close enough"""
+
+        @system
+        class ClientClass(object):
+            @command
+            def foo(self):
+                pass
+
+        assert hasattr(ClientClass, "_bg_name")
+        assert hasattr(ClientClass, "_bg_version")
+        assert hasattr(ClientClass, "_bg_commands")
+        assert hasattr(ClientClass, "_current_request")
+
     class TestCommandRegistrar(object):
         def test_basic(self):
             with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
This fixes beer-garden/beer-garden#927. It renames the system decorator to client but maintains compatibility.