### PR TITLE
Add reset_interval args to execute_job functions

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -618,18 +618,20 @@ class RestClient(object):
         """
         return self.session.post(self.job_url, data=payload, headers=self.JSON_HEADERS)
 
-    def post_execute_job(self, job_id):
+    def post_execute_job(self, job_id, reset_interval=False):
         # type: (str) -> Response
         """Performs a POST on the Job Execute URL
 
         Args:
             job_id: The ID of the Job
+            reset_interval: Sets interval of job to restart now
 
         Returns:
             Request Response object
         """
+        url_params = "?reset_interval=True" if reset_interval else ""
         return self.session.post(
-            self.job_url + job_id + "/execute", headers=self.JSON_HEADERS
+            self.job_url + job_id + "/execute" + url_params, headers=self.JSON_HEADERS
         )
 
     @enable_auth

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -633,7 +633,6 @@ class RestClient(object):
         if reset_interval:
             url_params["reset_interval"] = "True"
 
-        "?reset_interval=True" if reset_interval else ""
         return self.session.post(
             self.job_url + job_id + "/execute",
             headers=self.JSON_HEADERS,

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -635,7 +635,9 @@ class RestClient(object):
 
         "?reset_interval=True" if reset_interval else ""
         return self.session.post(
-            self.job_url + job_id + "/execute", headers=self.JSON_HEADERS, params=url_params
+            self.job_url + job_id + "/execute",
+            headers=self.JSON_HEADERS,
+            params=url_params,
         )
 
     @enable_auth

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -629,9 +629,13 @@ class RestClient(object):
         Returns:
             Request Response object
         """
-        url_params = "?reset_interval=True" if reset_interval else ""
+        url_params = {}
+        if reset_interval:
+            url_params["reset_interval"] = "True"
+
+        "?reset_interval=True" if reset_interval else ""
         return self.session.post(
-            self.job_url + job_id + "/execute" + url_params, headers=self.JSON_HEADERS
+            self.job_url + job_id + "/execute", headers=self.JSON_HEADERS, params=url_params
         )
 
     @enable_auth

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -843,16 +843,18 @@ class EasyClient(object):
         """
         return self._patch_job(job_id, [PatchOperation("update", "/status", "RUNNING")])
 
-    def execute_job(self, job_id):
+    def execute_job(self, job_id, reset_interval=False):
         """Execute a Job
 
         Args:
             job_id (str): The Job ID
+            reset_interval (bool): Restarts the job's interval time to now if
+                the job's trigger is an interval
 
         Returns:
             Request: The returned request
         """
-        return self.client.post_execute_job(job_id)
+        return self.client.post_execute_job(job_id, reset_interval)
 
     @wrap_response(parse_method="parse_resolvable")
     def upload_bytes(self, data):


### PR DESCRIPTION
Closes #369 

Adds a `reset_interval` argument to the POST function for ad-hoc executions. This argument is sent via the endpoint URL (`.../execute?reset_parameters=True`), but could be changed to use the POST request's body if any other arguments are introduced.