### PR TITLE
Clearing parameter model after grabbing the model parameters

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -691,6 +691,7 @@ def _initialize_parameter(
                 )
 
             param.parameters = param.model.parameters
+            param.model = None
 
         param.type = "Dictionary"
         param.parameters = _initialize_parameters(param.parameters)


### PR DESCRIPTION
Fixes beer-garden/beer-garden#987, can now reuse nested models.