### PR TITLE
#354 - Better define RoleAssignmentSchema domain field

### DIFF
--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -42,6 +42,9 @@ __all__ = [
     "UserListSchema",
     "RoleSchema",
     "RoleAssignmentSchema",
+    "RoleAssignmentDomainSchema",
+    "GardenDomainIdentifierSchema",
+    "SystemDomainIdentifierSchema",
 ]
 
 # This will be updated after all the schema classes are defined


### PR DESCRIPTION
Closes #354 

This updates the domain field of the `RoleAssignmentSchema` to be a nested schema field rather than string.  The original string definition was something of placeholder since the format for domain hadn't been defined. The schema's in this PR codify the domain field format as:

```python
{ "scope": "string", "identifier": {} }
```
And `identifier` can be one of the following:
```python
# for scope == "Garden"
{ "name": "string"}

# for scope == "System"
{ "name": "string", "version": "string", "namespace": "string" }
```

# Testing Instructions
These changes get used in the changes for [beer-garden #1122](https://github.com/beer-garden/beer-garden/pull/1127), so the unit tests over there should be passing.  I did also add unit tests here, just because there is the custom schema selector function which ought to be tested.

If you want to use the schemas yourself and test the validation based on `scope`, you can do the following in a shell:

```python
from brewtils.schemas import RoleAssignmentSchema

schema = RoleAssignmentSchema()
role = {"name": "myrole", "permissions": ["perm1"]}
domain = {"scope": "Garden", "identifiers": {"name": "mygarden"}}
role_assignment = {"role": role, "domain": domain}

schema.load(role_assignment) # should succeed

# Let's change the scope to System and see that we're now missing a required field because the schema
# for the identifiers has changed based on scope == "System"
domain["scope"] = "System"
schema.load(role_assignment)  # throws ValidationError

# Let's add the missing field and try again
domain["identifiers"]["namespace"] = "mygarden"
schema.load(role_assignment) # should succeed

# Let's make sure serialization works for good measure
schema.dumps(role_assignment)
```