### PR TITLE
#389 - Have PikaClient use client certs if present

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
         # Can't use ubuntu-latest until Python 3.4 has Ubuntu 20.X install options in setup-python@v2
         os: ['ubuntu-18.04']
     name: PyTests OS ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.6', '3.7', '3.8', '3.9']
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         # Can't use ubuntu-latest until Python 3.4 has Ubuntu 20.X install options in setup-python@v2
         os: ['ubuntu-18.04']
     name: PyTests OS ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 # Jupyter
 .ipydb_checkpoints/
 *.ipynb
+
+# Vim
+*.swp

--- a/brewtils/pika.py
+++ b/brewtils/pika.py
@@ -72,6 +72,7 @@ class PikaClient(object):
         ssl = ssl or {}
         self._ssl_options = None
         self._ssl_enabled = ssl.get("enabled", False)
+        self._ssl_client_cert = ssl.get("client_cert")
 
         if self._ssl_enabled:
             ssl_context = pyssl.create_default_context(cafile=ssl.get("ca_cert", None))
@@ -80,6 +81,10 @@ class PikaClient(object):
             else:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = pyssl.CERT_NONE
+
+            if self._ssl_client_cert:
+                ssl_context.load_cert_chain(self._ssl_client_cert)
+
             self._ssl_options = SSLOptions(ssl_context, server_hostname=self._host)
 
         # Save the 'normal' params so they don't need to be reconstructed

--- a/brewtils/plugin.py
+++ b/brewtils/plugin.py
@@ -136,7 +136,9 @@ class Plugin(object):
             authority that issued the Beer-garden server certificate
         ca_verify (bool): Whether to verify Beer-garden server certificate
         client_cert (str): Path to client certificate to use when communicating with
-            Beer-garden
+            Beer-garden. NOTE: This is required to be a cert / key bundle if SSL/TLS is
+            enabled for rabbitmq in your environment.
+        client_key (str): Path to client key. Not necessary if client_cert is a bundle.
         api_version (int): Beer-garden API version to use
         client_timeout (int): Max time to wait for Beer-garden server response
         username (str): Username for Beer-garden authentication
@@ -531,13 +533,14 @@ class Plugin(object):
         # values specified at plugin creation
         connection_info = self._instance.queue_info["connection"]
         if "ssl" in connection_info:
-            connection_info["ssl"].update(
-                {
-                    "ca_cert": self._config.ca_cert,
-                    "ca_verify": self._config.ca_verify,
-                    "client_cert": self._config.client_cert,
-                }
-            )
+            if self._config.ca_verify:
+                connection_info["ssl"]["ca_verify"] = self._config.ca_verify
+
+            if self._config.ca_cert:
+                connection_info["ssl"]["ca_cert"] = self._config.ca_cert
+
+            if self._config.client_cert:
+                connection_info["ssl"]["client_cert"] = self._config.client_cert
 
         # Each RequestProcessor needs a RequestConsumer, so start with those
         common_args = {

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import pytest
 import pytz
+
 from brewtils.models import (
     Choices,
     Command,
@@ -215,7 +216,12 @@ def instance_dict(ts_epoch):
                 "user": "guest",
                 "password": "guest",
                 "virtual_host": "/",
-                "ssl": {"enabled": False},
+                "ssl": {
+                    "enabled": False,
+                    "ca_verify": False,
+                    "client_cert": "/path/to/cert",
+                    "ca_cert": "/path/to/cacert",
+                },
             },
             "url": "amqp://guest:guest@localhost:5672",
         },

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ universal = 1
 [flake8]
 max-line-length = 100
 ignore = E203,W503
+
+[isort]
+profile = black
+known_first_party = brewtils


### PR DESCRIPTION
Closes #389 

This PR ensures that client certificates are actually used by the PikaClient if present in the config.  This allows local plugins to properly connect to rabbitmq when client certificates are required.

## Testing Instructions

See the instructions on https://github.com/beer-garden/beer-garden/pull/1289