### PR TITLE
Set Current Request after request is created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ TBD
 
 - Add support for cross-server parent/child requests
 - Fixed Typehinting parsing for `datetime.datetime` types
+- Fixed Self Referencing System Client Parent/Child request mapping
 
 3.25.0
 ------

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -75,7 +75,7 @@ class LocalRequestProcessor(object):
 
         request = self._ez_client.put_request(request)
         brewtils.plugin.request_context.current_request = request
-        
+
         try:
             output = self._invoke_command(brewtils.plugin.CLIENT, request)
         except Exception as exc:

--- a/brewtils/request_handling.py
+++ b/brewtils/request_handling.py
@@ -74,7 +74,8 @@ class LocalRequestProcessor(object):
         request.status = "IN_PROGRESS"
 
         request = self._ez_client.put_request(request)
-
+        brewtils.plugin.request_context.current_request = request
+        
         try:
             output = self._invoke_command(brewtils.plugin.CLIENT, request)
         except Exception as exc:


### PR DESCRIPTION
Fixed issue where local requests do not set the current request for proper parent request mapping