### PR TITLE
#348 - Add EasyClient support for getting/creating/destroying gardens

### DIFF
--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -273,21 +273,14 @@ class EasyClient(object):
         Returns:
             bool: True if removal was successful
 
-        Raises:
-            FetchError: Couldn't find a System matching given parameters
-
         """
-        garden = self.get_garden(garden_name)
-
-        if garden is None:
-            raise FetchError("No matching Garden found")
-        return self.client.delete_garden(garden_name)
+        return self.client.delete_garden(garden_name).ok
 
     @wrap_response(
         parse_method="parse_system", parse_many=False, default_exc=FetchError
     )
-    def get_system(self, system_id, **kwargs):
-        """Get a System
+    def get_system(self, system_id):
+        """Get a Garden
 
         Args:
             system_id: The Id
@@ -296,7 +289,7 @@ class EasyClient(object):
             The System
 
         """
-        return self.client.get_system(system_id, **kwargs)
+        return self.client.get_system(system_id)
 
     def find_unique_system(self, **kwargs):
         """Find a unique system

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -237,6 +237,53 @@ class EasyClient(object):
         return self.client.get_logging_config(local=local)
 
     @wrap_response(
+        parse_method="parse_garden", parse_many=False, default_exc=FetchError
+    )
+    def get_garden(self, garden_name, **kwargs):
+        """Get a System
+
+        Args:
+            garden_name: Name of garden to retrieve
+
+        Returns:
+            The Garden
+
+        """
+        return self.client.get_garden(garden_name, **kwargs)
+
+    @wrap_response(parse_method="parse_garden", parse_many=False, default_exc=SaveError)
+    def create_garden(self, garden):
+        """Create a new Garden
+
+        Args:
+            garden (Garden): The Garden to create
+
+        Returns:
+            Garden: The newly-created Garden
+
+        """
+        return self.client.post_gardens(SchemaParser.serialize_garden(garden))
+
+    def remove_garden(self, garden_name):
+        """Remove a unique Garden
+
+        Args:
+            garden_name (String): Name of Garden to remove
+
+        Returns:
+            bool: True if removal was successful
+
+        Raises:
+            FetchError: Couldn't find a System matching given parameters
+
+        """
+        garden = self.get_garden(garden_name)
+
+        if garden is None:
+            raise FetchError("No matching Garden found")
+        return self.client.delete_garden(garden_name)
+
+    @wrap_response(
         parse_method="parse_system", parse_many=False, default_exc=FetchError
     )
     def get_system(self, system_id, **kwargs):

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -275,7 +275,7 @@ class EasyClient(object):
             bool: True if removal was successful
 
         Raises:
-            FetchError: Couldn't find a System matching given parameters
+            NotFoundError: Couldn't find a Garden matching given name
 
         """
         return self.client.delete_garden(garden_name)

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -239,8 +239,8 @@ class EasyClient(object):
     @wrap_response(
         parse_method="parse_garden", parse_many=False, default_exc=FetchError
     )
-    def get_garden(self, garden_name, **kwargs):
-        """Get a System
+    def get_garden(self, garden_name):
+        """Get a Garden 
 
         Args:
             garden_name: Name of garden to retrieve
@@ -249,7 +249,7 @@ class EasyClient(object):
             The Garden
 
         """
-        return self.client.get_garden(garden_name, **kwargs)
+        return self.client.get_garden(garden_name)
 
     @wrap_response(parse_method="parse_garden", parse_many=False, default_exc=SaveError)
     def create_garden(self, garden):
@@ -264,6 +264,7 @@ class EasyClient(object):
         """
         return self.client.post_gardens(SchemaParser.serialize_garden(garden))
 
+    @wrap_response(return_boolean=True, raise_404=True)
     def remove_garden(self, garden_name):
         """Remove a unique Garden
 
@@ -277,10 +278,7 @@ class EasyClient(object):
             FetchError: Couldn't find a System matching given parameters
 
         """
-        if self.client.delete_garden(garden_name).ok:
-            return True
-        else:
-            raise FetchError
+        return self.client.delete_garden(garden_name)
 
     @wrap_response(
         parse_method="parse_system", parse_many=False, default_exc=FetchError

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -273,8 +273,14 @@ class EasyClient(object):
         Returns:
             bool: True if removal was successful
 
+        Raises:
+            FetchError: Couldn't find a System matching given parameters
+
         """
-        return self.client.delete_garden(garden_name).ok
+        if self.client.delete_garden(garden_name).ok:
+            return True
+        else:
+            raise FetchError
 
     @wrap_response(
         parse_method="parse_system", parse_many=False, default_exc=FetchError

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -240,7 +240,7 @@ class EasyClient(object):
         parse_method="parse_garden", parse_many=False, default_exc=FetchError
     )
     def get_garden(self, garden_name):
-        """Get a Garden 
+        """Get a Garden
 
         Args:
             garden_name: Name of garden to retrieve

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -149,7 +149,8 @@ class TestGardens(object):
         def test_not_found(self, monkeypatch, client, rest_client, not_found, bg_garden):
             monkeypatch.setattr(rest_client, "delete_garden", Mock(return_value=not_found))
 
-            assert client.remove_garden(bg_garden.name) == False
+            with pytest.raises(FetchError):
+                client.remove_garden(bg_garden.name)
 
 
 class TestSystems(object):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -119,6 +119,41 @@ def test_get_logging_config(client, rest_client, parser, success):
     assert client.get_logging_config() == success.json()
 
 
+class TestGardens(object):
+    class TestGet(object):
+        def test_success(self, client, rest_client, bg_garden, success, parser):
+            rest_client.get_garden.return_value = success
+            parser.parse_garden.return_value = bg_garden
+
+            assert client.get_garden(bg_garden.name) == bg_garden
+
+        def test_404(self, client, rest_client, bg_garden, not_found):
+            rest_client.get_garden.return_value = not_found
+
+            with pytest.raises(NotFoundError):
+                client.get_garden(bg_garden.name)
+
+    def test_create(self, client, rest_client, success, bg_garden):
+        rest_client.post_gardens.return_value = success
+        client.create_garden(bg_garden)
+        assert rest_client.post_gardens.called is True
+
+    class TestRemove(object):
+        def test_name(self, monkeypatch, client, rest_client, success, bg_garden):
+            monkeypatch.setattr(client, "get_garden", Mock(return_value=[bg_garden]))
+            rest_client.get_garden.return_value = success
+
+            client.remove_garden(bg_garden.name)
+            rest_client.delete_garden.assert_called_once_with(bg_garden.name)
+
+        def test_not_found(self, monkeypatch, client, rest_client, success, bg_garden):
+            monkeypatch.setattr(client, "get_garden", Mock(return_value=None))
+            rest_client.get_garden.return_value = success
+
+            with pytest.raises(FetchError):
+                client.remove_garden(bg_garden.name)
+
+
 class TestSystems(object):
     class TestGet(object):
         def test_success(self, client, rest_client, bg_system, success, parser):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -146,8 +146,12 @@ class TestGardens(object):
             client.remove_garden(bg_garden.name)
             rest_client.delete_garden.assert_called_once_with(bg_garden.name)
 
-        def test_not_found(self, monkeypatch, client, rest_client, not_found, bg_garden):
-            monkeypatch.setattr(rest_client, "delete_garden", Mock(return_value=not_found))
+        def test_not_found(
+            self, monkeypatch, client, rest_client, not_found, bg_garden
+        ):
+            monkeypatch.setattr(
+                rest_client, "delete_garden", Mock(return_value=not_found)
+            )
 
             with pytest.raises(FetchError):
                 client.remove_garden(bg_garden.name)

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -153,7 +153,7 @@ class TestGardens(object):
                 rest_client, "delete_garden", Mock(return_value=not_found)
             )
 
-            with pytest.raises(FetchError):
+            with pytest.raises(NotFoundError):
                 client.remove_garden(bg_garden.name)
 
 

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -146,12 +146,10 @@ class TestGardens(object):
             client.remove_garden(bg_garden.name)
             rest_client.delete_garden.assert_called_once_with(bg_garden.name)
 
-        def test_not_found(self, monkeypatch, client, rest_client, success, bg_garden):
-            monkeypatch.setattr(client, "get_garden", Mock(return_value=None))
-            rest_client.get_garden.return_value = success
+        def test_not_found(self, monkeypatch, client, rest_client, not_found, bg_garden):
+            monkeypatch.setattr(rest_client, "delete_garden", Mock(return_value=not_found))
 
-            with pytest.raises(FetchError):
-                client.remove_garden(bg_garden.name)
+            assert client.remove_garden(bg_garden.name) == False
 
 
 class TestSystems(object):


### PR DESCRIPTION
Closes #348 

## To Test
- Run the unit tests
- Create an EasyClient instance
- Create a Garden in the UI, fetch it by name with `get_garden`
- Remove the Garden by name with `remove_garden`
- Create a `brewtils.models.Garden` object, then call `create_garden` with it to create a garden