### PR TITLE
Literal Type Hinting Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Brewtils Changelog
 ==================
 
+3.20.0
+------
+TBD
+
+- Expanded Auto Generation to support Literal Type Hinting, if python version >= 3.8
+
 3.19.0
 ------
 10/20/2023

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -18,6 +18,8 @@ if sys.version_info.major == 2:
     from funcsigs import signature, Parameter as InspectParameter  # noqa
 else:
     from inspect import signature, Parameter as InspectParameter  # noqa
+    if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+        from typing import get_args
 
 __all__ = [
     "client",
@@ -562,6 +564,17 @@ def _parameter_docstring(method, parameter):
 
     return None
 
+def _choices_type_hint(method, cmd_parameter):
+    if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+        for _, arg in enumerate(signature(method).parameters.values()):
+            if arg.name == cmd_parameter:
+                if str(arg.annotation).startswith("typing.Literal"):
+                    arg_choices = list()
+                    for arg_choice in get_args(arg.annotation):
+                        arg_choices.append(str(arg_choice))
+                    return arg_choices
+
+    return None
 
 def _parameter_type_hint(method, cmd_parameter):
     for _, arg in enumerate(signature(method).parameters.values()):
@@ -719,6 +732,9 @@ def _initialize_parameter(
     # Extract Parameter Type if not present
     if param.type is None and method is not None:
         param.type = _parameter_type_hint(method, param.key)
+
+    if param.choices is None and method is not None:
+        param.choices = _choices_type_hint(method, param.key)
 
     # Type and type info
     # Type info is where type specific information goes. For now, this is specific

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -18,7 +18,8 @@ if sys.version_info.major == 2:
     from funcsigs import signature, Parameter as InspectParameter  # noqa
 else:
     from inspect import signature, Parameter as InspectParameter  # noqa
-    if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+
+    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
         from typing import get_args
 
 __all__ = [
@@ -564,8 +565,9 @@ def _parameter_docstring(method, parameter):
 
     return None
 
+
 def _choices_type_hint(method, cmd_parameter):
-    if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
         for _, arg in enumerate(signature(method).parameters.values()):
             if arg.name == cmd_parameter:
                 if str(arg.annotation).startswith("typing.Literal"):
@@ -575,6 +577,7 @@ def _choices_type_hint(method, cmd_parameter):
                     return arg_choices
 
     return None
+
 
 def _parameter_type_hint(method, cmd_parameter):
     for _, arg in enumerate(signature(method).parameters.values()):

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -587,9 +587,9 @@ def _parameter_type_hint(method, cmd_parameter):
                 if sys.version_info.major == 3 and sys.version_info.minor >= 8:
                     choice_types = None
                     for arg_choice in get_args(arg.annotation):
-                        if choice_types == None:
+                        if choice_types is None:
                             choice_types = type(arg_choice)
-                        elif type(arg_choice) != choice_types:
+                        elif type(arg_choice) is not choice_types:
                             choice_types = None
                             break
 

--- a/brewtils/rest/client.py
+++ b/brewtils/rest/client.py
@@ -227,7 +227,7 @@ class RestClient(object):
         try:
             self.session.get(self.config_url, **kwargs)
         except requests.exceptions.ConnectionError as ex:
-            if type(ex) == requests.exceptions.ConnectionError:
+            if type(ex) is requests.exceptions.ConnectionError:
                 return False
             raise
 
@@ -831,7 +831,7 @@ class RestClient(object):
             data = fd.read(file_params["chunk_size"])
             if not data:
                 break
-            if type(data) != bytes:
+            if type(data) is not bytes:
                 data = bytes(data, "utf-8")
             data = b64encode(data)
             chunk_result = self.session.post(

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -6,7 +6,7 @@ import warnings
 import pytest
 from mock import Mock
 
-if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+if sys.version_info.major == 3 and sys.version_info.minor >= 8:
     from typing import Literal
 
 import brewtils.decorators
@@ -212,9 +212,10 @@ class TestOverall(object):
                 assert bg_cmd.output_type == "JSON"
 
             def test_type_hints_choices(self):
-                if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+                if sys.version_info.major == 3 and sys.version_info.minor >= 8:
+
                     @command
-                    def cmd(foo: Literal["a","b"] = "a") -> dict:
+                    def cmd(foo: Literal["a", "b"] = "a") -> dict:
                         return foo
 
                     bg_cmd = _parse_method(cmd)
@@ -222,8 +223,8 @@ class TestOverall(object):
                     assert len(bg_cmd.parameters) == 1
                     assert bg_cmd.parameters[0].key == "foo"
                     assert bg_cmd.parameters[0].type == "Any"
-                    assert bg_cmd.parameters[0].choices.value == ["a","b"]
-                    assert bg_cmd.parameters[0].default == "a"              
+                    assert bg_cmd.parameters[0].choices.value == ["a", "b"]
+                    assert bg_cmd.parameters[0].default == "a"
                     assert bg_cmd.parameters[0].optional is True
 
         class TestDocString(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -211,7 +211,23 @@ class TestOverall(object):
 
                 assert bg_cmd.output_type == "JSON"
 
-            def test_type_hints_choices(self):
+            def test_type_hints_choices_any(self):
+                if sys.version_info.major == 3 and sys.version_info.minor >= 8:
+
+                    @command
+                    def cmd(foo: Literal["a", 2] = "a") -> dict:
+                        return foo
+
+                    bg_cmd = _parse_method(cmd)
+
+                    assert len(bg_cmd.parameters) == 1
+                    assert bg_cmd.parameters[0].key == "foo"
+                    assert bg_cmd.parameters[0].type == "Any"
+                    assert bg_cmd.parameters[0].choices.value == ["a", 2]
+                    assert bg_cmd.parameters[0].default == "a"
+                    assert bg_cmd.parameters[0].optional is True
+
+            def test_type_hints_choices_string(self):
                 if sys.version_info.major == 3 and sys.version_info.minor >= 8:
 
                     @command
@@ -222,9 +238,25 @@ class TestOverall(object):
 
                     assert len(bg_cmd.parameters) == 1
                     assert bg_cmd.parameters[0].key == "foo"
-                    assert bg_cmd.parameters[0].type == "Any"
+                    assert bg_cmd.parameters[0].type == "String"
                     assert bg_cmd.parameters[0].choices.value == ["a", "b"]
                     assert bg_cmd.parameters[0].default == "a"
+                    assert bg_cmd.parameters[0].optional is True
+
+            def test_type_hints_choices_integer(self):
+                if sys.version_info.major == 3 and sys.version_info.minor >= 8:
+
+                    @command
+                    def cmd(foo: Literal[1, 2] = 1) -> dict:
+                        return foo
+
+                    bg_cmd = _parse_method(cmd)
+
+                    assert len(bg_cmd.parameters) == 1
+                    assert bg_cmd.parameters[0].key == "foo"
+                    assert bg_cmd.parameters[0].type == "Integer"
+                    assert bg_cmd.parameters[0].choices.value == [1, 2]
+                    assert bg_cmd.parameters[0].default == 1
                     assert bg_cmd.parameters[0].optional is True
 
         class TestDocString(object):

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -6,6 +6,9 @@ import warnings
 import pytest
 from mock import Mock
 
+if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+    from typing import Literal
+
 import brewtils.decorators
 from brewtils.decorators import (
     _format_type,
@@ -207,6 +210,21 @@ class TestOverall(object):
                 bg_cmd = _parse_method(cmd)
 
                 assert bg_cmd.output_type == "JSON"
+
+            def test_type_hints_choices(self):
+                if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+                    @command
+                    def cmd(foo: Literal["a","b"] = "a") -> dict:
+                        return foo
+
+                    bg_cmd = _parse_method(cmd)
+
+                    assert len(bg_cmd.parameters) == 1
+                    assert bg_cmd.parameters[0].key == "foo"
+                    assert bg_cmd.parameters[0].type == "Any"
+                    assert bg_cmd.parameters[0].choices.value == ["a","b"]
+                    assert bg_cmd.parameters[0].default == "a"              
+                    assert bg_cmd.parameters[0].optional is True
 
         class TestDocString(object):
             def test_cmd_description(self):


### PR DESCRIPTION
Supports functions with Literal typing. Literal values are defined as the choices for the parameter.

```
def function(self, x: Literal["a","b"]):
    return a
```