### PR TITLE
Fixed self reference loop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Brewtils Changelog
 TBD
 
 - Expanded Auto Generation to support Literal Type Hinting, if python version >= 3.8
+- Fixed self reference bug in SystemClient
 
 3.19.0
 ------

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -203,6 +203,7 @@ class SystemClient(object):
         self._loaded = False
         self._system = None
         self._commands = {}
+        self._current_system_namespace = -1
 
         # Need this for back-compatibility (see #836)
         if len(args) > 2:
@@ -257,8 +258,6 @@ class SystemClient(object):
                 elif len(self._system_namespaces) == 1:
                     self._system_namespace = self._system_namespaces[0]
                     self._current_system_namespace = -1
-            else:
-                self._current_system_namespace = -1
 
         self._always_update = kwargs.get("always_update", False)
         self._timeout = kwargs.get("timeout", None)


### PR DESCRIPTION
If a client was self referencing, then it would cause an infinite loop trying to find the current namespace counter, because it wasn't defined. 