### PR TITLE
Require domain on RoleAssignmentSchema

### DIFF
--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -584,7 +584,7 @@ class RoleAssignmentDomainSchema(BaseSchema):
 
 
 class RoleAssignmentSchema(BaseSchema):
-    domain = fields.Nested(RoleAssignmentDomainSchema)
+    domain = fields.Nested(RoleAssignmentDomainSchema, required=True)
     role = fields.Nested(RoleSchema())
 
 


### PR DESCRIPTION
Benefits, but not strictly required for, beer-garden/beer-garden#1203.

This makes the domain field on `RoleAssignmentSchema` required.  This should have always been the case and not having hinders validation in certain circumstances.