### PR TITLE
Issue/924

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -973,7 +973,7 @@ def _signature_validate(cmd, method):
     so you shouldn't do that.
 
     Args:
-        param: Command to validate
+        cmd: Command to validate
         method: Target method object
 
     Returns:

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -324,6 +324,12 @@ def parameters(*args, **kwargs):
                 "the Beergarden team know how you got here!"
             )
 
+    _deprecate(
+        "Looks like you're using the '@parameters' decorator. This is now deprecated - "
+        "for passing bulk parameter definitions it's recommended to use the @command "
+        "decorator parameters kwarg, like this: @command(parameters=[...])"
+    )
+
     params = args[0]
     _wrapped = args[1]
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -386,7 +386,7 @@ def _parse_method(method):
 
         # Need to initialize existing parameters before attempting to add parameters
         # pulled from the method signature.
-        method_command.parameters = _generate_nested_params(
+        method_command.parameters = _initialize_parameters(
             method_command.parameters + getattr(method, "parameters", [])
         )
 
@@ -666,11 +666,11 @@ def _initialize_parameter(
     # Now deal with nested parameters
     if param.parameters:
         param.type = "Dictionary"
-        param.parameters = _generate_nested_params(param.parameters)
+        param.parameters = _initialize_parameters(param.parameters)
 
     elif param.model is not None:
         param.type = "Dictionary"
-        param.parameters = _generate_nested_params(param.model.parameters)
+        param.parameters = _initialize_parameters(param.model.parameters)
 
         # If the model is not nullable and does not have a default we will try
         # to generate a one using the defaults defined on the model parameters
@@ -839,7 +839,7 @@ def _format_choices(choices):
     )
 
 
-def _generate_nested_params(parameter_list):
+def _initialize_parameters(parameter_list):
     # type: (Iterable[Parameter, object]) -> List[Parameter]
     """Generate nested parameters from a list of Parameters or a Model object
 
@@ -874,7 +874,7 @@ def _generate_nested_params(parameter_list):
                 "Constructing a nested Parameters list using model class objects "
                 "is deprecated. Please pass the model's parameter list directly."
             )
-            initialized_params += _generate_nested_params(param.parameters)
+            initialized_params += _initialize_parameters(param.parameters)
 
         # This is a dict of Parameter kwargs
         elif isinstance(param, dict):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -840,20 +840,24 @@ def _format_choices(choices):
 
 
 def _initialize_parameters(parameter_list):
-    # type: (Iterable[Parameter, object]) -> List[Parameter]
-    """Generate nested parameters from a list of Parameters or a Model object
+    # type: (Iterable[Parameter, object, dict]) -> List[Parameter]
+    """Initialize Parameters from a list of parameter definitions
 
     This exists for backwards compatibility with the old way of specifying Models.
     Previously, models were defined by creating a class with a ``parameters`` class
     attribute. This required constructing each parameter manually, without using the
     ``@parameter`` decorator.
 
-    This function takes either a list of Parameters or a class object with a
-    ``parameters`` attribute. It will return a list of initialized parameters. See the
-    ``_initialize_parameter`` function for information on what that entails.
+    This function takes a list where members can be any of the following:
+    - A Parameter object
+    - A class object with a ``parameters`` attribute
+    - A dict containing kwargs for constructing a Parameter
+
+    The Parameters in the returned list will be initialized. See the function
+    ``_initialize_parameter`` for information on what that entails.
 
     Args:
-        parameter_list: List of parameters or object with a ``parameters`` attritube
+        parameter_list: List of parameter precursors
 
     Returns:
         List of initialized parameters

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -395,7 +395,7 @@ def _parse_method(method):
 
         # Verify that all parameters conform to the method signature
         for param in method_command.parameters:
-            _validate_signature(param=param, method=method)
+            _signature_validate(param=param, method=method)
 
         return method_command
 
@@ -958,7 +958,7 @@ def _signature_parameters(cmd, method):
     return cmd
 
 
-def _validate_signature(param, method):
+def _signature_validate(param, method):
     # type: (Parameter, MethodType) -> None
     """Ensure that a Parameter conforms to the method signature
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -233,6 +233,20 @@ class TestCommand(object):
         assert cmd._command.description == "desc2"
         assert cmd._command.output_type == "STRING"  # This is the default
 
+    def test_parameter_equivalence(self, basic_param):
+        @command(parameters=[basic_param])
+        def func1(_, foo):
+            return foo
+
+        @parameter(**basic_param)
+        def func2(_, foo):
+            return foo
+
+        cmd1 = _parse_method(func1)
+        cmd2 = _parse_method(func2)
+
+        assert_parameter_equal(cmd1.parameters[0], cmd2.parameters[0])
+
 
 class TestParameter(object):
     """Test parameter decorator
@@ -273,16 +287,30 @@ class TestParameters(object):
 
         assert cmd("input") == "input"
 
-    def test_decorator_equivalence(self, basic_param):
-        @parameter(**basic_param)
+    def test_parameter_equivalence(self, basic_param):
+        @parameters([basic_param])
         def func1(_, foo):
             return foo
 
-        @parameters([basic_param])
+        @parameter(**basic_param)
         def func2(_, foo):
             return foo
 
         assert_parameter_equal(func1.parameters[0], func2.parameters[0])
+
+    def test_command_equivalence(self, basic_param):
+        @parameters([basic_param])
+        def func1(_, foo):
+            return foo
+
+        @command(parameters=[basic_param])
+        def func2(_, foo):
+            return foo
+
+        cmd1 = _parse_method(func1)
+        cmd2 = _parse_method(func2)
+
+        assert_parameter_equal(cmd1.parameters[0], cmd2.parameters[0])
 
     def test_dict_values(self, basic_param):
         param_spec = {"foo": basic_param}

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -9,9 +9,9 @@ import brewtils.decorators
 from brewtils.decorators import (
     _format_choices,
     _format_type,
-    _generate_nested_params,
     _initialize_command,
     _initialize_parameter,
+    _initialize_parameters,
     _method_docstring,
     _method_name,
     _parse_client,
@@ -1099,7 +1099,7 @@ class TestFormatChoices(object):
             _format_choices(choices)
 
 
-class TestGenerateNestedParameters(object):
+class TestInitializeParameters(object):
     @pytest.fixture(autouse=True)
     def init_mock(self, monkeypatch):
         """Mock out _initialize_parameter functionality
@@ -1112,7 +1112,7 @@ class TestGenerateNestedParameters(object):
         return m
 
     def test_parameter(self, init_mock, param):
-        res = _generate_nested_params([param])
+        res = _initialize_parameters([param])
 
         assert len(res) == 1
         assert res[0] == init_mock.return_value
@@ -1122,7 +1122,7 @@ class TestGenerateNestedParameters(object):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            res = _generate_nested_params([nested_1])
+            res = _initialize_parameters([nested_1])
 
             assert len(res) == 1
             assert res[0] == init_mock.return_value
@@ -1132,7 +1132,7 @@ class TestGenerateNestedParameters(object):
             assert "model class objects" in str(w[0].message)
 
     def test_dict(self, init_mock, basic_param):
-        res = _generate_nested_params([basic_param])
+        res = _initialize_parameters([basic_param])
 
         assert len(res) == 1
         assert res[0] == init_mock.return_value
@@ -1140,7 +1140,7 @@ class TestGenerateNestedParameters(object):
 
     def test_unknown_type(self):
         with pytest.raises(PluginParamError):
-            _generate_nested_params(["This isn't a parameter!"])  # noqa
+            _initialize_parameters(["This isn't a parameter!"])  # noqa
 
 
 class TestSignatureValidate(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -286,6 +286,11 @@ class TestParameter(object):
 
 
 class TestParameters(object):
+    @pytest.fixture(autouse=True)
+    def catch_warnings(self):
+        with warnings.catch_warnings(record=True):
+            yield
+
     def test_function(self, basic_param):
         @parameters([basic_param])
         def cmd(foo):
@@ -411,8 +416,9 @@ class TestParseMethod(object):
         assert _parse_method(cmd_kwargs) is not None
 
     def test_parameters(self, cmd):
-        partial = parameters([{"key": "foo"}])
-        cmd = partial(cmd)
+        with warnings.catch_warnings(record=True):
+            partial = parameters([{"key": "foo"}])
+            cmd = partial(cmd)
         assert _parse_method(cmd) is not None
 
     def test_cmd_parameter(self, cmd):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -18,7 +18,7 @@ from brewtils.decorators import (
     _parse_method,
     _resolve_display_modifiers,
     _sig_info,
-    _validate_signature,
+    _signature_validate,
     command,
     command_registrar,
     parameter,
@@ -1143,26 +1143,26 @@ class TestGenerateNestedParameters(object):
             _generate_nested_params(["This isn't a parameter!"])  # noqa
 
 
-class TestValidateSignature(object):
+class TestSignatureValidate(object):
     class TestSuccess(object):
         def test_positional(self, cmd):
-            _validate_signature(Parameter(key="foo"), cmd)
+            _signature_validate(Parameter(key="foo"), cmd)
 
         def test_kwarg(self, cmd_kwargs):
-            _validate_signature(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
+            _signature_validate(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
 
     class TestFailure(object):
         def test_mismatch_is_kwarg_true(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_signature(Parameter(key="foo", is_kwarg=True), cmd)
+                _signature_validate(Parameter(key="foo", is_kwarg=True), cmd)
 
         def test_mismatch_is_kwarg_false(self, cmd_kwargs):
             with pytest.raises(PluginParamError):
-                _validate_signature(Parameter(key="foo", is_kwarg=False), cmd_kwargs)
+                _signature_validate(Parameter(key="foo", is_kwarg=False), cmd_kwargs)
 
         def test_no_kwargs_in_signature(self, cmd):
             with pytest.raises(PluginParamError):
-                _validate_signature(Parameter(key="extra", is_kwarg=True), cmd)
+                _signature_validate(Parameter(key="extra", is_kwarg=True), cmd)
 
         # This is not valid syntax in Python < 3.8, so punting on this (it does work
         # for me right now :)

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -28,7 +28,7 @@ from brewtils.decorators import (
     system,
 )
 from brewtils.errors import PluginParamError
-from brewtils.models import Parameter
+from brewtils.models import Command, Parameter
 from brewtils.test.comparable import assert_command_equal, assert_parameter_equal
 
 if sys.version_info.major == 2:
@@ -1145,23 +1145,32 @@ class TestInitializeParameters(object):
 class TestSignatureValidate(object):
     class TestSuccess(object):
         def test_positional(self, cmd):
-            _signature_validate(Parameter(key="foo"), cmd)
+            _signature_validate(Command(parameters=[Parameter(key="foo")]), cmd)
 
         def test_kwarg(self, cmd_kwargs):
-            _signature_validate(Parameter(key="foo", is_kwarg=True), cmd_kwargs)
+            _signature_validate(
+                Command(parameters=[Parameter(key="foo", is_kwarg=True)]), cmd_kwargs
+            )
 
     class TestFailure(object):
         def test_mismatch_is_kwarg_true(self, cmd):
             with pytest.raises(PluginParamError):
-                _signature_validate(Parameter(key="foo", is_kwarg=True), cmd)
+                _signature_validate(
+                    Command(parameters=[Parameter(key="foo", is_kwarg=True)]), cmd
+                )
 
         def test_mismatch_is_kwarg_false(self, cmd_kwargs):
             with pytest.raises(PluginParamError):
-                _signature_validate(Parameter(key="foo", is_kwarg=False), cmd_kwargs)
+                _signature_validate(
+                    Command(parameters=[Parameter(key="foo", is_kwarg=False)]),
+                    cmd_kwargs,
+                )
 
         def test_no_kwargs_in_signature(self, cmd):
             with pytest.raises(PluginParamError):
-                _signature_validate(Parameter(key="extra", is_kwarg=True), cmd)
+                _signature_validate(
+                    Command(parameters=[Parameter(key="extra", is_kwarg=True)]), cmd
+                )
 
         # This is not valid syntax in Python < 3.8, so punting on this (it does work
         # for me right now :)

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -418,27 +418,6 @@ class TestParseMethod(object):
         with pytest.raises(PluginParamError):
             _parse_method(parameter(cmd))
 
-
-class TestInitializeCommand(object):
-    def test_generate_command(self, cmd):
-        assert not hasattr(cmd, "_command")
-
-        cmd = _initialize_command(cmd)
-
-        assert cmd.name == "cmd"
-        assert cmd.description == "Docstring"
-        assert len(cmd.parameters) == 1
-
-    def test_overwrite_docstring(self):
-        new_description = "So descriptive"
-
-        @command(description=new_description)
-        def _cmd(_):
-            """This is a doc"""
-            pass
-
-        assert _initialize_command(_cmd).description == new_description
-
     class TestParameterReconciliation(object):
         """Test that the parameters line up correctly"""
 
@@ -450,7 +429,7 @@ class TestInitializeCommand(object):
                 def cmd(foo):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -465,7 +444,7 @@ class TestInitializeCommand(object):
                 def cmd(foo):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -480,7 +459,7 @@ class TestInitializeCommand(object):
                 def cmd(foo):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -495,7 +474,7 @@ class TestInitializeCommand(object):
                 def cmd(foo=None):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -510,7 +489,7 @@ class TestInitializeCommand(object):
                 def cmd(foo=None):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -525,7 +504,7 @@ class TestInitializeCommand(object):
                 def cmd(foo=None):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -540,7 +519,7 @@ class TestInitializeCommand(object):
                 def cmd(foo="hi"):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -555,7 +534,7 @@ class TestInitializeCommand(object):
                 def cmd(foo="hi"):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -591,7 +570,7 @@ class TestInitializeCommand(object):
                 def cmd(foo="hi"):
                     return foo
 
-                bg_cmd = _initialize_command(cmd)
+                bg_cmd = _parse_method(cmd)
 
                 assert len(bg_cmd.parameters) == 1
                 assert bg_cmd.parameters[0].key == "foo"
@@ -599,6 +578,26 @@ class TestInitializeCommand(object):
 
                 # AGAIN, THIS ONE IS DIFFERENT!!!!
                 assert bg_cmd.parameters[0].default == "hi"
+
+
+class TestInitializeCommand(object):
+    def test_generate_command(self, cmd):
+        assert not hasattr(cmd, "_command")
+
+        cmd = _initialize_command(cmd)
+
+        assert cmd.name == "cmd"
+        assert cmd.description == "Docstring"
+
+    def test_overwrite_docstring(self):
+        new_description = "So descriptive"
+
+        @command(description=new_description)
+        def _cmd(_):
+            """This is a doc"""
+            pass
+
+        assert _initialize_command(_cmd).description == new_description
 
 
 class TestMethodName(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -233,19 +233,25 @@ class TestCommand(object):
         assert cmd._command.description == "desc2"
         assert cmd._command.output_type == "STRING"  # This is the default
 
-    def test_parameter_equivalence(self, basic_param):
-        @command(parameters=[basic_param])
-        def func1(_, foo):
-            return foo
-
+    def test_parameter_equivalence(self, basic_param, param):
         @parameter(**basic_param)
-        def func2(_, foo):
+        def expected_method(foo):
             return foo
 
-        cmd1 = _parse_method(func1)
-        cmd2 = _parse_method(func2)
+        @command(parameters=[basic_param])
+        def dict_method(foo):
+            return foo
 
-        assert_parameter_equal(cmd1.parameters[0], cmd2.parameters[0])
+        @command(parameters=[param])
+        def param_method(foo):
+            return foo
+
+        expected = _parse_method(expected_method)
+        dict_cmd = _parse_method(dict_method)
+        param_cmd = _parse_method(param_method)
+
+        assert_parameter_equal(dict_cmd.parameters[0], expected.parameters[0])
+        assert_parameter_equal(param_cmd.parameters[0], expected.parameters[0])
 
 
 class TestParameter(object):
@@ -289,22 +295,22 @@ class TestParameters(object):
 
     def test_parameter_equivalence(self, basic_param):
         @parameters([basic_param])
-        def func1(_, foo):
+        def func1(foo):
             return foo
 
         @parameter(**basic_param)
-        def func2(_, foo):
+        def func2(foo):
             return foo
 
         assert_parameter_equal(func1.parameters[0], func2.parameters[0])
 
     def test_command_equivalence(self, basic_param):
         @parameters([basic_param])
-        def func1(_, foo):
+        def func1(foo):
             return foo
 
         @command(parameters=[basic_param])
-        def func2(_, foo):
+        def func2(foo):
             return foo
 
         cmd1 = _parse_method(func1)


### PR DESCRIPTION
Depends on #296.

Fixes beer-garden/beer-garden#924, deprecates `@parameters`. Also makes some modifications to the way the decorators parse method parameters in order to be fully compatible with how `@parameters` currently works. Specifically, this is now OK:

```python
param_defs = [
    {"key": "foo", ...},
    {"key": "bar", ...},
]

@command(parameters=param_defs)
def cmd(self, foo, bar):
    pass
```

Previously the items in `@command(parameters=[LIST])` could only be Parameter objects or Model objects (type object with a parameters attribute). Now an item can also be a dict of Parameter kwargs.