### PR TITLE
Add URL encoding to Queue deletion in RestClient

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -10,6 +10,7 @@ import jwt
 import requests.exceptions
 import urllib3
 from requests import Response, Session
+from requests.utils import quote
 from requests.adapters import HTTPAdapter
 from yapconf import YapconfSpec
 
@@ -17,8 +18,6 @@ import brewtils.plugin
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
-
-from requests.utils import quote
 
 
 def enable_auth(method):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -18,10 +18,7 @@ from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
 
-try:
-    from urllib.parse import quote_plus
-except ImportError:
-    from urllib import quote_plus
+from requests.utils import quote
 
 
 def enable_auth(method):
@@ -553,7 +550,7 @@ class RestClient(object):
         Returns:
             Requests Response object
         """
-        return self.session.delete(self.queue_url + quote_plus(queue_name))
+        return self.session.delete(self.queue_url + quote(queue_name))
 
     @enable_auth
     def get_jobs(self, **kwargs):

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -18,6 +18,11 @@ from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
 
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
+
 
 def enable_auth(method):
     """Decorate methods with this to enable using authentication"""
@@ -548,7 +553,7 @@ class RestClient(object):
         Returns:
             Requests Response object
         """
-        return self.session.delete(self.queue_url + queue_name)
+        return self.session.delete(self.queue_url + quote_plus(queue_name))
 
     @enable_auth
     def get_jobs(self, **kwargs):

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -276,8 +276,8 @@ class TestRestClient(object):
         session_mock.delete.assert_called_with(client.queue_url)
 
     def test_delete_queue(self, client, session_mock):
-        client.delete_queue("queue_name")
-        session_mock.delete.assert_called_with(client.queue_url + "queue_name")
+        client.delete_queue("queue_name!")
+        session_mock.delete.assert_called_with(client.queue_url + "queue_name%21")
 
     def test_get_jobs(self, client, session_mock):
         client.get_jobs(key="value")


### PR DESCRIPTION
Closes #339 

Unit test for `delete_queue` updated as well. This PR may conflict with PR #343, since it's trying to add an import used in that code as well. It should resolve itself automatically, but I'm unsure.