### PR TITLE
Add permissions to UserSchema

### DIFF
--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -592,6 +592,7 @@ class UserSchema(BaseSchema):
     id = fields.Str()
     username = fields.Str()
     role_assignments = fields.List(fields.Nested(RoleAssignmentSchema()))
+    permissions = fields.Dict()
 
 
 class UserCreateSchema(BaseSchema):


### PR DESCRIPTION
This PR adds the permissions field to UserSchema.  It is added as a `Dict` field for now as it's only used for output, in service of beer-garden/beer-garden#1179.