### PR TITLE
Handling display response content-type header with a charset

### DIFF
--- a/brewtils/display.py
+++ b/brewtils/display.py
@@ -94,8 +94,8 @@ def _load_from_url(url):
     # Use a RestClient's session since TLS will (hopefully) be configured
     response = RestClient(bg_host="").session.get(url)
 
-    if response.headers.get("content-type", "").lower() == "application/json":
-        return json.loads(response.text)
+    if "application/json" in response.headers.get("content-type", "").lower():
+        return response.json()
     return response.text
 
 

--- a/test/display_test.py
+++ b/test/display_test.py
@@ -55,7 +55,7 @@ class TestResolveSchema(object):
         requests_mock.get(
             url,
             json=schema,
-            headers={"content-type": "application/json"},
+            headers={"content-type": "application/json; charset=utf-8"},
         )
 
         assert resolve_schema(url) == schema
@@ -94,7 +94,7 @@ class TestResolveForm(object):
         requests_mock.get(
             url,
             json=form,
-            headers={"content-type": "application/json"},
+            headers={"content-type": "application/json; charset=utf-8"},
         )
 
         assert resolve_form(url) == form


### PR DESCRIPTION
Fixes beer-garden/beer-garden#1010, better handling for url display response content-type header.