### PR TITLE
#371 - Support None for resolvable parameters

### DIFF
--- a/brewtils/resolvers/manager.py
+++ b/brewtils/resolvers/manager.py
@@ -2,7 +2,8 @@
 
 import collections
 import logging
-from typing import Any, Dict, List, Mapping
+from collections.abc import Mapping
+from typing import Any, Dict, List
 
 from brewtils.models import Parameter, Resolvable
 from brewtils.resolvers.bytes import BytesResolver
@@ -89,7 +90,7 @@ class ResolutionManager(object):
                     elif (
                         not upload
                         and resolver.should_download(value, definition)
-                        and value
+                        and isinstance(value, Mapping)
                     ):
                         resolvable = Resolvable(**value)
                         resolved = resolver.download(resolvable, definition)

--- a/brewtils/resolvers/manager.py
+++ b/brewtils/resolvers/manager.py
@@ -2,8 +2,7 @@
 
 import collections
 import logging
-from collections.abc import Mapping
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 from brewtils.models import Parameter, Resolvable
 from brewtils.resolvers.bytes import BytesResolver

--- a/brewtils/resolvers/manager.py
+++ b/brewtils/resolvers/manager.py
@@ -86,7 +86,11 @@ class ResolutionManager(object):
                         resolvable = resolver.upload(value, definition)
                         resolved = SchemaParser.serialize(resolvable, to_string=False)
                         break
-                    elif not upload and resolver.should_download(value, definition):
+                    elif (
+                        not upload
+                        and resolver.should_download(value, definition)
+                        and value
+                    ):
                         resolvable = Resolvable(**value)
                         resolved = resolver.download(resolvable, definition)
                         break

--- a/test/resolvers/manager_test.py
+++ b/test/resolvers/manager_test.py
@@ -100,10 +100,9 @@ class TestSimpleResolve(object):
         assert resolved == {"message": "hi"}
 
     def test_download_value_none(
-        self, manager, resolver_mock, bg_command, resolvable_dict, bg_resolvable
+        self, manager, resolver_mock, bg_command, bg_resolvable
     ):
         resolver_mock.should_download.return_value = True
-        resolver_mock.download.return_value = "hi"
 
         # Need to clear out nested parameters otherwise this is a model parameter
         for param in bg_command.parameters:

--- a/test/resolvers/manager_test.py
+++ b/test/resolvers/manager_test.py
@@ -99,6 +99,24 @@ class TestSimpleResolve(object):
 
         assert resolved == {"message": "hi"}
 
+    def test_download_value_none(
+        self, manager, resolver_mock, bg_command, resolvable_dict, bg_resolvable
+    ):
+        resolver_mock.should_download.return_value = True
+        resolver_mock.download.return_value = "hi"
+
+        # Need to clear out nested parameters otherwise this is a model parameter
+        for param in bg_command.parameters:
+            param.parameters = None
+
+        resolved = manager.resolve(
+            {"message": None},
+            definitions=bg_command.parameters,
+            upload=False,
+        )
+
+        assert resolved == {"message": None}
+
 
 class TestNestedResolve(object):
     """Test nested, non-multi"""


### PR DESCRIPTION
closes #371 

Adds a check that value is not `NoneType` when trying to resolve parameter types `Base64` and `Bytes`. 

## Testing Instructions
- Add or update the `file-bytes` and `deploy` plugins to the plugin directory in beer garden (make sure using branch from PR https://github.com/beer-garden/example-plugins/pull/24 is merged)
- Run commands `base64_command_optional` and `echo_md5sum_optional` without selecting a file

Results
Output of request should be `no file selected`