### PR TITLE
Disable codecov patch check

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  patch:
+    default:
+      enabled: no
+      if_not_found: success

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,8 @@
+github_checks:
+  annotations: false
+
 coverage:
   patch:
     default:
-      enabled: no
+      enabled: false
       if_not_found: success


### PR DESCRIPTION
Disables the codecov patch check, which has proven to be very unreliable.