### PR TITLE
#358 - Add status_updated_at field to Request model

### DIFF
--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-
 from enum import Enum
 
 import pytz  # noqa # not in requirements file
@@ -703,7 +701,6 @@ class Request(RequestTemplate):
 
     @status.setter
     def status(self, value):
-        self.status_updated_at = datetime.now()
         self._status = value
 
     @property

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
+
 from enum import Enum
 
 import pytz  # noqa # not in requirements file
@@ -635,6 +637,7 @@ class Request(RequestTemplate):
         metadata=None,
         hidden=None,
         updated_at=None,
+        status_updated_at=None,
         has_parent=None,
         requester=None,
     ):
@@ -658,6 +661,7 @@ class Request(RequestTemplate):
         self.hidden = hidden
         self.created_at = created_at
         self.updated_at = updated_at
+        self.status_updated_at = status_updated_at
         self.error_class = error_class
         self.has_parent = has_parent
         self.requester = requester
@@ -699,6 +703,7 @@ class Request(RequestTemplate):
 
     @status.setter
     def status(self, value):
+        self.status_updated_at = datetime.now()
         self._status = value
 
     @property

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -338,6 +338,7 @@ class RequestSchema(RequestTemplateSchema):
     error_class = fields.Str(allow_none=True)
     created_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
     updated_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
+    status_updated_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
     has_parent = fields.Bool(allow_none=True)
     requester = fields.String(allow_none=True)
 

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -338,7 +338,9 @@ class RequestSchema(RequestTemplateSchema):
     error_class = fields.Str(allow_none=True)
     created_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
     updated_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
-    status_updated_at = DateTime(allow_none=True, format="epoch", example="1500065932000")
+    status_updated_at = DateTime(
+        allow_none=True, format="epoch", example="1500065932000"
+    )
     has_parent = fields.Bool(allow_none=True)
     requester = fields.String(allow_none=True)
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -290,6 +290,7 @@ def child_request_dict(ts_epoch):
         "command_type": "ACTION",
         "created_at": ts_epoch,
         "updated_at": ts_epoch,
+        "status_updated_at": ts_epoch,
         "error_class": None,
         "metadata": {"child": "stuff"},
         "has_parent": True,
@@ -303,6 +304,7 @@ def child_request(child_request_dict, ts_dt):
     dict_copy = copy.deepcopy(child_request_dict)
     dict_copy["created_at"] = ts_dt
     dict_copy["updated_at"] = ts_dt
+    dict_copy["status_updated_at"] = ts_dt
     return Request(**dict_copy)
 
 
@@ -326,6 +328,7 @@ def parent_request_dict(ts_epoch):
         "created_at": ts_epoch,
         "hidden": False,
         "updated_at": ts_epoch,
+        "status_updated_at": ts_epoch,
         "error_class": None,
         "metadata": {"parent": "stuff"},
         "has_parent": False,
@@ -339,6 +342,7 @@ def parent_request(parent_request_dict, ts_dt):
     dict_copy = copy.deepcopy(parent_request_dict)
     dict_copy["created_at"] = ts_dt
     dict_copy["updated_at"] = ts_dt
+    dict_copy["status_updated_at"] = ts_dt
     return Request(**dict_copy)
 
 
@@ -386,6 +390,7 @@ def request_dict(parent_request_dict, child_request_dict, ts_epoch):
         "command_type": "ACTION",
         "created_at": ts_epoch,
         "updated_at": ts_epoch,
+        "status_updated_at": ts_epoch,
         "error_class": "ValueError",
         "metadata": {"request": "stuff"},
         "has_parent": True,
@@ -401,6 +406,7 @@ def bg_request(request_dict, parent_request, child_request, ts_dt):
     dict_copy["children"] = [child_request]
     dict_copy["created_at"] = ts_dt
     dict_copy["updated_at"] = ts_dt
+    dict_copy["status_updated_at"] = ts_dt
     return Request(**dict_copy)
 
 

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -341,6 +341,11 @@ class TestRequest(object):
             if key != "command_type":
                 assert getattr(request, key) == getattr(bg_request_template, key)
 
+    def test_status_updated_at(self, request1):
+        first_time = request1.status_updated_at
+        request1.status = "RECEIVED"
+        assert first_time is not request1.status_updated_at
+
 
 class TestSystem(object):
     def test_get_command_by_name(self, bg_system, bg_command):

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -341,11 +341,6 @@ class TestRequest(object):
             if key != "command_type":
                 assert getattr(request, key) == getattr(bg_request_template, key)
 
-    def test_status_updated_at(self, request1):
-        first_time = request1.status_updated_at
-        request1.status = "RECEIVED"
-        assert first_time is not request1.status_updated_at
-
 
 class TestSystem(object):
     def test_get_command_by_name(self, bg_system, bg_command):


### PR DESCRIPTION
Closes #358

Adds `status_updated_at` field to Request model, which is *updated in the setter function for `status`*. The only time this change would be problematic would be if a request were manually being copied and ended up using something like `new_request.status = old_request.status` or something like that, which would update the time.