### PR TITLE
Reworking model and nested parameter initialization

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -671,21 +671,19 @@ def _initialize_parameter(
         param.default = None
 
     # Now deal with nested parameters
-    if param.parameters:
+    if param.parameters or param.model:
+        if param.model:
+            # Can't specify a model and parameters - which should win?
+            if param.parameters:
+                raise PluginParamError(
+                    "Specifying a model and nested parameters for a single parameter "
+                    "is not allowed"
+                )
+
+            param.parameters = param.model.parameters
+
         param.type = "Dictionary"
         param.parameters = _initialize_parameters(param.parameters)
-
-    elif param.model is not None:
-        param.type = "Dictionary"
-        param.parameters = _initialize_parameters(param.model.parameters)
-
-        # If the model is not nullable and does not have a default we will try
-        # to generate a one using the defaults defined on the model parameters
-        if not param.nullable and not param.default:
-            param.default = {}
-            for nested_param in param.parameters:
-                if nested_param.default:
-                    param.default[nested_param.key] = nested_param.default
 
     return param
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -848,24 +848,46 @@ class TestInitializeParameter(object):
         """File parameter defaults should be cleared for safety"""
         assert _initialize_parameter(Parameter(key="f", type="Base64")).default is None
 
-    @pytest.mark.parametrize(
-        "default,expected",
-        [(None, {"key1": 1, "key2": "100"}), ({"key1", 123}, {"key1", 123})],
-    )
-    def test_model(self, my_model, param_1, param_2, default, expected):
-        model_param = _initialize_parameter(
-            Parameter(key="foo", model=my_model, default=default)
-        )
-
-        assert model_param.key == "foo"
-        assert model_param.type == "Dictionary"
-        assert len(model_param.parameters) == 2
-        assert model_param.default == expected
-
-        assert_parameter_equal(model_param.parameters[0], param_1)
-        assert_parameter_equal(model_param.parameters[1], param_2)
-
     class TestNesting(object):
+        @pytest.fixture
+        def inner(self):
+            class Inner(object):
+                parameters = [Parameter(key="inner", type="String")]
+
+            return Inner
+
+        @pytest.fixture
+        def outer(self, inner):
+            class Outer(object):
+                parameters = [Parameter(key="outer", model=inner)]
+
+            return Outer
+
+        def test_nested_model(self, outer):
+            p = _initialize_parameter(Parameter(key="p", model=outer))
+
+            assert p.key == "p"
+            assert p.type == "Dictionary"
+            assert p.default is None
+            assert len(p.parameters) == 1
+
+            outer = p.parameters[0]
+            assert outer.key == "outer"
+            assert outer.type == "Dictionary"
+            assert outer.default is None
+            assert len(outer.parameters) == 1
+
+            inner = outer.parameters[0]
+            assert inner.key == "inner"
+
+        def test_model_and_parameters(self, outer, inner):
+            """This is not allowed"""
+            with pytest.raises(PluginParamError):
+                _initialize_parameter(
+                    Parameter(key="nested", model=outer, parameters=inner.parameters)
+                )
+
+    class TestParameterLists(object):
         """Tests nested model Parameter construction
 
         This tests both the new, "correct" way to nest parameters (where the given


### PR DESCRIPTION
Fixes beer-garden/beer-garden#983. Fixes the weirdness associated with multi-model parameters. EDIT: Also fixes beer-garden/beer-garden#769.

We were previously doing something where we'd attempt to set the default of the parent parameter. As in, that parameter is *really* a dictionary parameter, so set its default to a dictionary of {nested parameter key: nested parameter default}.

The problem with this is that when the parameter is also a multi the frontend interprets those default dictionaries (objects now that we're in javascript land) as *the same object*. So adding multiple items to the list is really weird - all the model entries will have the same data. Changing one field will change the field for all items in the list.

From what I can tell this is totally unnecessary. Nested parameter defaults already work correctly, including when those parameters come from a model. So that's been removed.

However, it's still be possible to get into this situation by setting a default yourself. The multi, model, and default kwargs of the "inner_list" parameter are the problem here:

```python
@parameter(key="a", type="String", optional=False)
@parameter(key="b", type="String", optional=False, default="b")
class Inner:
    pass

@parameter(key="inner_list", multi=True, optional=False, model=Inner, default={"a": "1", "b": 2})
class Outer:
    pass

@parameter(key="model_list", multi=True, optional=False, model=Outer)
def test(self, model_list):
    pass

```

EDIT: I originally explored ways to prevent this in the decorators, but after further consideration that's a problem for another day (and another PR).