### PR TITLE
#366 - Update auth token handling

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -172,7 +172,8 @@ class RestClient(object):
             self.job_url = self.base_url + "api/v1/jobs/"
             self.job_export_url = self.base_url + "api/v1/export/jobs/"
             self.job_import_url = self.base_url + "api/v1/import/jobs/"
-            self.token_url = self.base_url + "api/v1/tokens/"
+            self.token_url = self.base_url + "api/v1/token/"
+            self.token_refresh_url = self.base_url + "api/v1/token/refresh/"
             self.user_url = self.base_url + "api/v1/users/"
             self.admin_url = self.base_url + "api/v1/admin/"
             self.forward_url = self.base_url + "api/v1/forward"
@@ -910,7 +911,7 @@ class RestClient(object):
         if response.ok:
             response_data = response.json()
 
-            self.access_token = response_data["token"]
+            self.access_token = response_data["access"]
             self.refresh_token = response_data["refresh"]
             self.session.headers["Authorization"] = "Bearer " + self.access_token
 
@@ -927,19 +928,17 @@ class RestClient(object):
             Requests Response object
         """
         refresh_token = refresh_token or self.refresh_token
-        response = self.session.get(
-            self.token_url, headers={"X-BG-RefreshID": refresh_token}
+        response = self.session.post(
+            self.token_refresh_url,
+            headers={"Content-Type": "application/json"},
+            json={"refresh": refresh_token},
         )
-
-        # On older versions of the API (2.4.2 and below) the new refresh token
-        # is not available.
-        if response.status_code == 404:
-            response = self.session.get(self.token_url + refresh_token)
 
         if response.ok:
             response_data = response.json()
 
-            self.access_token = response_data["token"]
+            self.access_token = response_data["access"]
+            self.refresh_token = response_data["refresh"]
             self.session.headers["Authorization"] = "Bearer " + self.access_token
 
         return response

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -29,6 +29,8 @@ class TestRestClient(object):
             bg_port=80,
             api_version=1,
             url_prefix=url_prefix,
+            username="admin",
+            password="secret",
             ssl_enabled=False,
         )
         client.session = session_mock
@@ -111,7 +113,6 @@ class TestRestClient(object):
             ("logging_config_url", "http://host:80%sapi/v1/config/logging/"),
             ("job_url", "http://host:80%sapi/v1/jobs/"),
             ("token_url", "http://host:80%sapi/v1/token/"),
-            ("token_refresh_url", "http://host:80%sapi/v1/token/refresh/"),
             ("user_url", "http://host:80%sapi/v1/users/"),
             ("admin_url", "http://host:80%sapi/v1/admin/"),
         ],
@@ -131,7 +132,6 @@ class TestRestClient(object):
             ("logging_config_url", "https://host:80%sapi/v1/config/logging/"),
             ("job_url", "https://host:80%sapi/v1/jobs/"),
             ("token_url", "https://host:80%sapi/v1/token/"),
-            ("token_refresh_url", "https://host:80%sapi/v1/token/refresh/"),
             ("user_url", "https://host:80%sapi/v1/users/"),
             ("admin_url", "https://host:80%sapi/v1/admin/"),
         ],
@@ -368,7 +368,19 @@ class TestRestClient(object):
             client.token_url, data=json.dumps(kwargs), headers=ANY
         )
         assert client.access_token == "access"
-        assert client.refresh_token == "refresh"
+
+    def test_get_authenticate_and_retry(self, client, session_mock):
+        response401 = Mock(status_code=401)
+        response200 = Mock(status_code=200)
+        post_response = Mock(ok=True)
+        post_response.json.return_value = {"access": "access", "refresh": "refresh"}
+
+        session_mock.get.side_effect = [response401, response200]
+        session_mock.post.return_value = post_response
+        client.get_systems()
+
+        assert session_mock.get.call_count == 2
+        session_mock.post.assert_any_call(client.token_url, headers=ANY, data=ANY)
 
     def test_get_chunked_file(self, client, session_mock):
         client.get_chunked_file("id")
@@ -400,16 +412,6 @@ class TestRestClient(object):
         session_mock.patch.assert_called_with(
             client.admin_url, data="payload", headers=client.JSON_HEADERS
         )
-
-    def test_refresh(self, client, session_mock):
-        response = Mock(ok=True)
-        response.json.return_value = {"access": "new_access", "refresh": "new_refresh"}
-        session_mock.post.return_value = response
-
-        client.refresh(refresh_token="refresh")
-
-        assert client.access_token == "new_access"
-        assert client.refresh_token == "new_refresh"
 
     def test_session_client_cert(self):
         client = RestClient(


### PR DESCRIPTION
Closes #366 
This isn't really functionally testable until beer-garden/beer-garden#1171 is merged (alternatively you can check out that branch for use when testing this one).  It can safely be merged before that PR, but doesn't really do anything without it.

This PR updates the `RestClient` handling of authentication and tokens to match the updated beer-garden API.  I removed any use of the refresh token, as that model doesn't really make sense in a non-browser context.  Re-authenticating and refreshing are functionally equivalent here, so it seems preferably to streamline and not bother with the refresh token.  Longer-term we'll want to look into adopting longer lived tokens for brewtils and other non-UI use cases.

# Test Instructions
* Start beer garden with auth enabled and create a user with global superuser access for ease of testing.
  ```python
  from mongoengine import connect
  from beer_garden.db.mongo.models import Role, RoleAssignment, User

  # modify db and host parameters are appropriate for your environment
  connect(db="bg-parent1", host="mongodb://mongodb")

  role = Role.objects.get(name="superuser")
  role_assignment = RoleAssignment(role=role, domain={"scope": "Global"})
  user = User(username="admin", role_assignments=[role_assignment])
  user.set_password("password")
  user.save()
  ````
* Now connect using the `RestClient` and test some things out:
  ```python
  from brewtils.rest.client import RestClient
  rc = RestClient(bg_host="localhost", bg_port=2337, username="admin", password="password", ssl_enabled=False)

  # Should return a 200 Response
  rc.get_systems()

  # Capture the access token
  access_token = rc.access_token

  # Make another call
  rc.get_systems()

  # The token is still good, so it should be the same
  access_token == rc.access_token

  # Let's delete the token so that it's no good anymore (alternatively, wait for the token to naturally expire)
  from beer_garden.db.mongo.models import UserToken
  UserToken.drop_collection()

  # Make another call and compare the current tokens to the old ones. They should be different since the expired token forced a new login.
  rc.get_systems()  # 200
  access_token == rc.access_token   # False
  ```
* As a final test, if you edit your beer garden config and set the username and password under plugin --> local --> auth to the user you've been using for your tests, then restart beer garden, the plugins should start successfully and work as you'd expect.