### PR TITLE
#364 - Add support for global permission scope in RoleAssignmentSchema

### DIFF
--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -77,6 +77,7 @@ def _domain_identifier_schema_selector(_, role_assignment_domain):
     scope_schema_map = {
         "Garden": GardenDomainIdentifierSchema,
         "System": SystemDomainIdentifierSchema,
+        "Global": Schema,
     }
 
     if isinstance(role_assignment_domain, dict):
@@ -575,7 +576,7 @@ class RoleAssignmentDomainSchema(BaseSchema):
     identifiers = PolyField(
         serialization_schema_selector=_domain_identifier_schema_selector,
         deserialization_schema_selector=_domain_identifier_schema_selector,
-        required=True,
+        required=False,
     )
 
 

--- a/test/schema_test.py
+++ b/test/schema_test.py
@@ -122,6 +122,14 @@ class TestRoleAssignmentSchema(object):
 
         yield role_assignment
 
+    @pytest.fixture
+    def role_assignment_global_scope(self):
+        role = {"name": "myrole", "permissions": ["perm1"]}
+        domain = {"scope": "Global"}
+        role_assignment = {"role": role, "domain": domain}
+
+        yield role_assignment
+
     def test_role_assignment_domain_schema_can_deserialize_garden_scope(
         self, schema, role_assignment_garden_scope
     ):
@@ -138,12 +146,28 @@ class TestRoleAssignmentSchema(object):
             == role_assignment_system_scope
         )
 
+    def test_role_assignment_domain_schema_can_deserialize_global_scope(
+        self, schema, role_assignment_global_scope
+    ):
+        assert (
+            schema.load(role_assignment_global_scope).data
+            == role_assignment_global_scope
+        )
+
     def test_role_assignment_domain_schema_can_serialize(
         self, schema, role_assignment_garden_scope
     ):
         assert (
             schema.dump(role_assignment_garden_scope).data
             == role_assignment_garden_scope
+        )
+
+    def test_role_assignment_domain_schema_can_serialize_global_scope(
+        self, schema, role_assignment_global_scope
+    ):
+        assert (
+            schema.dump(role_assignment_global_scope).data
+            == role_assignment_global_scope
         )
 
     def test_role_assignment_domain_schema_validates_identifiers(


### PR DESCRIPTION
Closes #364 

This is a minor set of changes that accommodates the addition of the "Global" scope that is added in beer-garden/beer-garden#1169.

# Test Instructions
This change is pretty straightforward and there are new unit tests to cover the change.

The easiest way to functionally test this is to test beer-garden/beer-garden#1169 while using this branch of brewtils and then using the `/api/v1/users` api endpoint to retrieve a user that has a role assignment for the "Global" scope.  If the results return correctly, then this change is doing what it intends.