### PR TITLE
Reworking Garden Models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ TBD
 
 - Expanding Garden model to include children gardens
 - Added Source/Target Garden labels on Request model
+- Added Metadata to Garden model
 
 3.23.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,18 @@
 Brewtils Changelog
 ==================
 
+3.24.0
+------
+TBD
+
+- Expanding Garden model to include children gardens
+- Added Source/Target Garden labels on Request model
+
 3.23.1
 ------
 TBD
 
 - Fixed self reference bug that was returning back output instead of Request object.
-- Added Source/Target Garden labels on Request model
 
 3.23.0
 ------
@@ -28,6 +34,7 @@ TBD
 - Added new KWARG input to @command for tag/tags. This can be utilized for filtering commands.
 - Adding default topic for PublishClient to Plugins {Namespace}.{System}.{Version}.{Instance}
 - Removed Python 12 support until we upgrade Marshmallow dependency to 3.15 or greater
+
 
 3.21.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Brewtils Changelog
 TBD
 
 - Fixed self reference bug that was returning back output instead of Request object.
+- Added Source/Target Garden labels on Request model
 
 3.23.0
 ------

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1502,6 +1502,7 @@ class Operation(BaseModel):
         kwargs=None,
         target_garden_name=None,
         source_garden_name=None,
+        source_api=None,
         operation_type=None,
     ):
         self.model = model
@@ -1510,6 +1511,7 @@ class Operation(BaseModel):
         self.kwargs = kwargs or {}
         self.target_garden_name = target_garden_name
         self.source_garden_name = source_garden_name
+        self.source_api = source_api
         self.operation_type = operation_type
 
     def __str__(self):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1481,7 +1481,8 @@ class Garden(BaseModel):
 
     def __repr__(self):
         return (
-            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
+            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, " \
+            "connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
             % (
                 self.name,
                 self.status,

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1453,7 +1453,6 @@ class Garden(BaseModel):
         namespaces=None,
         systems=None,
         connection_type=None,
-        connection_params=None,
         receiving_connections=None,
         publishing_connections=None,
         has_parent=None,
@@ -1501,20 +1500,22 @@ class Connection(BaseModel):
     def __init__(
         self,
         api=None,
-        enabled=False,
+        status=None,
+        status_info=None,
         config=None,
     ):
         self.api = api
-        self.enabled = enabled
+        self.status = status
+        self.status_info = status_info or {}
         self.config = config or {}
 
     def __str__(self):
-        return "%s %s" % (self.api, "ENABLED" if self.enabled else "DISABLED")
+        return "%s %s" % (self.api, self.status)
 
     def __repr__(self):
-        return "<Connection: api=%s, enabled=%s, config=%s>" % (
+        return "<Connection: api=%s, status=%s, config=%s>" % (
             self.api,
-            self.enabled,
+            self.status,
             self.config,
         )
 

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1452,7 +1452,6 @@ class Garden(BaseModel):
         status_info=None,
         namespaces=None,
         systems=None,
-        connection_type=None,
         receiving_connections=None,
         publishing_connections=None,
         has_parent=None,
@@ -1467,7 +1466,6 @@ class Garden(BaseModel):
         self.namespaces = namespaces or []
         self.systems = systems or []
 
-        self.connection_type = connection_type
         self.receiving_connections = receiving_connections or []
         self.publishing_connections = publishing_connections or []
 
@@ -1482,13 +1480,12 @@ class Garden(BaseModel):
     def __repr__(self):
         return (
             "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, " \
-            "connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
+            "receiving_connections=%s, publishing_connections=%s>"
             % (
                 self.name,
                 self.status,
                 self.parent,
                 self.has_parent,
-                self.connection_type,
                 self.receiving_connections,
                 self.publishing_connections,
             )

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -12,6 +12,7 @@ __all__ = [
     "System",
     "Instance",
     "Command",
+    "Connection",
     "Parameter",
     "Request",
     "PatchOperation",
@@ -1497,6 +1498,7 @@ class Connection(BaseModel):
     schema = "ConnectionSchema"
 
     def __init__(
+        self,
         api = None,
         enabled = False,
         config = None,

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1498,6 +1498,16 @@ class Garden(BaseModel):
 class Connection(BaseModel):
     schema = "ConnectionSchema"
 
+    CONNECTION_STATUSES = {
+        "ENABLED", # Sending
+        "DISABLED" # Stopped via config or API
+        "NOT_CONFIGURED", # Not enabled in configuration file
+        "MISSING_CONFIGURATION", # Missing configuration file
+        "UNREACHABLE", # Unable to send message
+        "ERROR", # Error occured, outside of unreachable
+        "UNKNOWN", 
+    }
+
     def __init__(
         self,
         api=None,

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1482,7 +1482,7 @@ class Garden(BaseModel):
 
     def __repr__(self):
         return (
-            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, " \
+            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, "
             "connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
             % (
                 self.name,
@@ -1502,14 +1502,14 @@ class Connection(BaseModel):
     CONNECTION_STATUSES = {
         "PUBLISHING",
         "RECEIVING",
-        "DISABLED" # Stopped via config or API
-        "NOT_CONFIGURED", # Not enabled in configuration file
-        "MISSING_CONFIGURATION", # Missing configuration file
-        "CONFIGURATION_ERROR", # Unable to load configuration file
-        "UNREACHABLE", # Unable to send message
-        "UNRESPONSIVE", # Haven't seen a message in N timeframe
-        "ERROR", # Error occured, outside of unreachable
-        "UNKNOWN", 
+        "DISABLED"  # Stopped via config or API
+        "NOT_CONFIGURED",  # Not enabled in configuration file
+        "MISSING_CONFIGURATION",  # Missing configuration file
+        "CONFIGURATION_ERROR",  # Unable to load configuration file
+        "UNREACHABLE",  # Unable to send message
+        "UNRESPONSIVE",  # Haven't seen a message in N timeframe
+        "ERROR",  # Error occured, outside of unreachable
+        "UNKNOWN",
     }
 
     def __init__(

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -64,6 +64,7 @@ class Events(Enum):
     DB_UPDATE = 17
     DB_DELETE = 18
     GARDEN_CREATED = 19
+    GARDEN_CONFIGURED = 53
     GARDEN_UPDATED = 20
     GARDEN_REMOVED = 21
     FILE_CREATED = 24
@@ -93,7 +94,7 @@ class Events(Enum):
     COMMAND_PUBLISHING_BLOCKLIST_REMOVE = 49
     COMMAND_PUBLISHING_BLOCKLIST_UPDATE = 50
 
-    # Next: 53
+    # Next: 54
 
 
 class BaseModel(object):
@@ -1452,6 +1453,7 @@ class Garden(BaseModel):
         systems=None,
         connection_type=None,
         connection_params=None,
+        connection_params_enabled=None,
         has_parent=None,
         parent=None,
         children=None,
@@ -1464,8 +1466,9 @@ class Garden(BaseModel):
         self.namespaces = namespaces or []
         self.systems = systems or []
 
-        self.connection_type = connection_type
+        self.connection_type = connection_type        
         self.connection_params = connection_params
+        self.connection_params_enabled = connection_params_enabled or {}
 
         self.has_parent = has_parent
         self.parent = parent

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1439,6 +1439,7 @@ class Garden(BaseModel):
         "BLOCKED",
         "STOPPED",
         "NOT_CONFIGURED",
+        "CONFIGURATION_ERROR",
         "UNREACHABLE",
         "ERROR",
         "UNKNOWN",
@@ -1504,6 +1505,7 @@ class Connection(BaseModel):
         "DISABLED" # Stopped via config or API
         "NOT_CONFIGURED", # Not enabled in configuration file
         "MISSING_CONFIGURATION", # Missing configuration file
+        "CONFIGURATION_ERROR", # Unable to load configuration file
         "UNREACHABLE", # Unable to send message
         "UNRESPONSIVE", # Haven't seen a message in N timeframe
         "ERROR", # Error occured, outside of unreachable

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -655,6 +655,8 @@ class Request(RequestTemplate):
         status_updated_at=None,
         has_parent=None,
         requester=None,
+        source_garden=None,
+        target_garden=None,
     ):
         super(Request, self).__init__(
             system=system,
@@ -681,6 +683,8 @@ class Request(RequestTemplate):
         self.error_class = error_class
         self.has_parent = has_parent
         self.requester = requester
+        self.source_garden = source_garden
+        self.target_garden = target_garden
 
     @classmethod
     def from_template(cls, template, **kwargs):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1454,8 +1454,8 @@ class Garden(BaseModel):
         systems=None,
         connection_type=None,
         connection_params=None,
-        receiving_connections=None, 
-        publishing_connections = None,
+        receiving_connections=None,
+        publishing_connections=None,
         has_parent=None,
         parent=None,
         children=None,
@@ -1468,7 +1468,7 @@ class Garden(BaseModel):
         self.namespaces = namespaces or []
         self.systems = systems or []
 
-        self.connection_type = connection_type        
+        self.connection_type = connection_type
         self.receiving_connections = receiving_connections or []
         self.publishing_connections = publishing_connections or []
 
@@ -1494,14 +1494,15 @@ class Garden(BaseModel):
             )
         )
 
+
 class Connection(BaseModel):
     schema = "ConnectionSchema"
 
     def __init__(
         self,
-        api = None,
-        enabled = False,
-        config = None,
+        api=None,
+        enabled=False,
+        config=None,
     ):
         self.api = api
         self.enabled = enabled
@@ -1509,16 +1510,14 @@ class Connection(BaseModel):
 
     def __str__(self):
         return "%s %s" % (self.api, "ENABLED" if self.enabled else "DISABLED")
-    
+
     def __repr__(self):
-        return (
-            "<Connection: api=%s, enabled=%s, config=%s>"
-            % (
-                self.api,
-                self.enabled,
-                self.config,
-            )
+        return "<Connection: api=%s, enabled=%s, config=%s>" % (
+            self.api,
+            self.enabled,
+            self.config,
         )
+
 
 class Operation(BaseModel):
     schema = "OperationSchema"

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1452,6 +1452,7 @@ class Garden(BaseModel):
         status_info=None,
         namespaces=None,
         systems=None,
+        connection_type=None,
         receiving_connections=None,
         publishing_connections=None,
         has_parent=None,
@@ -1466,6 +1467,7 @@ class Garden(BaseModel):
         self.namespaces = namespaces or []
         self.systems = systems or []
 
+        self.connection_type = connection_type
         self.receiving_connections = receiving_connections or []
         self.publishing_connections = publishing_connections or []
 
@@ -1480,12 +1482,13 @@ class Garden(BaseModel):
     def __repr__(self):
         return (
             "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, " \
-            "receiving_connections=%s, publishing_connections=%s>"
+            "connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
             % (
                 self.name,
                 self.status,
                 self.parent,
                 self.has_parent,
+                self.connection_type,
                 self.receiving_connections,
                 self.publishing_connections,
             )

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1453,7 +1453,8 @@ class Garden(BaseModel):
         systems=None,
         connection_type=None,
         connection_params=None,
-        connection_params_enabled=None,
+        receiving_connections=None, 
+        publishing_connections = None,
         has_parent=None,
         parent=None,
         children=None,
@@ -1467,8 +1468,8 @@ class Garden(BaseModel):
         self.systems = systems or []
 
         self.connection_type = connection_type        
-        self.connection_params = connection_params
-        self.connection_params_enabled = connection_params_enabled or {}
+        self.receiving_connections = receiving_connections or []
+        self.publishing_connections = publishing_connections or []
 
         self.has_parent = has_parent
         self.parent = parent
@@ -1480,16 +1481,42 @@ class Garden(BaseModel):
 
     def __repr__(self):
         return (
-            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, connection_type=%s>"
+            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, connection_type=%s, receiving_connections=%s, publishing_connections=%s>"
             % (
                 self.name,
                 self.status,
                 self.parent,
                 self.has_parent,
                 self.connection_type,
+                self.receiving_connections,
+                self.publishing_connections,
             )
         )
 
+class Connection(BaseModel):
+    schema = "ConnectionSchema"
+
+    def __init__(
+        api = None,
+        enabled = False,
+        config = None,
+    ):
+        self.api = api
+        self.enabled = enabled
+        self.config = config or {}
+
+    def __str__(self):
+        return "%s %s" % (self.api, "ENABLED" if self.enabled else "DISABLED")
+    
+    def __repr__(self):
+        return (
+            "<Connection: api=%s, enabled=%s, config=%s>"
+            % (
+                self.api,
+                self.enabled,
+                self.config,
+            )
+        )
 
 class Operation(BaseModel):
     schema = "OperationSchema"

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1452,6 +1452,9 @@ class Garden(BaseModel):
         systems=None,
         connection_type=None,
         connection_params=None,
+        has_parent=None,
+        parent=None,
+        children=None,
     ):
         self.id = id
         self.name = name
@@ -1463,11 +1466,24 @@ class Garden(BaseModel):
         self.connection_type = connection_type
         self.connection_params = connection_params
 
+        self.has_parent = has_parent
+        self.parent = parent
+        self.children = children
+
     def __str__(self):
         return "%s" % self.name
 
     def __repr__(self):
-        return "<Garden: garden_name=%s, status=%s>" % (self.name, self.status)
+        return (
+            "<Garden: garden_name=%s, status=%s, parent=%s, has_parent=%s, connection_type=%s>"
+            % (
+                self.name,
+                self.status,
+                self.parent,
+                self.has_parent,
+                self.connection_type,
+            )
+        )
 
 
 class Operation(BaseModel):

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1499,11 +1499,13 @@ class Connection(BaseModel):
     schema = "ConnectionSchema"
 
     CONNECTION_STATUSES = {
-        "ENABLED", # Sending
+        "PUBLISHING",
+        "RECEIVING",
         "DISABLED" # Stopped via config or API
         "NOT_CONFIGURED", # Not enabled in configuration file
         "MISSING_CONFIGURATION", # Missing configuration file
         "UNREACHABLE", # Unable to send message
+        "UNRESPONSIVE", # Haven't seen a message in N timeframe
         "ERROR", # Error occured, outside of unreachable
         "UNKNOWN", 
     }

--- a/brewtils/models.py
+++ b/brewtils/models.py
@@ -1455,6 +1455,7 @@ class Garden(BaseModel):
         has_parent=None,
         parent=None,
         children=None,
+        metadata=None,
     ):
         self.id = id
         self.name = name
@@ -1469,6 +1470,7 @@ class Garden(BaseModel):
         self.has_parent = has_parent
         self.parent = parent
         self.children = children
+        self.metadata = metadata or {}
 
     def __str__(self):
         return "%s" % self.name

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -102,7 +102,7 @@ class SchemaParser(object):
         return cls.parse(
             command, brewtils.models.Command, from_string=from_string, **kwargs
         )
-    
+
     @classmethod
     def parse_connection(cls, connection, from_string=False, **kwargs):
         """Convert raw JSON string or dictionary to a command model object
@@ -512,7 +512,7 @@ class SchemaParser(object):
             schema_name=brewtils.models.Command.schema,
             **kwargs
         )
-    
+
     @classmethod
     def serialize_connection(cls, connection, to_string=True, **kwargs):
         """Convert a connection model into serialized form

--- a/brewtils/schema_parser.py
+++ b/brewtils/schema_parser.py
@@ -23,6 +23,7 @@ class SchemaParser(object):
     _models = {
         "ChoicesSchema": brewtils.models.Choices,
         "CommandSchema": brewtils.models.Command,
+        "ConnectionSchema": brewtils.models.Connection,
         "CronTriggerSchema": brewtils.models.CronTrigger,
         "DateTriggerSchema": brewtils.models.DateTrigger,
         "EventSchema": brewtils.models.Event,
@@ -100,6 +101,22 @@ class SchemaParser(object):
         """
         return cls.parse(
             command, brewtils.models.Command, from_string=from_string, **kwargs
+        )
+    
+    @classmethod
+    def parse_connection(cls, connection, from_string=False, **kwargs):
+        """Convert raw JSON string or dictionary to a command model object
+
+        Args:
+            connection: The raw input
+            from_string: True if input is a JSON string, False if a dictionary
+            **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+
+        Returns:
+            A Command object
+        """
+        return cls.parse(
+            connection, brewtils.models.Connection, from_string=from_string, **kwargs
         )
 
     @classmethod
@@ -493,6 +510,26 @@ class SchemaParser(object):
             command,
             to_string=to_string,
             schema_name=brewtils.models.Command.schema,
+            **kwargs
+        )
+    
+    @classmethod
+    def serialize_connection(cls, connection, to_string=True, **kwargs):
+        """Convert a connection model into serialized form
+
+        Args:
+            connection: The connection object(s) to be serialized
+            to_string: True to generate a JSON-formatted string, False to generate a
+                dictionary
+            **kwargs: Additional parameters to be passed to the Schema (e.g. many=True)
+
+        Returns:
+            Serialized representation of connection
+        """
+        return cls.serialize(
+            connection,
+            to_string=to_string,
+            schema_name=brewtils.models.Connection.schema,
             **kwargs
         )
 

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -348,6 +348,8 @@ class RequestSchema(RequestTemplateSchema):
     )
     has_parent = fields.Bool(allow_none=True)
     requester = fields.String(allow_none=True)
+    source_garden = fields.String(allow_none=True)
+    target_garden = fields.String(allow_none=True)
 
 
 class StatusInfoSchema(BaseSchema):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -560,6 +560,8 @@ class OperationSchema(BaseSchema):
 
     target_garden_name = fields.Str(allow_none=True)
     source_garden_name = fields.Str(allow_none=True)
+    source_api = fields.Str(allow_none=True)
+    
     operation_type = fields.Str(allow_none=True)
 
 

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -497,6 +497,11 @@ class GardenSchema(BaseSchema):
     connection_params = fields.Dict(allow_none=True)
     namespaces = fields.List(fields.Str(), allow_none=True)
     systems = fields.Nested("SystemSchema", many=True, allow_none=True)
+    has_parent = fields.Bool(allow_none=True)
+    parent = fields.Str(allow_none=True)
+    children = fields.Nested(
+        "self", exclude=("parent"), many=True, default=None, allow_none=True
+    )
 
 
 class GardenDomainIdentifierSchema(BaseSchema):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -35,6 +35,7 @@ __all__ = [
     "IntervalTriggerSchema",
     "CronTriggerSchema",
     "FileTriggerSchema",
+    "ConnectionSchema",
     "GardenSchema",
     "OperationSchema",
     "UserSchema",
@@ -627,6 +628,7 @@ model_schema_map.update(
     {
         "Choices": ChoicesSchema,
         "Command": CommandSchema,
+        "Connection": ConnectionSchema,
         "CronTrigger": CronTriggerSchema,
         "DateTrigger": DateTriggerSchema,
         "Event": EventSchema,

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -488,6 +488,7 @@ class FileTriggerSchema(BaseSchema):
     recursive = fields.Bool(allow_none=True)
     callbacks = fields.Dict(fields.Bool(), allow_none=True)
 
+
 class ConnectionSchema(BaseSchema):
     api = fields.Str(allow_none=True)
     enabled = fields.Boolean(allow_none=True)
@@ -500,8 +501,12 @@ class GardenSchema(BaseSchema):
     status = fields.Str(allow_none=True)
     status_info = fields.Nested("StatusInfoSchema", allow_none=True)
     connection_type = fields.Str(allow_none=True)
-    receiving_connections = fields.Nested("ConnectionSchema", many=True, allow_none=True)
-    publishing_connections = fields.Nested("ConnectionSchema", many=True, allow_none=True)
+    receiving_connections = fields.Nested(
+        "ConnectionSchema", many=True, allow_none=True
+    )
+    publishing_connections = fields.Nested(
+        "ConnectionSchema", many=True, allow_none=True
+    )
     namespaces = fields.List(fields.Str(), allow_none=True)
     systems = fields.Nested("SystemSchema", many=True, allow_none=True)
     has_parent = fields.Bool(allow_none=True)
@@ -556,6 +561,7 @@ class JobExportSchema(JobSchema):
 class JobExportListSchema(BaseSchema):
     jobs = fields.List(fields.Nested(JobExportSchema, allow_none=True))
 
+
 class OperationSchema(BaseSchema):
     model_type = fields.Str(allow_none=True)
     model = ModelField(allow_none=True, type_field="model_type")
@@ -566,7 +572,7 @@ class OperationSchema(BaseSchema):
     target_garden_name = fields.Str(allow_none=True)
     source_garden_name = fields.Str(allow_none=True)
     source_api = fields.Str(allow_none=True)
-    
+
     operation_type = fields.Str(allow_none=True)
 
 

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -487,6 +487,11 @@ class FileTriggerSchema(BaseSchema):
     recursive = fields.Bool(allow_none=True)
     callbacks = fields.Dict(fields.Bool(), allow_none=True)
 
+class ConnectionSchema(BaseSchema):
+    api = fields.Str(allow_none=True)
+    enabled = fields.Boolean(allow_none=True)
+    config = fields.Dict(allow_none=True)
+
 
 class GardenSchema(BaseSchema):
     id = fields.Str(allow_none=True)
@@ -494,8 +499,8 @@ class GardenSchema(BaseSchema):
     status = fields.Str(allow_none=True)
     status_info = fields.Nested("StatusInfoSchema", allow_none=True)
     connection_type = fields.Str(allow_none=True)
-    connection_params = fields.Dict(allow_none=True)
-    connection_params_enabled = fields.Dict(allow_none=True)
+    receiving_connections = fields.Nested("ConnectionSchema", many=True, allow_none=True)
+    publishing_connections = fields.Nested("ConnectionSchema", many=True, allow_none=True)
     namespaces = fields.List(fields.Str(), allow_none=True)
     systems = fields.Nested("SystemSchema", many=True, allow_none=True)
     has_parent = fields.Bool(allow_none=True)
@@ -549,7 +554,6 @@ class JobExportSchema(JobSchema):
 
 class JobExportListSchema(BaseSchema):
     jobs = fields.List(fields.Nested(JobExportSchema, allow_none=True))
-
 
 class OperationSchema(BaseSchema):
     model_type = fields.Str(allow_none=True)

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -502,6 +502,7 @@ class GardenSchema(BaseSchema):
     children = fields.Nested(
         "self", exclude=("parent"), many=True, default=None, allow_none=True
     )
+    metadata = fields.Dict(allow_none=True)
 
 
 class GardenDomainIdentifierSchema(BaseSchema):

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -501,7 +501,6 @@ class GardenSchema(BaseSchema):
     name = fields.Str(allow_none=True)
     status = fields.Str(allow_none=True)
     status_info = fields.Nested("StatusInfoSchema", allow_none=True)
-    connection_type = fields.Str(allow_none=True)
     receiving_connections = fields.Nested(
         "ConnectionSchema", many=True, allow_none=True
     )

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -501,6 +501,7 @@ class GardenSchema(BaseSchema):
     name = fields.Str(allow_none=True)
     status = fields.Str(allow_none=True)
     status_info = fields.Nested("StatusInfoSchema", allow_none=True)
+    connection_type = fields.Str(allow_none=True)
     receiving_connections = fields.Nested(
         "ConnectionSchema", many=True, allow_none=True
     )

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -495,6 +495,7 @@ class GardenSchema(BaseSchema):
     status_info = fields.Nested("StatusInfoSchema", allow_none=True)
     connection_type = fields.Str(allow_none=True)
     connection_params = fields.Dict(allow_none=True)
+    connection_params_enabled = fields.Dict(allow_none=True)
     namespaces = fields.List(fields.Str(), allow_none=True)
     systems = fields.Nested("SystemSchema", many=True, allow_none=True)
     has_parent = fields.Bool(allow_none=True)

--- a/brewtils/schemas.py
+++ b/brewtils/schemas.py
@@ -491,7 +491,8 @@ class FileTriggerSchema(BaseSchema):
 
 class ConnectionSchema(BaseSchema):
     api = fields.Str(allow_none=True)
-    enabled = fields.Boolean(allow_none=True)
+    status = fields.Str(allow_none=True)
+    status_info = fields.Nested("StatusInfoSchema", allow_none=True)
     config = fields.Dict(allow_none=True)
 
 

--- a/brewtils/test/comparable.py
+++ b/brewtils/test/comparable.py
@@ -16,6 +16,7 @@ import brewtils.test
 from brewtils.models import (
     Choices,
     Command,
+    Connection,
     CronTrigger,
     DateTrigger,
     Event,
@@ -191,6 +192,7 @@ assert_trigger_equal = partial(
 assert_request_file_equal = partial(_assert_wrapper, expected_type=RequestFile)
 assert_runner_equal = partial(_assert_wrapper, expected_type=Runner)
 assert_resolvable_equal = partial(_assert_wrapper, expected_type=Resolvable)
+assert_connection_equal = partial(_assert_wrapper, expected_type=Connection)
 
 
 def assert_command_equal(obj1, obj2, do_raise=False):
@@ -379,6 +381,6 @@ def assert_garden_equal(obj1, obj2, do_raise=False):
         obj1,
         obj2,
         expected_type=Garden,
-        deep_fields={"systems": partial(assert_system_equal, do_raise=True)},
+        deep_fields={"systems": partial(assert_system_equal, do_raise=True), "receiving_connections": partial(assert_connection_equal, do_raise=True), "publishing_connections": partial(assert_connection_equal, do_raise=True)},
         do_raise=do_raise,
     )

--- a/brewtils/test/comparable.py
+++ b/brewtils/test/comparable.py
@@ -381,6 +381,10 @@ def assert_garden_equal(obj1, obj2, do_raise=False):
         obj1,
         obj2,
         expected_type=Garden,
-        deep_fields={"systems": partial(assert_system_equal, do_raise=True), "receiving_connections": partial(assert_connection_equal, do_raise=True), "publishing_connections": partial(assert_connection_equal, do_raise=True)},
+        deep_fields={
+            "systems": partial(assert_system_equal, do_raise=True),
+            "receiving_connections": partial(assert_connection_equal, do_raise=True),
+            "publishing_connections": partial(assert_connection_equal, do_raise=True),
+        },
         do_raise=do_raise,
     )

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -9,6 +9,7 @@ import pytz
 from brewtils.models import (
     Choices,
     Command,
+    Connection,
     CronTrigger,
     DateTrigger,
     Event,
@@ -787,10 +788,12 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
 
 
 @pytest.fixture
-def bg_garden(garden_dict, bg_system):
+def bg_garden(garden_dict, bg_system, bg_connection):
     """An operation as a model."""
     dict_copy = copy.deepcopy(garden_dict)
     dict_copy["systems"] = [bg_system]
+    dict_copy["receiving_connections"] = [bg_connection]
+    dict_copy["publishing_connections"] = [bg_connection]
     return Garden(**dict_copy)
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -758,7 +758,18 @@ def connection_dict():
     return {
         "api": "HTTP",
         "config": {},
-        "status": "RUNNING",
+        "status": "RECEIVING",
+        "status_info": {},
+    }
+
+@pytest.fixture
+def connection_publishing_dict():
+    """A connection as a dictionary."""
+
+    return {
+        "api": "HTTP",
+        "config": {},
+        "status": "PUBLISHING",
         "status_info": {},
     }
 
@@ -771,7 +782,14 @@ def bg_connection(connection_dict):
 
 
 @pytest.fixture
-def garden_dict(ts_epoch, system_dict, connection_dict):
+def bg_connection_publishing(connection_publishing_dict):
+    """An connection as a model."""
+    dict_copy = copy.deepcopy(connection_publishing_dict)
+    return Connection(**dict_copy)
+
+
+@pytest.fixture
+def garden_dict(ts_epoch, system_dict, connection_dict, connection_publishing_dict):
     """A garden as a dictionary."""
 
     return {
@@ -783,7 +801,7 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
         "systems": [system_dict],
         "connection_type": "http",
         "receiving_connections": [connection_dict],
-        "publishing_connections": [connection_dict],
+        "publishing_connections": [connection_publishing_dict],
         "parent": None,
         "has_parent": False,
         "children": [],
@@ -792,12 +810,12 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
 
 
 @pytest.fixture
-def bg_garden(garden_dict, bg_system, bg_connection):
+def bg_garden(garden_dict, bg_system, bg_connection, bg_connection_publishing):
     """An operation as a model."""
     dict_copy = copy.deepcopy(garden_dict)
     dict_copy["systems"] = [bg_system]
     dict_copy["receiving_connections"] = [bg_connection]
-    dict_copy["publishing_connections"] = [bg_connection]
+    dict_copy["publishing_connections"] = [bg_connection_publishing]
     return Garden(**dict_copy)
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -763,6 +763,9 @@ def garden_dict(ts_epoch, system_dict):
         "systems": [system_dict],
         "connection_type": "http",
         "connection_params": {},
+        "parent": None,
+        "has_parent": False,
+        "children": [],
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -750,6 +750,7 @@ def bg_request_file(request_file_dict):
     """A request file as a model"""
     return RequestFile(**request_file_dict)
 
+
 @pytest.fixture
 def connection_dict():
     """A connection as a dictionary."""
@@ -760,11 +761,13 @@ def connection_dict():
         "enabled": True,
     }
 
+
 @pytest.fixture
 def bg_connection(connection_dict):
     """An connection as a model."""
     dict_copy = copy.deepcopy(connection_dict)
     return Connection(**dict_copy)
+
 
 @pytest.fixture
 def garden_dict(ts_epoch, system_dict, connection_dict):
@@ -783,7 +786,7 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
         "parent": None,
         "has_parent": False,
         "children": [],
-        "metadata": {}
+        "metadata": {},
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -763,6 +763,7 @@ def garden_dict(ts_epoch, system_dict):
         "systems": [system_dict],
         "connection_type": "http",
         "connection_params": {},
+        "connection_params_enabled": {"http":True},
         "parent": None,
         "has_parent": False,
         "children": [],

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -781,7 +781,6 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
         "status_info": {},
         "namespaces": [system_dict["namespace"]],
         "systems": [system_dict],
-        "connection_type": "http",
         "receiving_connections": [connection_dict],
         "publishing_connections": [connection_dict],
         "parent": None,

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -781,6 +781,7 @@ def garden_dict(ts_epoch, system_dict, connection_dict):
         "status_info": {},
         "namespaces": [system_dict["namespace"]],
         "systems": [system_dict],
+        "connection_type": "http",
         "receiving_connections": [connection_dict],
         "publishing_connections": [connection_dict],
         "parent": None,

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -766,6 +766,7 @@ def garden_dict(ts_epoch, system_dict):
         "parent": None,
         "has_parent": False,
         "children": [],
+        "metadata": {}
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -790,6 +790,7 @@ def operation_dict(ts_epoch, request_dict):
         "kwargs": {"extra": "kwargs"},
         "target_garden_name": "child",
         "source_garden_name": "parent",
+        "source_api": "HTTP",
         "operation_type": "REQUEST_CREATE",
     }
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -762,6 +762,7 @@ def connection_dict():
         "status_info": {},
     }
 
+
 @pytest.fixture
 def connection_publishing_dict():
     """A connection as a dictionary."""

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -306,6 +306,8 @@ def child_request_dict(ts_epoch):
         "metadata": {"child": "stuff"},
         "has_parent": True,
         "requester": "user",
+        "source_garden": "parent",
+        "target_garden": "child",
     }
 
 
@@ -345,6 +347,8 @@ def parent_request_dict(ts_epoch):
         "metadata": {"parent": "stuff"},
         "has_parent": False,
         "requester": "user",
+        "source_garden": "parent",
+        "target_garden": "child",
     }
 
 
@@ -408,6 +412,8 @@ def request_dict(parent_request_dict, child_request_dict, ts_epoch):
         "metadata": {"request": "stuff"},
         "has_parent": True,
         "requester": "user",
+        "source_garden": "parent",
+        "target_garden": "child",
     }
 
 

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -749,9 +749,24 @@ def bg_request_file(request_file_dict):
     """A request file as a model"""
     return RequestFile(**request_file_dict)
 
+@pytest.fixture
+def connection_dict():
+    """A connection as a dictionary."""
+
+    return {
+        "api": "HTTP",
+        "config": {},
+        "enabled": True,
+    }
 
 @pytest.fixture
-def garden_dict(ts_epoch, system_dict):
+def bg_connection(connection_dict):
+    """An connection as a model."""
+    dict_copy = copy.deepcopy(connection_dict)
+    return Connection(**dict_copy)
+
+@pytest.fixture
+def garden_dict(ts_epoch, system_dict, connection_dict):
     """A garden as a dictionary."""
 
     return {
@@ -762,8 +777,8 @@ def garden_dict(ts_epoch, system_dict):
         "namespaces": [system_dict["namespace"]],
         "systems": [system_dict],
         "connection_type": "http",
-        "connection_params": {},
-        "connection_params_enabled": {"http":True},
+        "receiving_connections": [connection_dict],
+        "publishing_connections": [connection_dict],
         "parent": None,
         "has_parent": False,
         "children": [],

--- a/brewtils/test/fixtures.py
+++ b/brewtils/test/fixtures.py
@@ -758,7 +758,8 @@ def connection_dict():
     return {
         "api": "HTTP",
         "config": {},
-        "enabled": True,
+        "status": "RUNNING",
+        "status_info": {},
     }
 
 

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -11,6 +11,7 @@ from brewtils.models import System
 from brewtils.schema_parser import SchemaParser
 from brewtils.test.comparable import (
     assert_command_equal,
+    assert_connection_equal,
     assert_event_equal,
     assert_garden_equal,
     assert_instance_equal,

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -792,7 +792,11 @@ class TestRoundTrip(object):
                 lazy_fixture("bg_instance"),
             ),
             (brewtils.models.Command, assert_command_equal, lazy_fixture("bg_command")),
-            (brewtils.models.Connection, assert_connection_equal, lazy_fixture("bg_connection")),
+            (
+                brewtils.models.Connection,
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
+            ),
             (
                 brewtils.models.Parameter,
                 assert_parameter_equal,

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -85,6 +85,12 @@ class TestParse(object):
                 lazy_fixture("bg_command"),
             ),
             (
+                brewtils.models.Connection,
+                lazy_fixture("connection_dict"),
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
+            ),
+            (
                 brewtils.models.Parameter,
                 lazy_fixture("parameter_dict"),
                 assert_parameter_equal,
@@ -151,12 +157,6 @@ class TestParse(object):
                 lazy_fixture("bg_request_file"),
             ),
             (
-                brewtils.models.Connection,
-                lazy_fixture("connection_dict"),
-                assert_connection_equal,
-                lazy_fixture("bg_connection"),
-            ),
-            (
                 brewtils.models.Garden,
                 lazy_fixture("garden_dict"),
                 assert_garden_equal,
@@ -211,6 +211,12 @@ class TestParse(object):
                 lazy_fixture("command_dict"),
                 assert_command_equal,
                 lazy_fixture("bg_command"),
+            ),
+            (
+                "parse_connection",
+                lazy_fixture("connection_dict"),
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
             ),
             (
                 "parse_parameter",
@@ -340,6 +346,12 @@ class TestParse(object):
                 lazy_fixture("bg_command"),
             ),
             (
+                brewtils.models.Connection,
+                lazy_fixture("connection_dict"),
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
+            ),
+            (
                 brewtils.models.Parameter,
                 lazy_fixture("parameter_dict"),
                 assert_parameter_equal,
@@ -458,6 +470,12 @@ class TestParse(object):
                 lazy_fixture("command_dict"),
                 assert_command_equal,
                 lazy_fixture("bg_command"),
+            ),
+            (
+                "parse_connection",
+                lazy_fixture("connection_dict"),
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
             ),
             (
                 "parse_parameter",
@@ -580,6 +598,7 @@ class TestSerialize(object):
             (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
             (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
             (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_connection"), lazy_fixture("connection_dict")),
             (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
             (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
             (lazy_fixture("bg_patch"), lazy_fixture("patch_dict_no_envelop")),
@@ -617,6 +636,11 @@ class TestSerialize(object):
                 "serialize_command",
                 lazy_fixture("bg_command"),
                 lazy_fixture("command_dict"),
+            ),
+            (
+                "serialize_connection",
+                lazy_fixture("bg_connection"),
+                lazy_fixture("connection_dict"),
             ),
             (
                 "serialize_parameter",
@@ -703,6 +727,7 @@ class TestSerialize(object):
             (lazy_fixture("bg_system"), lazy_fixture("system_dict")),
             (lazy_fixture("bg_instance"), lazy_fixture("instance_dict")),
             (lazy_fixture("bg_command"), lazy_fixture("command_dict")),
+            (lazy_fixture("bg_connection"), lazy_fixture("connection_dict")),
             (lazy_fixture("bg_parameter"), lazy_fixture("parameter_dict")),
             (lazy_fixture("bg_request"), lazy_fixture("request_dict")),
             (lazy_fixture("bg_patch"), lazy_fixture("patch_dict_no_envelop")),
@@ -767,6 +792,7 @@ class TestRoundTrip(object):
                 lazy_fixture("bg_instance"),
             ),
             (brewtils.models.Command, assert_command_equal, lazy_fixture("bg_command")),
+            (brewtils.models.Connection, assert_connection_equal, lazy_fixture("bg_connection")),
             (
                 brewtils.models.Parameter,
                 assert_parameter_equal,
@@ -817,6 +843,7 @@ class TestRoundTrip(object):
             (brewtils.models.System, lazy_fixture("system_dict")),
             (brewtils.models.Instance, lazy_fixture("instance_dict")),
             (brewtils.models.Command, lazy_fixture("command_dict")),
+            (brewtils.models.Connection, lazy_fixture("connection_dict")),
             (brewtils.models.Parameter, lazy_fixture("parameter_dict")),
             (brewtils.models.Request, lazy_fixture("request_dict")),
             (brewtils.models.LoggingConfig, lazy_fixture("logging_config_dict")),

--- a/test/schema_parser_test.py
+++ b/test/schema_parser_test.py
@@ -150,6 +150,12 @@ class TestParse(object):
                 lazy_fixture("bg_request_file"),
             ),
             (
+                brewtils.models.Connection,
+                lazy_fixture("connection_dict"),
+                assert_connection_equal,
+                lazy_fixture("bg_connection"),
+            ),
+            (
                 brewtils.models.Garden,
                 lazy_fixture("garden_dict"),
                 assert_garden_equal,


### PR DESCRIPTION
This is a major overhaul on how Gardens are tracked within Beer Garden.

Source and Target Gardens are now tracked on the Requests objects. Requests that are forwarded to children have the Source/Target Gardens removed. And when the update is sent back, the Target Garden is updated. So children always thing it originated within themselves. 

Updating Gardens to track child Gardens. So it is easy to filter on the scope of control for each Garden. And giving insights into all downstream gardens. 