### PR TITLE
Issue/997

### DIFF
--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -14,7 +14,7 @@ except ImportError:
     from lark.common import ParseError
 
 from brewtils.choices import parse
-from brewtils.display import resolve_display_modifiers
+from brewtils.display import resolve_form, resolve_schema, resolve_template
 from brewtils.errors import PluginParamError, _deprecate
 from brewtils.models import Command, Parameter, Choices
 
@@ -441,12 +441,9 @@ def _initialize_command(method):
     cmd.description = cmd.description or _method_docstring(method)
 
     try:
-        resolved_mod = resolve_display_modifiers(
-            method, schema=cmd.schema, form=cmd.form, template=cmd.template
-        )
-        cmd.schema = resolved_mod["schema"]
-        cmd.form = resolved_mod["form"]
-        cmd.template = resolved_mod["template"]
+        cmd.schema = resolve_schema(method, cmd.schema)
+        cmd.form = resolve_form(method, cmd.form)
+        cmd.template = resolve_template(method, cmd.template)
     except PluginParamError as ex:
         six.raise_from(
             PluginParamError("Error initializing command '%s': %s" % (cmd.name, ex)),

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -442,7 +442,7 @@ def _initialize_command(method):
 
     try:
         resolved_mod = resolve_display_modifiers(
-            method, cmd.name, schema=cmd.schema, form=cmd.form, template=cmd.template
+            method, schema=cmd.schema, form=cmd.form, template=cmd.template
         )
         cmd.schema = resolved_mod["schema"]
         cmd.form = resolved_mod["form"]

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -440,12 +440,18 @@ def _initialize_command(method):
     cmd.name = _method_name(method)
     cmd.description = cmd.description or _method_docstring(method)
 
-    resolved_mod = resolve_display_modifiers(
-        method, cmd.name, schema=cmd.schema, form=cmd.form, template=cmd.template
-    )
-    cmd.schema = resolved_mod["schema"]
-    cmd.form = resolved_mod["form"]
-    cmd.template = resolved_mod["template"]
+    try:
+        resolved_mod = resolve_display_modifiers(
+            method, cmd.name, schema=cmd.schema, form=cmd.form, template=cmd.template
+        )
+        cmd.schema = resolved_mod["schema"]
+        cmd.form = resolved_mod["form"]
+        cmd.template = resolved_mod["template"]
+    except PluginParamError as ex:
+        six.raise_from(
+            PluginParamError("Error initializing command '%s': %s" % (cmd.name, ex)),
+            ex,
+        )
 
     return cmd
 

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -2,6 +2,7 @@
 
 import functools
 import inspect
+import os
 import sys
 from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
@@ -441,9 +442,11 @@ def _initialize_command(method):
     cmd.description = cmd.description or _method_docstring(method)
 
     try:
-        cmd.schema = resolve_schema(method, cmd.schema)
-        cmd.form = resolve_form(method, cmd.form)
-        cmd.template = resolve_template(method, cmd.template)
+        base_dir = os.path.dirname(inspect.getfile(method))
+
+        cmd.schema = resolve_schema(cmd.schema, base_dir=base_dir)
+        cmd.form = resolve_form(cmd.form, base_dir=base_dir)
+        cmd.template = resolve_template(cmd.template, base_dir=base_dir)
     except PluginParamError as ex:
         six.raise_from(
             PluginParamError("Error initializing command '%s': %s" % (cmd.name, ex)),

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -5,12 +5,88 @@ import json
 import os
 from io import open
 from types import MethodType
-from typing import Union
+from typing import Optional, Union
 
 import requests
 import six
 
 from brewtils.errors import PluginParamError
+
+
+def resolve_schema(wrapped, schema=None):
+    # type: (MethodType, Union[dict, str]) -> Optional[dict]
+    """Resolve a schema attribute
+
+    Returns:
+        Dictionary that fully describes a schema
+    """
+    if schema is None or isinstance(schema, dict):
+        return schema
+    elif isinstance(schema, six.string_types):
+        try:
+            if schema.startswith("http"):
+                return _load_from_url(schema)
+            elif schema.startswith("/") or schema.startswith("."):
+                return json.loads(_load_from_path(wrapped, schema))
+            else:
+                raise PluginParamError("Schema was not a definition, file path, or URL")
+        except Exception as ex:
+            six.raise_from(PluginParamError("Error resolving schema: %s" % ex), ex)
+    else:
+        raise PluginParamError(
+            "Schema specified was not a definition, file path, or URL"
+        )
+
+
+def resolve_form(wrapped, form=None):
+    # type: (MethodType, Union[None, dict, list, str]) -> Optional[dict]
+    """Resolve a form attribute
+
+    Returns:
+        Dictionary that fully describes a form
+    """
+    if form is None or isinstance(form, dict):
+        return form
+    elif isinstance(form, list):
+        return {"type": "fieldset", "items": form}
+    elif isinstance(form, six.string_types):
+        try:
+            if form.startswith("http"):
+                return _load_from_url(form)
+            elif form.startswith("/") or form.startswith("."):
+                return json.loads(_load_from_path(wrapped, form))
+            else:
+                raise PluginParamError("Form was not a definition, file path, or URL")
+        except Exception as ex:
+            six.raise_from(PluginParamError("Error resolving form: %s" % ex), ex)
+    else:
+        raise PluginParamError("Schema was not a definition, file path, or URL")
+
+
+def resolve_template(wrapped, template=None):
+    # type: (MethodType, str) -> Optional[str]
+    """Resolve a template attribute
+
+    Returns:
+        Dictionary that fully describes a template
+    """
+    if template is None:
+        return None
+    elif isinstance(template, six.string_types):
+        try:
+            if template.startswith("http"):
+                return _load_from_url(template)
+            elif template.startswith("/") or template.startswith("."):
+                return _load_from_path(wrapped, template)
+            else:
+                return template
+
+        except Exception as ex:
+            six.raise_from(PluginParamError("Error resolving template: %s" % ex), ex)
+    else:
+        raise PluginParamError(
+            "Template specified was not a definition, file path, or URL"
+        )
 
 
 def resolve_display_modifiers(
@@ -26,51 +102,15 @@ def resolve_display_modifiers(
         Dictionary that fully describes a display specification
     """
 
-    resolved = {}
-
-    for key, value in {"schema": schema, "form": form, "template": template}.items():
-
-        if isinstance(value, six.string_types):
-            try:
-                if value.startswith("http"):
-                    resolved[key] = _load_from_url(value)
-
-                elif value.startswith("/") or value.startswith("."):
-                    loaded_value = _load_from_path(wrapped, value)
-                    resolved[key] = (
-                        loaded_value if key == "template" else json.loads(loaded_value)
-                    )
-
-                elif key == "template":
-                    resolved[key] = value
-
-                else:
-                    raise PluginParamError(
-                        "%s was not a definition, file path, or URL" % key
-                    )
-            except Exception as ex:
-                six.raise_from(
-                    PluginParamError(
-                        "Error reading %s definition from '%s': %s" % (key, value, ex)
-                    ),
-                    ex,
-                )
-
-        elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):
-            resolved[key] = value
-
-        elif key == "form" and isinstance(value, list):
-            resolved[key] = {"type": "fieldset", "items": value}
-
-        else:
-            raise PluginParamError(
-                "%s specified was not a definition, file path, or URL" % key
-            )
-
-    return resolved
+    return {
+        "schema": resolve_schema(wrapped, schema),
+        "form": resolve_form(wrapped, form),
+        "template": resolve_template(wrapped, template),
+    }
 
 
 def _load_from_url(url):
+    # type: (str) -> Union[str, dict]
     response = requests.get(url)
     if response.headers.get("content-type", "").lower() == "application/json":
         return json.loads(response.text)
@@ -78,6 +118,7 @@ def _load_from_url(url):
 
 
 def _load_from_path(wrapped, path):
+    # type: (MethodType, str) -> str
     current_dir = os.path.dirname(inspect.getfile(wrapped))
     file_path = os.path.abspath(os.path.join(current_dir, path))
 

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -133,5 +133,14 @@ def _load_from_path(path, base_dir=None):
     else:
         file_path = os.path.abspath(os.path.join(os.getcwd(), path))
 
-    with open(file_path, "r") as definition_file:
-        return definition_file.read()
+    try:
+        with open(file_path, "r") as definition_file:
+            return definition_file.read()
+    except IOError as ex:
+        six.raise_from(
+            PluginParamError(
+                "%s. Please remember that relative paths will be resolved starting "
+                "from the plugin's current working directory." % ex
+            ),
+            ex,
+        )

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+import inspect
+import json
+import os
+from io import open
+from types import MethodType
+from typing import Union
+
+import requests
+import six
+
+from brewtils.errors import PluginParamError
+
+
+def resolve_display_modifiers(
+    wrapped,  # type: MethodType
+    command_name,  # type: str
+    schema=None,  # type: Union[dict, str]
+    form=None,  # type: Union[dict, list, str]
+    template=None,  # type: str
+):
+    # type: (...) -> dict
+    """Parse display modifier parameter attributes
+
+    Returns:
+        Dictionary that fully describes a display specification
+    """
+
+    resolved = {}
+
+    for key, value in {"schema": schema, "form": form, "template": template}.items():
+
+        if isinstance(value, six.string_types):
+            try:
+                if value.startswith("http"):
+                    resolved[key] = _load_from_url(value)
+
+                elif value.startswith("/") or value.startswith("."):
+                    loaded_value = _load_from_path(wrapped, value)
+                    resolved[key] = (
+                        loaded_value if key == "template" else json.loads(loaded_value)
+                    )
+
+                elif key == "template":
+                    resolved[key] = value
+
+                else:
+                    raise PluginParamError(
+                        "%s specified for command '%s' was not a "
+                        "definition, file path, or URL" % (key, command_name)
+                    )
+            except Exception as ex:
+                raise PluginParamError(
+                    "Error reading %s definition from '%s' for command "
+                    "'%s': %s" % (key, value, command_name, ex)
+                )
+
+        elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):
+            resolved[key] = value
+
+        elif key == "form" and isinstance(value, list):
+            resolved[key] = {"type": "fieldset", "items": value}
+
+        else:
+            raise PluginParamError(
+                "%s specified for command '%s' was not a definition, "
+                "file path, or URL" % (key, command_name)
+            )
+
+    return resolved
+
+
+def _load_from_url(url):
+    response = requests.get(url)
+    if response.headers.get("content-type", "").lower() == "application/json":
+        return json.loads(response.text)
+    return response.text
+
+
+def _load_from_path(wrapped, path):
+    current_dir = os.path.dirname(inspect.getfile(wrapped))
+    file_path = os.path.abspath(os.path.join(current_dir, path))
+
+    with open(file_path, "r") as definition_file:
+        return definition_file.read()

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -15,7 +15,6 @@ from brewtils.errors import PluginParamError
 
 def resolve_display_modifiers(
     wrapped,  # type: MethodType
-    command_name,  # type: str
     schema=None,  # type: Union[dict, str]
     form=None,  # type: Union[dict, list, str]
     template=None,  # type: str
@@ -47,13 +46,11 @@ def resolve_display_modifiers(
 
                 else:
                     raise PluginParamError(
-                        "%s specified for command '%s' was not a "
-                        "definition, file path, or URL" % (key, command_name)
+                        "%s was not a definition, file path, or URL" % key
                     )
             except Exception as ex:
                 raise PluginParamError(
-                    "Error reading %s definition from '%s' for command "
-                    "'%s': %s" % (key, value, command_name, ex)
+                    "Error reading %s definition from '%s': %s" % (key, value, ex)
                 )
 
         elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):
@@ -64,8 +61,7 @@ def resolve_display_modifiers(
 
         else:
             raise PluginParamError(
-                "%s specified for command '%s' was not a definition, "
-                "file path, or URL" % (key, command_name)
+                "%s specified was not a definition, file path, or URL" % key
             )
 
     return resolved

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import inspect
 import json
 import os
 from io import open
@@ -13,8 +12,8 @@ import six
 from brewtils.errors import PluginParamError
 
 
-def resolve_schema(wrapped, schema=None):
-    # type: (MethodType, Union[dict, str]) -> Optional[dict]
+def resolve_schema(schema=None, base_dir=None):
+    # type: (Union[dict, str], str) -> Optional[dict]
     """Resolve a schema attribute
 
     Returns:
@@ -27,7 +26,7 @@ def resolve_schema(wrapped, schema=None):
             if schema.startswith("http"):
                 return _load_from_url(schema)
             elif schema.startswith("/") or schema.startswith("."):
-                return json.loads(_load_from_path(wrapped, schema))
+                return json.loads(_load_from_path(schema, base_dir=base_dir))
             else:
                 raise PluginParamError("Schema was not a definition, file path, or URL")
         except Exception as ex:
@@ -38,8 +37,8 @@ def resolve_schema(wrapped, schema=None):
         )
 
 
-def resolve_form(wrapped, form=None):
-    # type: (MethodType, Union[None, dict, list, str]) -> Optional[dict]
+def resolve_form(form=None, base_dir=None):
+    # type: (Union[None, dict, list, str], str) -> Optional[dict]
     """Resolve a form attribute
 
     Returns:
@@ -54,7 +53,7 @@ def resolve_form(wrapped, form=None):
             if form.startswith("http"):
                 return _load_from_url(form)
             elif form.startswith("/") or form.startswith("."):
-                return json.loads(_load_from_path(wrapped, form))
+                return json.loads(_load_from_path(form, base_dir=base_dir))
             else:
                 raise PluginParamError("Form was not a definition, file path, or URL")
         except Exception as ex:
@@ -63,8 +62,8 @@ def resolve_form(wrapped, form=None):
         raise PluginParamError("Schema was not a definition, file path, or URL")
 
 
-def resolve_template(wrapped, template=None):
-    # type: (MethodType, str) -> Optional[str]
+def resolve_template(template=None, base_dir=None):
+    # type: (str, str) -> Optional[str]
     """Resolve a template attribute
 
     Returns:
@@ -77,7 +76,7 @@ def resolve_template(wrapped, template=None):
             if template.startswith("http"):
                 return _load_from_url(template)
             elif template.startswith("/") or template.startswith("."):
-                return _load_from_path(wrapped, template)
+                return _load_from_path(template, base_dir=base_dir)
             else:
                 return template
 
@@ -117,10 +116,11 @@ def _load_from_url(url):
     return response.text
 
 
-def _load_from_path(wrapped, path):
-    # type: (MethodType, str) -> str
-    current_dir = os.path.dirname(inspect.getfile(wrapped))
-    file_path = os.path.abspath(os.path.join(current_dir, path))
+def _load_from_path(path, base_dir=None):
+    # type: (str, str) -> str
+    if not base_dir:
+        base_dir = os.getcwd()
+    file_path = os.path.abspath(os.path.join(base_dir, path))
 
     with open(file_path, "r") as definition_file:
         return definition_file.read()

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -3,7 +3,6 @@
 import json
 import os
 from io import open
-from types import MethodType
 from typing import Optional, Union
 
 import requests
@@ -86,26 +85,6 @@ def resolve_template(template=None, base_dir=None):
         raise PluginParamError(
             "Template specified was not a definition, file path, or URL"
         )
-
-
-def resolve_display_modifiers(
-    wrapped,  # type: MethodType
-    schema=None,  # type: Union[dict, str]
-    form=None,  # type: Union[dict, list, str]
-    template=None,  # type: str
-):
-    # type: (...) -> dict
-    """Parse display modifier parameter attributes
-
-    Returns:
-        Dictionary that fully describes a display specification
-    """
-
-    return {
-        "schema": resolve_schema(wrapped, schema),
-        "form": resolve_form(wrapped, form),
-        "template": resolve_template(wrapped, template),
-    }
 
 
 def _load_from_url(url):

--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -49,8 +49,11 @@ def resolve_display_modifiers(
                         "%s was not a definition, file path, or URL" % key
                     )
             except Exception as ex:
-                raise PluginParamError(
-                    "Error reading %s definition from '%s': %s" % (key, value, ex)
+                six.raise_from(
+                    PluginParamError(
+                        "Error reading %s definition from '%s': %s" % (key, value, ex)
+                    ),
+                    ex,
                 )
 
         elif value is None or (key in ["schema", "form"] and isinstance(value, dict)):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -703,6 +703,7 @@ class System(BaseModel):
         metadata=None,
         namespace=None,
         local=None,
+        template=None,
     ):
         self.name = name
         self.description = description
@@ -716,6 +717,7 @@ class System(BaseModel):
         self.metadata = metadata or {}
         self.namespace = namespace
         self.local = local
+        self.template = template
 
     def __str__(self):
         return "%s:%s-%s" % (self.namespace, self.name, self.version)

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -761,6 +761,7 @@ class Plugin(object):
             "max_instances",
             "metadata",
             "namespace",
+            "template",
         }
 
         if system:
@@ -792,6 +793,7 @@ class Plugin(object):
                 max_instances=self._config.max_instances,
                 icon_name=self._config.icon_name,
                 display_name=self._config.display_name,
+                template=self._config.template,
             )
 
         return system

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -463,6 +463,9 @@ class Plugin(object):
         # Make sure that the system is actually valid before trying anything
         self._validate_system()
 
+        # Do any necessary template resolution
+        self._system.template = resolve_template(self._system.template)
+
         existing_system = self._ez_client.find_unique_system(
             name=self._system.name,
             version=self._system.version,
@@ -795,7 +798,7 @@ class Plugin(object):
                 max_instances=self._config.max_instances,
                 icon_name=self._config.icon_name,
                 display_name=self._config.display_name,
-                template=resolve_template(self._config.template),
+                template=self._config.template,
             )
 
         return system

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -15,6 +15,7 @@ from requests import ConnectionError as RequestsConnectionError
 import brewtils
 from brewtils.config import load_config
 from brewtils.decorators import _parse_client
+from brewtils.display import resolve_template
 from brewtils.errors import (
     ConflictError,
     DiscardMessageException,
@@ -494,6 +495,7 @@ class Plugin(object):
             "description": self._system.description,
             "display_name": self._system.display_name,
             "icon_name": self._system.icon_name,
+            "template": self._system.template,
         }
 
         # And if this particular instance doesn't exist we want to add it
@@ -793,7 +795,7 @@ class Plugin(object):
                 max_instances=self._config.max_instances,
                 icon_name=self._config.icon_name,
                 display_name=self._config.display_name,
-                template=self._config.template,
+                template=resolve_template(self._config.template),
             )
 
         return system

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -317,7 +317,8 @@ class EasyClient(object):
             metadata (dict): New System metadata
             description (str): New System description
             display_name (str): New System display name
-            icon_name (str) The: New System icon name
+            icon_name (str): New System icon name
+            template (str): New System template
 
         Returns:
             System: The updated system

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -215,6 +215,7 @@ class SystemSchema(BaseSchema):
     metadata = fields.Dict(allow_none=True)
     namespace = fields.Str(allow_none=True)
     local = fields.Bool(allow_none=True)
+    template = fields.Str(allow_none=True)
 
 
 class RequestFileSchema(BaseSchema):

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -133,6 +133,13 @@ _SYSTEM_SPEC = {
         "description": "The namespace this system will be created in",
         "required": False,
     },
+    "template": {
+        "type": "str",
+        "description": "Custom system page definition",
+        "required": False,
+        "long_description": "Follows the same rules as @command templates - can be "
+        "a URL, path string to a template file, or an actual html string",
+    },
 }
 
 _PLUGIN_SPEC = {

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -248,7 +248,7 @@ def system_dict(instance_dict, command_dict, command_dict_2, system_id):
         "metadata": {"some": "stuff"},
         "namespace": "ns",
         "local": True,
-        "template": "./template.html",
+        "template": "<html>template</html>",
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -248,6 +248,7 @@ def system_dict(instance_dict, command_dict, command_dict_2, system_id):
         "metadata": {"some": "stuff"},
         "namespace": "ns",
         "local": True,
+        "template": "./template.html",
     }
 
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+
 import sys
 import warnings
 
 import pytest
-from mock import Mock, patch
+from mock import Mock
 
 import brewtils.decorators
 from brewtils.decorators import (
@@ -16,7 +17,6 @@ from brewtils.decorators import (
     _method_name,
     _parse_client,
     _parse_method,
-    _resolve_display_modifiers,
     _sig_info,
     _signature_validate,
     client,
@@ -666,122 +666,6 @@ class TestMethodName(object):
 class TestMethodDocstring(object):
     def test_docstring(self, cmd):
         assert _method_docstring(cmd) == "Docstring"
-
-
-class TestResolveModifiers(object):
-    @pytest.mark.parametrize(
-        "args",
-        [
-            {"schema": None, "form": None, "template": None},
-            {"schema": {}, "form": {}, "template": None},
-            {"schema": {}, "form": {"type": "fieldset", "items": []}, "template": None},
-        ],
-    )
-    def test_identity(self, args):
-        assert args == _resolve_display_modifiers(Mock(), Mock(), **args)
-
-    @pytest.mark.parametrize(
-        "field,args,expected",
-        [
-            ("form", {"form": []}, {"type": "fieldset", "items": []}),
-            ("template", {"template": "<html>"}, "<html>"),
-        ],
-    )
-    def test_aspects(self, field, args, expected):
-        assert expected == _resolve_display_modifiers(Mock(), Mock(), **args).get(field)
-
-    @pytest.mark.parametrize(
-        "args",
-        [
-            {"template": {}},
-            {"schema": ""},
-            {"form": ""},
-            {"schema": 123},
-            {"form": 123},
-            {"template": 123},
-        ],
-    )
-    def test_type_errors(self, args):
-        with pytest.raises(PluginParamError):
-            _resolve_display_modifiers(Mock(), Mock(), **args)
-
-    def test_load_url(self, requests_mock):
-        args = {
-            "schema": "http://test/schema",
-            "form": "http://test/form",
-            "template": "http://test/template",
-        }
-        expected = {
-            "schema": {"schema": "test"},
-            "form": {"form": "test"},
-            "template": "<html></html>",
-        }
-
-        requests_mock.get(
-            args["schema"],
-            json=expected["schema"],
-            headers={"content-type": "application/json"},
-        )
-        requests_mock.get(
-            args["form"],
-            json=expected["form"],
-            headers={"content-type": "application/json"},
-        )
-        requests_mock.get(
-            args["template"],
-            text=expected["template"],
-            headers={"content-type": "text/html"},
-        )
-
-        resolved = _resolve_display_modifiers(Mock(), Mock(), **args)
-        assert resolved["schema"] == expected["schema"]
-        assert resolved["form"] == expected["form"]
-        assert resolved["template"] == expected["template"]
-
-    @pytest.mark.parametrize(
-        "args,expected",
-        [
-            ({"schema": "/abs/path/schema.json"}, "/abs/path/schema.json"),
-            ({"schema": "../rel/schema.json"}, "/abs/test/rel/schema.json"),
-        ],
-    )
-    def test_load_file(self, monkeypatch, args, expected):
-        inspect_mock = Mock()
-        inspect_mock.getfile.return_value = "/abs/test/dir/client.py"
-        monkeypatch.setattr("brewtils.decorators.inspect", inspect_mock)
-
-        with patch("brewtils.decorators.open") as op_mock:
-            op_mock.return_value.__enter__.return_value.read.return_value = "{}"
-            _resolve_display_modifiers(Mock(), Mock(), **args)
-
-        op_mock.assert_called_once_with(expected, "r")
-
-    @pytest.mark.parametrize(
-        "args",
-        [
-            {"schema": "http://test"},
-            {"form": "http://test"},
-            {"template": "http://test"},
-        ],
-    )
-    def test_url_resolve_error(self, monkeypatch, args):
-        requests_mock = Mock()
-        requests_mock.get.side_effect = Exception
-        monkeypatch.setattr("brewtils.decorators.requests", requests_mock)
-
-        with pytest.raises(PluginParamError):
-            _resolve_display_modifiers(Mock(), Mock(), **args)
-
-    @pytest.mark.parametrize(
-        "args", [{"schema": "./test"}, {"form": "./test"}, {"template": "./test"}]
-    )
-    def test_file_resolve_error(self, monkeypatch, args):
-        open_mock = Mock()
-        open_mock.side_effect = Exception
-        monkeypatch.setattr("brewtils.decorators.open", open_mock)
-
-        with pytest.raises(PluginParamError):
-            _resolve_display_modifiers(Mock(), Mock(), **args)
 
 
 class TestSigInfo(object):

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -1,123 +1,157 @@
 # -*- coding: utf-8 -*-
+import json
+import os
 
 import pytest
 from mock import Mock, patch
 
-from brewtils.display import resolve_display_modifiers
+import brewtils.display
+from brewtils.display import (
+    resolve_form,
+    resolve_schema,
+    resolve_template,
+    _load_from_path,
+)
 from brewtils.errors import PluginParamError
 
 
-class TestResolveModifiers(object):
-    @pytest.mark.parametrize(
-        "args",
-        [
-            {"schema": None, "form": None, "template": None},
-            {"schema": {}, "form": {}, "template": None},
-            {"schema": {}, "form": {"type": "fieldset", "items": []}, "template": None},
-        ],
-    )
-    def test_identity(self, args):
-        assert args == resolve_display_modifiers(Mock(), **args)
+class TestConsistent(object):
+    """Test functionality that's EXACTLY the same for schema, form, and template"""
 
     @pytest.mark.parametrize(
-        "field,args,expected",
-        [
-            ("form", {"form": []}, {"type": "fieldset", "items": []}),
-            ("template", {"template": "<html>"}, "<html>"),
-        ],
+        "func", ["resolve_schema", "resolve_form", "resolve_template"]
     )
-    def test_aspects(self, field, args, expected):
-        assert expected == resolve_display_modifiers(Mock(), **args).get(field)
+    def test_none(self, func):
+        assert getattr(brewtils.display, func)(None) is None
 
     @pytest.mark.parametrize(
-        "args",
-        [
-            {"template": {}},
-            {"schema": ""},
-            {"form": ""},
-            {"schema": 123},
-            {"form": 123},
-            {"template": 123},
-        ],
+        "func", ["resolve_schema", "resolve_form", "resolve_template"]
     )
-    def test_type_errors(self, args):
+    def test_url_resolve_error(self, func):
         with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), **args)
+            getattr(brewtils.display, func)("http://test")
 
-    def test_load_url(self, requests_mock):
-        args = {
-            "schema": "http://test/schema",
-            "form": "http://test/form",
-            "template": "http://test/template",
-        }
-        expected = {
-            "schema": {"schema": "test"},
-            "form": {"form": "test"},
-            "template": "<html></html>",
-        }
+    @pytest.mark.parametrize(
+        "func", ["resolve_schema", "resolve_form", "resolve_template"]
+    )
+    def test_file_resolve_error(self, monkeypatch, func):
+        monkeypatch.setattr("brewtils.display.open", Mock(side_effect=Exception))
+
+        with pytest.raises(PluginParamError):
+            getattr(brewtils.display, func)("./test")
+
+
+class TestResolveSchema(object):
+    @pytest.fixture
+    def schema(self):
+        return {"test": "schema"}
+
+    def test_dict(self, schema):
+        assert resolve_schema(schema) == schema
+
+    def test_url(self, requests_mock, schema):
+        url = "http://test/schema"
 
         requests_mock.get(
-            args["schema"],
-            json=expected["schema"],
+            url,
+            json=schema,
             headers={"content-type": "application/json"},
         )
+
+        assert resolve_schema(url) == schema
+
+    def test_file(self, monkeypatch, tmpdir, schema):
+        path = os.path.join(str(tmpdir), "schema.txt")
+        with open(path, "w") as f:
+            json.dump(schema, f)
+
+        assert resolve_schema("./schema.txt", base_dir=str(tmpdir)) == schema
+
+    @pytest.mark.parametrize("data", ["", 123])
+    def test_type_errors(self, data):
+        with pytest.raises(PluginParamError):
+            resolve_schema(data)
+
+
+class TestResolveForm(object):
+    @pytest.fixture
+    def items(self):
+        return ["item"]
+
+    @pytest.fixture
+    def form(self, items):
+        return {"type": "fieldset", "items": items}
+
+    def test_dict(self, form):
+        assert resolve_form(form) == form
+
+    def test_list(self, form, items):
+        assert resolve_form(items) == form
+
+    def test_url(self, requests_mock, form):
+        url = "http://test/form"
+
         requests_mock.get(
-            args["form"],
-            json=expected["form"],
+            url,
+            json=form,
             headers={"content-type": "application/json"},
         )
+
+        assert resolve_form(url) == form
+
+    def test_file(self, monkeypatch, tmpdir, form):
+        path = os.path.join(str(tmpdir), "form.txt")
+        with open(path, "w") as f:
+            json.dump(form, f)
+
+        assert resolve_form("./form.txt", base_dir=str(tmpdir)) == form
+
+    @pytest.mark.parametrize("data", ["", 123])
+    def test_type_errors(self, data):
+        with pytest.raises(PluginParamError):
+            resolve_form(data)
+
+
+class TestResolveTemplate(object):
+    @pytest.fixture
+    def template(self):
+        return "<html></html>"
+
+    def test_url(self, requests_mock, template):
+        url = "http://test/template"
+
         requests_mock.get(
-            args["template"],
-            text=expected["template"],
+            url,
+            text=template,
             headers={"content-type": "text/html"},
         )
 
-        resolved = resolve_display_modifiers(Mock(), **args)
-        assert resolved["schema"] == expected["schema"]
-        assert resolved["form"] == expected["form"]
-        assert resolved["template"] == expected["template"]
+        assert resolve_template(url) == template
 
-    @pytest.mark.parametrize(
-        "args,expected",
-        [
-            ({"schema": "/abs/path/schema.json"}, "/abs/path/schema.json"),
-            ({"schema": "../rel/schema.json"}, "/abs/test/rel/schema.json"),
-        ],
-    )
-    def test_load_file(self, monkeypatch, args, expected):
-        inspect_mock = Mock()
-        inspect_mock.getfile.return_value = "/abs/test/dir/client.py"
-        monkeypatch.setattr("brewtils.display.inspect", inspect_mock)
+    def test_file(self, monkeypatch, tmpdir, template):
+        path = os.path.join(str(tmpdir), "template.txt")
+        with open(path, "w") as f:
+            f.write(template)
 
-        with patch("brewtils.display.open") as op_mock:
-            op_mock.return_value.__enter__.return_value.read.return_value = "{}"
-            resolve_display_modifiers(Mock(), **args)
+        assert resolve_template("./template.txt", base_dir=str(tmpdir)) == template
 
-        op_mock.assert_called_once_with(expected, "r")
-
-    @pytest.mark.parametrize(
-        "args",
-        [
-            {"schema": "http://test"},
-            {"form": "http://test"},
-            {"template": "http://test"},
-        ],
-    )
-    def test_url_resolve_error(self, monkeypatch, args):
-        requests_mock = Mock()
-        requests_mock.get.side_effect = Exception
-        monkeypatch.setattr("brewtils.display.requests", requests_mock)
-
+    @pytest.mark.parametrize("data", [{}, [], 123])
+    def test_type_errors(self, data):
         with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), **args)
+            resolve_template(data)
 
-    @pytest.mark.parametrize(
-        "args", [{"schema": "./test"}, {"form": "./test"}, {"template": "./test"}]
-    )
-    def test_file_resolve_error(self, monkeypatch, args):
-        open_mock = Mock()
-        open_mock.side_effect = Exception
-        monkeypatch.setattr("brewtils.display.open", open_mock)
 
-        with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), **args)
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ("/abs/path/schema.json", "/abs/path/schema.json"),
+        ("./schema.json", "/abs/test/dir/schema.json"),
+        ("../rel/schema.json", "/abs/test/rel/schema.json"),
+    ],
+)
+def test_load_from_path(monkeypatch, schema, expected):
+    with patch("brewtils.display.open") as op_mock:
+        op_mock.return_value.__enter__.return_value.read.return_value = "{}"
+        _load_from_path(schema, base_dir="/abs/test/dir")
+
+    op_mock.assert_called_once_with(expected, "r")

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -177,7 +177,7 @@ class TestLoadFromPath(object):
             assert _load_from_path("./test.txt", base_dir=base_dir) == "TEST"
 
         def test_nonexistent(self, base_dir):
-            with pytest.raises(IOError):
+            with pytest.raises(PluginParamError):
                 _load_from_path("./foo.bar", base_dir=base_dir)
 
     class TestNoBaseDir(object):
@@ -188,5 +188,5 @@ class TestLoadFromPath(object):
             assert _load_from_path("./test.txt") == "TEST"
 
         def test_nonexistent(self):
-            with pytest.raises(IOError):
+            with pytest.raises(PluginParamError):
                 _load_from_path("./foo.bar")

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from mock import Mock, patch
+
+from brewtils.display import resolve_display_modifiers
+from brewtils.errors import PluginParamError
+
+
+class TestResolveModifiers(object):
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"schema": None, "form": None, "template": None},
+            {"schema": {}, "form": {}, "template": None},
+            {"schema": {}, "form": {"type": "fieldset", "items": []}, "template": None},
+        ],
+    )
+    def test_identity(self, args):
+        assert args == resolve_display_modifiers(Mock(), Mock(), **args)
+
+    @pytest.mark.parametrize(
+        "field,args,expected",
+        [
+            ("form", {"form": []}, {"type": "fieldset", "items": []}),
+            ("template", {"template": "<html>"}, "<html>"),
+        ],
+    )
+    def test_aspects(self, field, args, expected):
+        assert expected == resolve_display_modifiers(Mock(), Mock(), **args).get(field)
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"template": {}},
+            {"schema": ""},
+            {"form": ""},
+            {"schema": 123},
+            {"form": 123},
+            {"template": 123},
+        ],
+    )
+    def test_type_errors(self, args):
+        with pytest.raises(PluginParamError):
+            resolve_display_modifiers(Mock(), Mock(), **args)
+
+    def test_load_url(self, requests_mock):
+        args = {
+            "schema": "http://test/schema",
+            "form": "http://test/form",
+            "template": "http://test/template",
+        }
+        expected = {
+            "schema": {"schema": "test"},
+            "form": {"form": "test"},
+            "template": "<html></html>",
+        }
+
+        requests_mock.get(
+            args["schema"],
+            json=expected["schema"],
+            headers={"content-type": "application/json"},
+        )
+        requests_mock.get(
+            args["form"],
+            json=expected["form"],
+            headers={"content-type": "application/json"},
+        )
+        requests_mock.get(
+            args["template"],
+            text=expected["template"],
+            headers={"content-type": "text/html"},
+        )
+
+        resolved = resolve_display_modifiers(Mock(), Mock(), **args)
+        assert resolved["schema"] == expected["schema"]
+        assert resolved["form"] == expected["form"]
+        assert resolved["template"] == expected["template"]
+
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            ({"schema": "/abs/path/schema.json"}, "/abs/path/schema.json"),
+            ({"schema": "../rel/schema.json"}, "/abs/test/rel/schema.json"),
+        ],
+    )
+    def test_load_file(self, monkeypatch, args, expected):
+        inspect_mock = Mock()
+        inspect_mock.getfile.return_value = "/abs/test/dir/client.py"
+        monkeypatch.setattr("brewtils.display.inspect", inspect_mock)
+
+        with patch("brewtils.display.open") as op_mock:
+            op_mock.return_value.__enter__.return_value.read.return_value = "{}"
+            resolve_display_modifiers(Mock(), Mock(), **args)
+
+        op_mock.assert_called_once_with(expected, "r")
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"schema": "http://test"},
+            {"form": "http://test"},
+            {"template": "http://test"},
+        ],
+    )
+    def test_url_resolve_error(self, monkeypatch, args):
+        requests_mock = Mock()
+        requests_mock.get.side_effect = Exception
+        monkeypatch.setattr("brewtils.display.requests", requests_mock)
+
+        with pytest.raises(PluginParamError):
+            resolve_display_modifiers(Mock(), Mock(), **args)
+
+    @pytest.mark.parametrize(
+        "args", [{"schema": "./test"}, {"form": "./test"}, {"template": "./test"}]
+    )
+    def test_file_resolve_error(self, monkeypatch, args):
+        open_mock = Mock()
+        open_mock.side_effect = Exception
+        monkeypatch.setattr("brewtils.display.open", open_mock)
+
+        with pytest.raises(PluginParamError):
+            resolve_display_modifiers(Mock(), Mock(), **args)

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -17,7 +17,7 @@ class TestResolveModifiers(object):
         ],
     )
     def test_identity(self, args):
-        assert args == resolve_display_modifiers(Mock(), Mock(), **args)
+        assert args == resolve_display_modifiers(Mock(), **args)
 
     @pytest.mark.parametrize(
         "field,args,expected",
@@ -27,7 +27,7 @@ class TestResolveModifiers(object):
         ],
     )
     def test_aspects(self, field, args, expected):
-        assert expected == resolve_display_modifiers(Mock(), Mock(), **args).get(field)
+        assert expected == resolve_display_modifiers(Mock(), **args).get(field)
 
     @pytest.mark.parametrize(
         "args",
@@ -42,7 +42,7 @@ class TestResolveModifiers(object):
     )
     def test_type_errors(self, args):
         with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), Mock(), **args)
+            resolve_display_modifiers(Mock(), **args)
 
     def test_load_url(self, requests_mock):
         args = {
@@ -72,7 +72,7 @@ class TestResolveModifiers(object):
             headers={"content-type": "text/html"},
         )
 
-        resolved = resolve_display_modifiers(Mock(), Mock(), **args)
+        resolved = resolve_display_modifiers(Mock(), **args)
         assert resolved["schema"] == expected["schema"]
         assert resolved["form"] == expected["form"]
         assert resolved["template"] == expected["template"]
@@ -91,7 +91,7 @@ class TestResolveModifiers(object):
 
         with patch("brewtils.display.open") as op_mock:
             op_mock.return_value.__enter__.return_value.read.return_value = "{}"
-            resolve_display_modifiers(Mock(), Mock(), **args)
+            resolve_display_modifiers(Mock(), **args)
 
         op_mock.assert_called_once_with(expected, "r")
 
@@ -109,7 +109,7 @@ class TestResolveModifiers(object):
         monkeypatch.setattr("brewtils.display.requests", requests_mock)
 
         with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), Mock(), **args)
+            resolve_display_modifiers(Mock(), **args)
 
     @pytest.mark.parametrize(
         "args", [{"schema": "./test"}, {"form": "./test"}, {"template": "./test"}]
@@ -120,4 +120,4 @@ class TestResolveModifiers(object):
         monkeypatch.setattr("brewtils.display.open", open_mock)
 
         with pytest.raises(PluginParamError):
-            resolve_display_modifiers(Mock(), Mock(), **args)
+            resolve_display_modifiers(Mock(), **args)

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -469,7 +469,7 @@ class TestInitializeSystem(object):
             description=bg_system.description,
             icon_name=bg_system.icon_name,
             display_name=bg_system.display_name,
-            template="./template.html",
+            template="<html>template</html>",
         )
         # assert ez_client.create_system.return_value == plugin.system
 
@@ -497,7 +497,7 @@ class TestInitializeSystem(object):
             description=bg_system.description,
             icon_name=bg_system.icon_name,
             display_name=bg_system.display_name,
-            template="./template.html",
+            template="<html>template</html>",
             add_instance=ANY,
         )
         assert ez_client.update_system.call_args[1]["add_instance"].name == new_name

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -453,6 +453,7 @@ class TestInitializeSystem(object):
             instances=[bg_instance],
             commands=current_commands,
             metadata={"foo": "bar"},
+            template=None,
         )
         ez_client.find_unique_system.return_value = existing_system
 
@@ -468,6 +469,7 @@ class TestInitializeSystem(object):
             description=bg_system.description,
             icon_name=bg_system.icon_name,
             display_name=bg_system.display_name,
+            template="./template.html",
         )
         # assert ez_client.create_system.return_value == plugin.system
 
@@ -479,6 +481,7 @@ class TestInitializeSystem(object):
             instances=[bg_instance],
             max_instances=2,
             metadata={"foo": "bar"},
+            template=None,
         )
         ez_client.find_unique_system.return_value = existing_system
 
@@ -494,6 +497,7 @@ class TestInitializeSystem(object):
             description=bg_system.description,
             icon_name=bg_system.icon_name,
             display_name=bg_system.display_name,
+            template="./template.html",
             add_instance=ANY,
         )
         assert ez_client.update_system.call_args[1]["add_instance"].name == new_name


### PR DESCRIPTION
This is part of beer-garden/beer-garden#997, system templates.

This moves some pieces out of the `decorators` module into the new `display` module. It also breaks apart the `_resolve_display_modifiers` function into separate functions. This helps with organization (because systems only need to resolve templates) and testability.

It also improves the tests somewhat, using actual file fixtures instead of patching the `open` function.

The largest wrinkle here was determining how to handle relative paths in a sensible way. I'm going to just copy/paste the `_load_from_path` docstring here:

    Load a definition from a path

    This is a little odd because of the differences between command-level resources and
    system-level ones and the need to be backwards-compatible.

    The problem is determining the "correct" base to use when a relative path is given.
    For command resources we're able to use ``inspect`` on the method object to
    determine the current module file. So we've always just used the directory
    containing that file as the base for relative paths.

    However, we don't have that ability when it comes to system resources. For example,
    supposed the system template is specified in an environment variable:

      BG_SYSTEM_TEMPLATE=./resources/template.html

    The only thing that really makes sense in this case is starting in the plugin's
    current working directory. In hindsight, we probably should have done that for
    command resources as well.

    Finally, having ONLY system resources start at cwd and ONLY command resources be
    dependent on the file in which they're declared would be extremely confusing.

    So in an attempt to remain compatible this will attempt to use a provided base_dir
    as the starting point for relative path resolution. If there's no file there then it
    will re-resolve the path, this time using the cwd as he starting point. If no
    base_dir is provided then it'll just use the cwd.

    Going forward this will hopefully allow us to present using the cwd as a best
    practice for everything without forcing anyone to rewrite their plugins.