### PR TITLE
Add RestClient support for creating/deleting/getting gardens

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -9,6 +9,7 @@ from base64 import b64encode
 import jwt
 import requests.exceptions
 import urllib3
+from urllib.parse import quote_plus
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
 from yapconf import YapconfSpec
@@ -155,6 +156,7 @@ class RestClient(object):
         self.config_url = self.base_url + "config"
 
         if self.api_version == 1:
+            self.garden_url = self.base_url + "api/v1/gardens/"
             self.system_url = self.base_url + "api/v1/systems/"
             self.instance_url = self.base_url + "api/v1/instances/"
             self.command_url = self.base_url + "api/v1/commands/"
@@ -297,6 +299,52 @@ class RestClient(object):
             Requests Response object
         """
         return self.session.get(self.logging_url, params=kwargs)
+
+    @enable_auth
+    def get_garden(self, garden_name, **kwargs):
+        # type: (str, **Any) -> Response
+        """Performs a GET on the Garden URL
+
+        Args:
+            garden_name: Name of garden to retreive
+            **kwargs: Query parameters to be used in the GET request
+
+        Returns:
+            Requests Response object
+        """
+        # quote_plus will URL encode the Garden name
+        return self.session.get(
+            self.garden_url + quote_plus(garden_name), params=kwargs
+        )
+
+    @enable_auth
+    def post_gardens(self, payload):
+        # type: (str) -> Response
+        """Performs a POST on the Garden URL
+
+        Args:
+            payload: New Garden definition
+
+        Returns:
+            Requests Response object
+        """
+        return self.session.post(
+            self.garden_url, data=payload, headers=self.JSON_HEADERS
+        )
+
+    @enable_auth
+    def delete_garden(self, garden_name):
+        # type: (str) -> Response
+        """Performs a DELETE on a Garden URL
+
+        Args:
+            garden_name: Name of Garden to delete
+
+        Returns:
+            Requests Response object
+        """
+        # quote_plus will URL encode the Garden name
+        return self.session.delete(self.garden_url + quote_plus(garden_name))
 
     @enable_auth
     def get_systems(self, **kwargs):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -9,7 +9,6 @@ from base64 import b64encode
 import jwt
 import requests.exceptions
 import urllib3
-from urllib.parse import quote_plus
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
 from yapconf import YapconfSpec
@@ -18,6 +17,11 @@ import brewtils.plugin
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
+
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
 
 
 def enable_auth(method):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -10,6 +10,7 @@ import jwt
 import requests.exceptions
 import urllib3
 from requests import Response, Session
+from requests.utils import quote
 from requests.adapters import HTTPAdapter
 from yapconf import YapconfSpec
 
@@ -17,11 +18,6 @@ import brewtils.plugin
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
-
-try:
-    from urllib.parse import quote_plus
-except ImportError:
-    from urllib import quote_plus
 
 
 def enable_auth(method):
@@ -316,10 +312,8 @@ class RestClient(object):
         Returns:
             Requests Response object
         """
-        # quote_plus will URL encode the Garden name
-        return self.session.get(
-            self.garden_url + quote_plus(garden_name), params=kwargs
-        )
+        # quote will URL encode the Garden name
+        return self.session.get(self.garden_url + quote(garden_name), params=kwargs)
 
     @enable_auth
     def post_gardens(self, payload):
@@ -347,8 +341,8 @@ class RestClient(object):
         Returns:
             Requests Response object
         """
-        # quote_plus will URL encode the Garden name
-        return self.session.delete(self.garden_url + quote_plus(garden_name))
+        # quote will URL encode the Garden name
+        return self.session.delete(self.garden_url + quote(garden_name))
 
     @enable_auth
     def get_systems(self, **kwargs):

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -186,9 +186,7 @@ class TestRestClient(object):
 
     def test_get_garden(self, client, session_mock):
         client.get_garden("name!")
-        session_mock.get.assert_called_with(
-            client.garden_url + "name%21", params={}
-        )
+        session_mock.get.assert_called_with(client.garden_url + "name%21", params={})
 
     def test_post_garden(self, client, session_mock):
         client.post_gardens(payload="payload")

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -184,6 +184,22 @@ class TestRestClient(object):
             assert len(w) == 1
             assert w[0].category == DeprecationWarning
 
+    def test_get_garden(self, client, session_mock):
+        client.get_garden("name!")
+        session_mock.get.assert_called_with(
+            client.garden_url + "name%21", params={}
+        )
+
+    def test_post_garden(self, client, session_mock):
+        client.post_gardens(payload="payload")
+        session_mock.post.assert_called_with(
+            client.garden_url, data="payload", headers=client.JSON_HEADERS
+        )
+
+    def test_delete_garden(self, client, session_mock):
+        client.delete_garden("name!")
+        session_mock.delete.assert_called_with(client.garden_url + "name%21")
+
     def test_get_system_1(self, client, session_mock):
         client.get_system("id")
         session_mock.get.assert_called_with(client.system_url + "id", params={})


### PR DESCRIPTION
Closes #342 

Added unit tests for this as well. Updating the `EasyClient` to be able to interface with these new `RestClient` calls can go on a separate PR, as it will also need its own unit tests. All requests send here will URL encode if necessary.

## To Test
- Run the unit tests
- Create gardens within Beergarden's UI, then delete them by name with `delete_garden`
- Create gardens within Beergarden's UI, then fetch them with `get_garden`

Testing `post_gardens` is more complex without `EasyClient`:
- Create a garden using `brewtils.model.Garden`
- Convert the garden model to JSON using `SchemaParser.serialize_garden`
- Call `post_gardens` with this JSON model to create a garden