### PR TITLE
3.30.0 Add Reattempt for file chunks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ TBD
 
 - Fixed issue trying to check the bytes hash in resolver 
 - Added `is_newer` support for various models to enable improved event handling in framework 
+- Added reattempt for file chunk download
 
 3.29.1
 ------

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -1055,36 +1055,50 @@ class EasyClient(object):
         Returns:
             A file object
         """
-        (valid, meta) = self._check_chunked_file_validity(file_id)
+        delay_time = 0.5
+        total_wait_time = 0
+
+        # This loop will give 2.5 to 3 minutes of wait time
+        # before giving up
+        for _ in range(10):
+
+            (valid, meta) = self._check_chunked_file_validity(file_id)
+            if valid:
+                break
+
+            if "missing_chunks" in meta and len(meta["missing_chunks"]) == 0:
+                # All of the chunks are present but something else failed
+                break
+
+            time.sleep(delay_time)
+            total_wait_time += delay_time
+            delay_time = min(delay_time * 2, 30)
+
         file_obj = BytesIO()
         if valid:
             for x in range(meta["number_of_chunks"]):
-                delay_time = 0.5
-                total_wait_time = 0
-                attempt = 0
 
-                # This loop will give 2.5 to 3 minutes of wait time
-                # before giving up
-                while attempt < 10:
-                    try:
-                        resp = self.client.get_chunked_file(
-                            file_id, params={"chunk": x}
-                        )
-                        if resp.ok:
-                            break
-                    except Exception:
-                        time.sleep(delay_time)
-                        total_wait_time += delay_time
-                        delay_time = min(delay_time * 2, 30)
-                        attempt = attempt + 1
+                resp = self.client.get_chunked_file(file_id, params={"chunk": x})
+
+                if resp.ok:
+                    data = resp.json()["data"]
+                    file_obj.write(b64decode(data))
                 else:
-                    raise ValueError("Could not fetch chunk %d" % x)
-
-                data = resp.json()["data"]
-                file_obj.write(b64decode(data))
-
+                    raise ValueError("Could not fetch chunk {x}")
         else:
-            raise ValidationError("Requested file %s is incomplete." % file_id)
+            if "missing_chunks" in meta and len(meta["missing_chunks"]) > 0:
+                raise ValidationError(
+                    f"Requested file {file_id} is missing chunks {meta['missing_chunks']}"
+                )
+
+            if "chunks_ok" in meta and not meta["chunks_ok"]:
+                raise ValidationError(
+                    f"Requested file {file_id} has mismatched chunks lengths"
+                )
+
+            if "size_ok" in meta and not meta["size_ok"]:
+                raise ValidationError(f"Requested file {file_id} has mismatched size")
+            raise ValidationError(f"Requested file {file_id} is incomplete.")
 
         file_obj.seek(0)
 
@@ -1093,8 +1107,10 @@ class EasyClient(object):
             and meta["md5_sum"] != md5(file_obj.getbuffer()).hexdigest()
         ):
             raise ValidationError(
-                "Requested file %s MD5 SUM %s does match actual MD5 SUM %s"
-                % (file_id, meta["md5_sum"], md5(file_obj.getbuffer()).hexdigest())
+                (
+                    f"Requested file {file_id} MD5 SUM {meta['md5_sum']} "
+                    f"does match actual MD5 SUM {md5(file_obj.getbuffer()).hexdigest()}"
+                )
             )
 
         return file_obj

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -9,6 +9,7 @@ from hashlib import md5
 import six
 import wrapt
 from requests import Response  # noqa # not in requirements file
+import time
 
 from brewtils.config import get_connection_info
 from brewtils.errors import (
@@ -1058,12 +1059,30 @@ class EasyClient(object):
         file_obj = BytesIO()
         if valid:
             for x in range(meta["number_of_chunks"]):
-                resp = self.client.get_chunked_file(file_id, params={"chunk": x})
-                if resp.ok:
-                    data = resp.json()["data"]
-                    file_obj.write(b64decode(data))
+                delay_time = 0.5
+                total_wait_time = 0
+                attempt = 0
+
+                # This loop will give 2.5 to 3 minutes of wait time
+                # before giving up
+                while attempt < 10:
+                    try:
+                        resp = self.client.get_chunked_file(
+                            file_id, params={"chunk": x}
+                        )
+                        if resp.ok:
+                            break
+                    except Exception:
+                        time.sleep(delay_time)
+                        total_wait_time += delay_time
+                        delay_time = min(delay_time * 2, 30)
+                        attempt = attempt + 1
                 else:
                     raise ValueError("Could not fetch chunk %d" % x)
+
+                data = resp.json()["data"]
+                file_obj.write(b64decode(data))
+
         else:
             raise ValidationError("Requested file %s is incomplete." % file_id)
 

--- a/brewtils/rest/easy_client.py
+++ b/brewtils/rest/easy_client.py
@@ -1084,7 +1084,7 @@ class EasyClient(object):
                     data = resp.json()["data"]
                     file_obj.write(b64decode(data))
                 else:
-                    raise ValueError("Could not fetch chunk {x}")
+                    raise ValueError(f"Requested file {file_id} is missing chunk {x}")
         else:
             if "missing_chunks" in meta and len(meta["missing_chunks"]) > 0:
                 raise ValidationError(


### PR DESCRIPTION
When files are pushed to downstream there could be a delay in the file chunks being available. This gives the plugin a chance to reattempt to see if the chunks ever arrive.