### PR TITLE
Adding timeout field to job model

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1128,6 +1128,7 @@ class Job(BaseModel):
         error_count=None,
         status=None,
         max_instances=None,
+        timeout=None,
     ):
         self.id = id
         self.name = name
@@ -1141,6 +1142,7 @@ class Job(BaseModel):
         self.error_count = error_count
         self.status = status
         self.max_instances = max_instances
+        self.timeout = timeout
 
     def __str__(self):
         return "%s: %s" % (self.name, self.id)

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -468,6 +468,7 @@ class JobSchema(BaseSchema):
     error_count = fields.Int(allow_none=True)
     status = fields.Str(allow_none=True)
     max_instances = fields.Int(allow_none=True)
+    timeout = fields.Int(allow_none=True)
 
 
 class OperationSchema(BaseSchema):

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -553,6 +553,7 @@ def job_dict(ts_epoch, request_template_dict, date_trigger_dict):
         "error_count": 0,
         "status": "RUNNING",
         "max_instances": 3,
+        "timeout": 30,
     }
 
 


### PR DESCRIPTION
Part of beer-garden/beer-garden#1046. Adds a `timeout` field to the job model.