### PR TITLE
Add proxy parameters to RestClient session

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -124,6 +124,12 @@ class RestClient(object):
         # Configure the session to use when making requests
         self.session = Session()
 
+        if self._config.proxy:
+            if self._config.ssl_enabled:
+                self.session.proxies.update({"https": self._config.proxy})
+            else:
+                self.session.proxies.update({"http": self._config.proxy})
+
         # This is what Requests is expecting
         if self._config.client_key:
             self.session.cert = (self._config.client_cert, self._config.client_key)

--- a/brewtils/specification.py
+++ b/brewtils/specification.py
@@ -96,6 +96,16 @@ _CONNECTION_SPEC = {
         "description": "Refresh token for authentication",
         "required": False,
     },
+    "proxy": {
+        "type": "str",
+        "description": "HTTP proxy to use when communicating with Beergarden",
+        "long_description": "Proxy information should be given in the format "
+        "of `<hostname>:<port>`. This setting will overwrite default proxy "
+        "set by the HTTP(s)_PROXY environment variable. Use of SSL for this "
+        "proxy will be determined by the ssl_enabled config option.",
+        "default": "",
+        "required": False,
+    },
 }
 
 _SYSTEM_SPEC = {

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -34,6 +34,7 @@ def params():
         "access_token": None,
         "refresh_token": None,
         "client_timeout": -1.0,
+        "proxy": "",
     }
 
 

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -73,6 +73,28 @@ class TestRestClient(object):
         assert client.bg_host == "localhost"
         assert client.bg_port == 3000
 
+    def test_proxy_config_no_ssl(self, monkeypatch):
+        proxy = "test:1234"
+
+        brewtils.plugin.CONFIG.bg_host = "localhost"
+        brewtils.plugin.CONFIG.bg_port = 3000
+        brewtils.plugin.CONFIG.ssl_enabled = False
+        brewtils.plugin.CONFIG.proxy = proxy
+
+        client = RestClient()
+        assert client.session.proxies["http"] == proxy
+
+    def test_proxy_config_ssl(self, monkeypatch):
+        proxy = "test:1234"
+
+        brewtils.plugin.CONFIG.bg_host = "localhost"
+        brewtils.plugin.CONFIG.bg_port = 3000
+        brewtils.plugin.CONFIG.ssl_enabled = True
+        brewtils.plugin.CONFIG.proxy = proxy
+
+        client = RestClient()
+        assert client.session.proxies["https"] == proxy
+
     def test_non_versioned_uris(self, client, url_prefix):
         assert client.version_url == "http://host:80" + url_prefix + "version"
         assert client.config_url == "http://host:80" + url_prefix + "config"


### PR DESCRIPTION
Closes #336

Allow users to specify a proxy when initializing a RestClient, overwriting any pre-existing environment variable that the session would take by default.

## To test:
- Use `export HTTP_PROXY="test"` to create an environment variable that Session will take by default.
- Create a default `brewtils.rest.client.RestClient()` session and ensure that the `client.session.proxies` includes your environment variable as its proxy.
- Create another `brewtils.rest.client.RestClient()` session with the kwarg `http_proxy="test2"`. Ensure this new client sets `client.session.proxies` with the domain specified in your kwarg. 

`export -n HTTP_PROXY` will remove your environment variable. Keeping this variable in your env will make you fail some unit tests in `test/display_test.py`