### PR TITLE
Adding metadata field to Command model

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -92,6 +92,7 @@ def command(
     template=None,  # type: Optional[str]
     icon_name=None,  # type: Optional[str]
     hidden=False,  # type: Optional[bool]
+    metadata=None,  # type: Optional[Dict]
 ):
     """Decorator for specifying Command details
 
@@ -119,6 +120,7 @@ def command(
         template: A custom template definition.
         icon_name: The icon name. Should be either a FontAwesome or a Glyphicon name.
         hidden: Flag controlling whether the command is visible on the user interface.
+        metadata: Free-form dictionary
 
     Returns:
         The decorated function
@@ -135,6 +137,7 @@ def command(
             template=template,
             icon_name=icon_name,
             hidden=hidden,
+            metadata=metadata,
         )
 
     new_command = Command(
@@ -147,6 +150,7 @@ def command(
         template=template,
         icon_name=icon_name,
         hidden=hidden,
+        metadata=metadata,
     )
 
     # Python 2 compatibility

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -104,6 +104,7 @@ class Command(BaseModel):
         template=None,
         icon_name=None,
         hidden=False,
+        metadata=None,
     ):
         self.name = name
         self.description = description
@@ -115,6 +116,7 @@ class Command(BaseModel):
         self.template = template
         self.icon_name = icon_name
         self.hidden = hidden
+        self.metadata = metadata or {}
 
     def __str__(self):
         return self.name

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -187,6 +187,7 @@ class CommandSchema(BaseSchema):
     template = fields.Str(allow_none=True)
     icon_name = fields.Str(allow_none=True)
     hidden = fields.Boolean(allow_none=True)
+    metadata = fields.Dict(allow_none=True)
 
 
 class InstanceSchema(BaseSchema):

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -168,6 +168,7 @@ def command_dict(parameter_dict, system_id):
         "form": {},
         "template": "<html></html>",
         "icon_name": "icon!",
+        "metadata": {"meta": "data"},
     }
 
 
@@ -219,7 +220,7 @@ def instance_dict(ts_epoch):
             "url": "amqp://guest:guest@localhost:5672",
         },
         "status_info": {"heartbeat": ts_epoch},
-        "metadata": {},
+        "metadata": {"meta": "data"},
     }
 
 


### PR DESCRIPTION
Part of beer-garden/beer-garden#358. Adds a `metadata` field to the Command model.