### PR TITLE
#370 - Add get_gardens() & update_garden()

### DIFF
--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -2,20 +2,19 @@
 
 import functools
 import json
-from typing import Any, List
 from base64 import b64encode
-
-import requests.exceptions
-import urllib3
-from requests import Response, Session
-from requests.utils import quote
-from requests.adapters import HTTPAdapter
-from yapconf import YapconfSpec
+from typing import Any, List
 
 import brewtils.plugin
+import requests.exceptions
+import urllib3
 from brewtils.errors import _deprecate
 from brewtils.rest import normalize_url_prefix
 from brewtils.specification import _CONNECTION_SPEC
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+from requests.utils import quote
+from yapconf import YapconfSpec
 
 
 def enable_auth(method):
@@ -301,6 +300,18 @@ class RestClient(object):
         return self.session.get(self.garden_url + quote(garden_name), params=kwargs)
 
     @enable_auth
+    def get_gardens(self, **kwargs):
+        # type: (**Any) -> Response
+        """Preform a GET on the Garden URL
+
+        This fetches all gardens.
+
+        Returns:
+            Requests Response object
+        """
+        return self.session.get(self.garden_url, params=kwargs)
+
+    @enable_auth
     def post_gardens(self, payload):
         # type: (str) -> Response
         """Performs a POST on the Garden URL
@@ -328,6 +339,24 @@ class RestClient(object):
         """
         # quote will URL encode the Garden name
         return self.session.delete(self.garden_url + quote(garden_name))
+
+    @enable_auth
+    def patch_garden(self, garden_name, payload):
+        # type: (str, str) -> Response
+        """Perform a PATCH on a Garden URL
+
+        Args:
+            garden_name: Garden name
+            payload: Serialized patch operation
+
+        Returns:
+            Request Response object
+        """
+        return self.session.patch(
+            self.garden_url + quote(garden_name),
+            data=payload,
+            headers=self.JSON_HEADERS,
+        )
 
     @enable_auth
     def get_systems(self, **kwargs):
@@ -621,7 +650,7 @@ class RestClient(object):
         return self.session.post(self.job_url, data=payload, headers=self.JSON_HEADERS)
 
     def post_execute_job(self, job_id, reset_interval=False):
-        # type: (str) -> Response
+        # type: (str, bool) -> Response
         """Performs a POST on the Job Execute URL
 
         Args:

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-from asyncio.log import logger  # noqa
 from base64 import b64decode
 from io import BytesIO
 from pathlib import Path
@@ -291,26 +290,20 @@ class EasyClient(object):
         """
         return self.client.delete_garden(garden_name)
 
-    @wrap_response(parse_method="parse_garden")
+    @wrap_response(parse_method="parse_garden", default_exc=FetchError)
     def update_garden(self, garden):
-        operations = [
-            PatchOperation(
-                operation="config",
-                path="",
-                value=SchemaParser.serialize_garden(garden, many=False),
-            ),
-        ]
-        patches = SchemaParser.serialize_patch(operations, many=True, to_string=True)
+        garden_as_dict = SchemaParser.serialize_garden(garden, to_string=False)
 
         patches = json.dumps(
             [
                 {
                     "operation": "config",
                     "path": "",
-                    "value": SchemaParser.serialize_garden(garden, to_string=False),
+                    "value": garden_as_dict,
                 }
             ]
         )
+
         return self.client.patch_garden(garden.name, patches)
 
     @wrap_response(

--- a/test/rest/client_test.py
+++ b/test/rest/client_test.py
@@ -4,13 +4,12 @@ import json
 import os
 import warnings
 
+import brewtils.rest
 import pytest
 import requests.exceptions
+from brewtils.rest.client import RestClient
 from mock import ANY, MagicMock, Mock
 from yapconf.exceptions import YapconfItemError
-
-import brewtils.rest
-from brewtils.rest.client import RestClient
 
 
 class TestRestClient(object):
@@ -212,10 +211,22 @@ class TestRestClient(object):
         client.get_garden("name!")
         session_mock.get.assert_called_with(client.garden_url + "name%21", params={})
 
+    def test_get_gardens(self, client, session_mock):
+        client.get_gardens()
+        session_mock.get.assert_called_with(client.garden_url, params={})
+
     def test_post_garden(self, client, session_mock):
         client.post_gardens(payload="payload")
         session_mock.post.assert_called_with(
             client.garden_url, data="payload", headers=client.JSON_HEADERS
+        )
+
+    def test_patch_garden(self, client, session_mock):
+        client.patch_garden("gardenname", "payload")
+        session_mock.patch.assert_called_with(
+            client.garden_url + "gardenname",
+            data="payload",
+            headers=client.JSON_HEADERS,
         )
 
     def test_delete_garden(self, client, session_mock):

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -24,6 +24,7 @@ from brewtils.rest.easy_client import (
     handle_response_failure,
 )
 from brewtils.schema_parser import SchemaParser
+from brewtils.schemas import GardenSchema
 from mock import ANY, Mock
 
 
@@ -159,6 +160,7 @@ class TestGardens(object):
     def test_update(self, client, rest_client, bg_garden, success, parser):
         rest_client.patch_garden.return_value = success
         parser.parse_garden.return_value = bg_garden
+        parser.serialize_garden.return_value = GardenSchema().dumps(bg_garden)
         updated = client.update_garden(bg_garden)
 
         assert updated == bg_garden

--- a/test/rest/easy_client_test.py
+++ b/test/rest/easy_client_test.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import warnings
-
-import pytest
-from mock import ANY, Mock
-from base64 import b64encode, b64decode
+from base64 import b64decode, b64encode
 
 import brewtils.rest.easy_client
+import pytest
 from brewtils.errors import (
     ConflictError,
     DeleteError,
@@ -25,6 +24,7 @@ from brewtils.rest.easy_client import (
     handle_response_failure,
 )
 from brewtils.schema_parser import SchemaParser
+from mock import ANY, Mock
 
 
 @pytest.fixture
@@ -155,6 +155,22 @@ class TestGardens(object):
 
             with pytest.raises(NotFoundError):
                 client.remove_garden(bg_garden.name)
+
+    def test_update(self, client, rest_client, bg_garden, success, parser):
+        rest_client.patch_garden.return_value = success
+        parser.parse_garden.return_value = bg_garden
+        updated = client.update_garden(bg_garden)
+
+        assert updated == bg_garden
+
+    def test_get_all(self, client, rest_client, bg_garden, success, parser):
+        child_garden = copy.deepcopy(bg_garden)
+        child_garden.name = "child1"
+        both_gardens = [bg_garden, child_garden]
+        rest_client.get_gardens.return_value = success
+        parser.parse_garden.return_value = both_gardens
+
+        assert client.get_gardens() == both_gardens
 
 
 class TestSystems(object):


### PR DESCRIPTION
Fixes #370 

Unit tests provided for `get_gardens()` and `update_garden()`, though they exactly follow the format of previous unit tests and it's unclear what, if anything, those test.

At any rate, functionality can be exercised through ipython. Assuming a setup with a parent and child garden, from a fresh database instance, the connection parameters for the child will be the reasonable, but unusable, defaults. We can update them with:

```python
from brewtils.rest import easy_client

ez_client = easy_client.get_easy_client(**{"bg_host": "localhost", "ssl_enabled": str(False)})

gardens = ez_client.get_gardens(); print(f"get_gardens() output:\n\t{gardens!r}")
child = gardens[1]; conn_params = child.connection_params

print(f"Child connection params before update:\n\t{conn_params!r}")

child.connection_params = {"http": {**conn_params["http"], **{"host": "bg-child1", "port": 2447}}}
ez_client.update_garden(child)

print(f"Child connection params from get_gardens() after update:\n\t{ez_client.get_gardens()[1].connection_params!r}")
```

which will produce the following output:

```bash
get_gardens() output:
        [<Garden: garden_name=parent1, status=RUNNING>, <Garden: garden_name=child1, status=RUNNING>]
Child connection params before update:
        {'http': {'port': 2337, 'client_cert': '', 'ca_verify': False, 'ca_cert': '', 'ssl': False, 'url_prefix': '/', 'host': 'child_hostname'}}
Child connection params from get_gardens() after update:
        {'http': {'port': 2447, 'client_cert': '', 'ca_verify': False, 'ca_cert': '', 'ssl': False, 'url_prefix': '/', 'host': 'bg-child1'}}
```