### PR TITLE
#380 - Allow the use of certificates without a username or password

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -29,7 +29,7 @@ def enable_auth(method):
             return original_response
 
         # Try to use credentials
-        if self.username and self.password:
+        if (self.username and self.password) or self.client_cert:
             credential_response = self.get_tokens()
 
             if credential_response.ok:
@@ -96,6 +96,8 @@ class RestClient(object):
         self.password = self._config.password
         self.access_token = self._config.access_token
         self.refresh_token = self._config.refresh_token
+        self.client_cert = self._config.client_cert
+        self.client_key = self._config.client_key
 
         # Configure the session to use when making requests
         self.session = Session()

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -436,3 +436,26 @@ class TestRestClient(object):
         client = RestClient(bg_host="host", bg_port=80, api_version=1, ca_verify=False)
         assert client.session.verify is False
         assert urllib_mock.disable_warnings.called is True
+
+    def test_client_cert_without_username_password(self, monkeypatch):
+        get_tokens_mock = Mock()
+        monkeypatch.setattr(
+            brewtils.rest.client.RestClient, "get_tokens", get_tokens_mock
+        )
+
+        client = RestClient(
+            bg_host="host",
+            bg_port=443,
+            api_version=1,
+            ssl_enabled=True,
+            client_cert="/path/to/cert",
+        )
+
+        session_get_response = Mock()
+        session_get_response.status_code = 401
+        session_get_mock = Mock(return_value=session_get_response)
+        monkeypatch.setattr(client.session, "get", session_get_mock)
+
+        client.get_garden("somegarden")
+
+        assert get_tokens_mock.called is True


### PR DESCRIPTION
Closes #380 

This PR allows the use of certificates for authentication without requiring a username and password also be provided.  There was a check in place that looked for a username and password before attempting to get an access token.  This updates that to also do get the token if a certificate is present.