### PR TITLE
#372 - Update EasyClient.import_jobs to properly handle the beer-garden api response

### DIFF
--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -775,9 +775,7 @@ class EasyClient(object):
 
         return self.client.post_export_jobs(payload)  # noqa # wrapper changes type
 
-    @wrap_response(
-        parse_method="parse_job_ids", parse_many=True, default_exc=FetchError
-    )
+    @wrap_response(parse_method="parse_job_ids")
     def import_jobs(self, job_list):
         # type: (List[Job]) -> List[str]
         """Import job definitions from a list of Jobs.

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -301,33 +301,25 @@ class SchemaParser(object):
         return cls.parse(job, brewtils.models.Job, from_string=from_string, **kwargs)
 
     @classmethod
-    def parse_job_ids(cls, job_id_list, from_string=False, **kwargs):
-        """Convert raw JSON string or list of strings to a list of job ids.
+    def parse_job_ids(cls, job_id_json, from_string=False, **kwargs):
+        """Convert raw JSON string containing a list of strings to a list of job ids.
 
         Passes a list of strings through unaltered if from_string is False.
 
         Args:
-            job_id_list: Raw input
+            job_id_json: Raw input
             from_string: True if input is a JSON string, False otherwise
             **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
 
         Returns:
-            A list of job ids.
+            A dictionary containing a list of job ids
         """
-        # this is needed by easy_client
-        #
-        # some functionality duplicated from the parse method because model not used
-        if job_id_list is None:  # pragma: no cover
-            raise TypeError("job_id_list can not be None")
-        if not bool(from_string):
-            if isinstance(job_id_list, list):
-                if len(job_id_list) > 0 and not all(
-                    map(lambda x: isinstance(x, str), job_id_list)
-                ):  # pragma: no cover
-                    raise TypeError("Not a list of strings")
-                return job_id_list
+        schema = brewtils.schemas.JobExportInputSchema(**kwargs)
 
-        return json.dumps(job_id_list)
+        if from_string:
+            return schema.loads(job_id_json).data
+        else:
+            return schema.load(job_id_json).data
 
     @classmethod
     def parse_garden(cls, garden, from_string=False, **kwargs):


### PR DESCRIPTION
Closes #372 

This PR fixes the EasyClient `import_jobs` method so that it properly parses the api response and returns a dictionary, rather than stringified json.

# Test Instructions
You can use the EasyClient to test as follows:

```python
from brewtils.rest.easy_client import EasyClient
from brewtils.models import Job

ec = EasyClient(bg_host="localhost", bg_port=2337, ssl_enabled=False)

job_dict = {
     "name": "well_formed_job",   
     "misfire_grace_time": 3,
     "trigger": {         
         "timezone": "utc",
         "run_date": 1700000000000
     },
     "coalesce": True,
     "trigger_type": "date",
     "timeout": 30,
     "max_instances": 3,
     "request_template": {
         "metadata": {
           "request": "stuff"
       },
       "command": "speak",
       "parameters": {
           "message": "hey!"
       },
       "instance_name": "default",
       "output_type": "STRING",
       "command_type": "ACTION",
       "namespace": "ns",
       "system": "system",
       "system_version": "1.0.0",
       "comment": "hi!"
     }
 }

job = Job(**job_dict)
ec.import_jobs([job])
# Should return something like:
# {'ids': ['6195542207e95261e512ce45']}
```