### PR TITLE
Adding Temp Command Type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Brewtils Changelog
 ==================
 
+3.17.0
+------
+10/11/2023
+- Add new command type TEMP
+
 3.16.0
 ------
 4/14/2023

--- a/brewtils/__version__.py
+++ b/brewtils/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -101,7 +101,7 @@ class BaseModel(object):
 class Command(BaseModel):
     schema = "CommandSchema"
 
-    COMMAND_TYPES = ("ACTION", "INFO", "EPHEMERAL", "ADMIN")
+    COMMAND_TYPES = ("ACTION", "INFO", "EPHEMERAL", "ADMIN", "TEMP")
     OUTPUT_TYPES = ("STRING", "JSON", "XML", "HTML", "JS", "CSS")
 
     def __init__(
@@ -619,7 +619,7 @@ class Request(RequestTemplate):
         "INVALID",
     )
     COMPLETED_STATUSES = ("CANCELED", "SUCCESS", "ERROR", "INVALID")
-    COMMAND_TYPES = ("ACTION", "INFO", "EPHEMERAL", "ADMIN")
+    COMMAND_TYPES = ("ACTION", "INFO", "EPHEMERAL", "ADMIN", "TEMP")
     OUTPUT_TYPES = ("STRING", "JSON", "XML", "HTML", "JS", "CSS")
 
     def __init__(


### PR DESCRIPTION
Adds new TEMP command type to be supported in the main BG environment for deleting requests after they are done being processed/referenced. 