### PR TITLE
Fixed self targeting no parent bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Brewtils Changelog
 TBD
 
 - Fixed self reference bug that was returning back output instead of Request object.
+- Fixed self reference bug, when SystemClient calls itself but doesn't have a current request it 
+  now sends it to Beer Garden instead of attempting to process it locally. 
 
 3.23.0
 ------

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -425,7 +425,9 @@ class SystemClient(object):
         # If not blocking just return the future
         if not blocking:
             # TODO: Investigate if self targeting requests with no parents can be processed locally
-            if not self.target_self or not getattr(brewtils.plugin.request_context, "current_request", None):
+            if not self.target_self or not getattr(
+                brewtils.plugin.request_context, "current_request", None
+            ):
                 return self._thread_pool.submit(
                     self._wait_for_request, request, raise_on_error, timeout
                 )

--- a/brewtils/rest/system_client.py
+++ b/brewtils/rest/system_client.py
@@ -424,7 +424,8 @@ class SystemClient(object):
 
         # If not blocking just return the future
         if not blocking:
-            if not self.target_self:
+            # TODO: Investigate if self targeting requests with no parents can be processed locally
+            if not self.target_self or not getattr(brewtils.plugin.request_context, "current_request", None):
                 return self._thread_pool.submit(
                     self._wait_for_request, request, raise_on_error, timeout
                 )


### PR DESCRIPTION
If a SystemClient was triggered within a Plugin, without a parent request, it would fail. Instead, do not process this request locally. and let Beer Garden manage it.