### PR TITLE
All undefined kwargs flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Brewtils Changelog
 ==================
 
+3.21.0
+------
+TBD
+
+- Added new paramter to Commands to signal if non defined kwargs can be passed
+
+
 3.20.2
 ------
 11/9/2023

--- a/brewtils/decorators.py
+++ b/brewtils/decorators.py
@@ -90,6 +90,7 @@ def command(
     icon_name=None,  # type: Optional[str]
     hidden=False,  # type: Optional[bool]
     metadata=None,  # type: Optional[Dict]
+    allow_any_kwargs=None,  # type: Optional[bool]
 ):
     """Decorator for specifying Command details
 
@@ -153,6 +154,7 @@ def command(
             icon_name=icon_name,
             hidden=hidden,
             metadata=metadata,
+            allow_any_kwargs=allow_any_kwargs,
         )
 
     if output_type is None:
@@ -174,6 +176,7 @@ def command(
         icon_name=icon_name,
         hidden=hidden,
         metadata=metadata,
+        allow_any_kwargs=allow_any_kwargs,
     )
 
     # Python 2 compatibility
@@ -519,6 +522,13 @@ def _initialize_command(method):
 
     """
     cmd = getattr(method, "_command", Command())
+
+    if cmd.allow_any_kwargs is None:
+        cmd.allow_any_kwargs = False
+        for p in signature(method).parameters.values():
+            if p.kind == InspectParameter.VAR_KEYWORD:
+                cmd.allow_any_kwargs = True
+                break
 
     cmd.name = _method_name(method)
     cmd.description = cmd.description or _method_docstring(method)

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -119,6 +119,7 @@ class Command(BaseModel):
         hidden=False,
         metadata=None,
         topics=None,
+        allow_any_kwargs=None,
     ):
         self.name = name
         self.description = description
@@ -132,6 +133,7 @@ class Command(BaseModel):
         self.hidden = hidden
         self.metadata = metadata or {}
         self.topics = topics or []
+        self.allow_any_kwargs = allow_any_kwargs
 
     def __str__(self):
         return self.name

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -222,6 +222,7 @@ class CommandSchema(BaseSchema):
     hidden = fields.Boolean(allow_none=True)
     metadata = fields.Dict(allow_none=True)
     topics = fields.List(fields.Str(), allow_none=True)
+    allow_any_kwargs = fields.Boolean(allow_none=True)
 
 
 class InstanceSchema(BaseSchema):

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -171,6 +171,7 @@ def command_dict(parameter_dict, system_id):
         "icon_name": "icon!",
         "metadata": {"meta": "data"},
         "topics": [],
+        "allow_any_kwargs": False,
     }
 
 

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -777,7 +777,7 @@ class TestInitializeCommand(object):
         assert cmd_kwargs.name == "cmd"
         assert cmd_kwargs.allow_any_kwargs is True
 
-    def test_kwarg_command(self):
+    def test_kwarg_command_allow_none(self):
         @command(allow_any_kwargs=False)
         def _cmd(self, **kwargs):
             """Docstring"""

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -61,6 +61,17 @@ def cmd_kwargs():
 
 
 @pytest.fixture
+def cmd_kwargs_must_define():
+    class Bar(object):
+        @command(allow_any_kwargs=False)
+        def cmd(self, **kwargs):
+            """Docstring"""
+            pass
+
+    return Bar.cmd
+
+
+@pytest.fixture
 def basic_param():
     return {
         "key": "foo",
@@ -768,6 +779,22 @@ class TestInitializeCommand(object):
 
         assert cmd.name == "cmd"
         assert cmd.description == "Docstring"
+
+    def test_kwarg_command(self, cmd_kwargs):
+        assert not hasattr(cmd_kwargs, "_command")
+
+        cmd_kwargs = _initialize_command(cmd_kwargs)
+
+        assert cmd_kwargs.name == "cmd"
+        assert cmd_kwargs.allow_any_kwargs == True
+
+    def test_kwarg_command(self, cmd_kwargs_must_define):
+        assert hasattr(cmd_kwargs_must_define, "_command")
+
+        cmd_kwargs_must_define = _initialize_command(cmd_kwargs_must_define)
+
+        assert cmd_kwargs_must_define.name == "cmd"
+        assert cmd_kwargs_must_define.allow_any_kwargs == False
 
     def test_overwrite_docstring(self):
         new_description = "So descriptive"

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -786,7 +786,7 @@ class TestInitializeCommand(object):
         cmd_kwargs = _initialize_command(cmd_kwargs)
 
         assert cmd_kwargs.name == "cmd"
-        assert cmd_kwargs.allow_any_kwargs == True
+        assert cmd_kwargs.allow_any_kwargs is True
 
     def test_kwarg_command(self, cmd_kwargs_must_define):
         assert hasattr(cmd_kwargs_must_define, "_command")
@@ -794,7 +794,7 @@ class TestInitializeCommand(object):
         cmd_kwargs_must_define = _initialize_command(cmd_kwargs_must_define)
 
         assert cmd_kwargs_must_define.name == "cmd"
-        assert cmd_kwargs_must_define.allow_any_kwargs == False
+        assert cmd_kwargs_must_define.allow_any_kwargs is False
 
     def test_overwrite_docstring(self):
         new_description = "So descriptive"

--- a/test/decorators_test.py
+++ b/test/decorators_test.py
@@ -61,17 +61,6 @@ def cmd_kwargs():
 
 
 @pytest.fixture
-def cmd_kwargs_must_define():
-    class Bar(object):
-        @command(allow_any_kwargs=False)
-        def cmd(self, **kwargs):
-            """Docstring"""
-            pass
-
-    return Bar.cmd
-
-
-@pytest.fixture
 def basic_param():
     return {
         "key": "foo",
@@ -788,13 +777,18 @@ class TestInitializeCommand(object):
         assert cmd_kwargs.name == "cmd"
         assert cmd_kwargs.allow_any_kwargs is True
 
-    def test_kwarg_command(self, cmd_kwargs_must_define):
-        assert hasattr(cmd_kwargs_must_define, "_command")
+    def test_kwarg_command(self):
+        @command(allow_any_kwargs=False)
+        def _cmd(self, **kwargs):
+            """Docstring"""
+            pass
 
-        cmd_kwargs_must_define = _initialize_command(cmd_kwargs_must_define)
+        assert hasattr(_cmd, "_command")
 
-        assert cmd_kwargs_must_define.name == "cmd"
-        assert cmd_kwargs_must_define.allow_any_kwargs is False
+        _cmd = _initialize_command(_cmd)
+
+        assert _cmd.name == "_cmd"
+        assert _cmd.allow_any_kwargs is False
 
     def test_overwrite_docstring(self):
         new_description = "So descriptive"


### PR DESCRIPTION
Adds flag that can indicate if the command will accept any kwarg values that are not defined. 